### PR TITLE
Use native zipping to prevent duplicates jars in deploy artifact

### DIFF
--- a/project/MembershipAttributeService.scala
+++ b/project/MembershipAttributeService.scala
@@ -6,6 +6,7 @@ import play.sbt.routes.RoutesKeys._
 import sbt.Keys._
 import sbt._
 import sbtbuildinfo.Plugin._
+import com.typesafe.sbt.packager.universal.UniversalPlugin.autoImport.useNativeZip
 
 trait MembershipAttributeService {
 
@@ -56,6 +57,7 @@ trait MembershipAttributeService {
     .settings(playArtifactDistSettings: _*)
     .settings(magentaPackageName := name)
     .settings(dynamoDBLocalSettings)
+    .settings(useNativeZip)
 }
 
 object MembershipAttributeService extends Build with MembershipAttributeService {
@@ -70,3 +72,4 @@ object MembershipAttributeService extends Build with MembershipAttributeService 
 
   val root = Project("root", base=file(".")).aggregate(api)
 }
+


### PR DESCRIPTION
Had intermittent problems with Java zipping, which have persisted over past 24 hrs. 

See thread here: https://github.com/sbt/sbt-native-packager/issues/759#issuecomment-218528423

Using native gnu zip seems to have solved problem.

cc @rtyley 