### PR TITLE
Add a 7-day threshold so only recently-read articles are considered

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,6 +16,7 @@ object Dependencies {
   val playFilters = PlayImport.filters
   val scalaTest =  "org.scalatestplus" %% "play" % "1.4.0-M3" % "test"
   val specs2 = PlayImport.specs2 % "test"
+  val scanamo = "com.gu" %% "scanamo" % "0.4.0"
   val awsWrap = "com.github.dwhjames" %% "aws-wrap" % "0.7.2"
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
@@ -27,7 +28,7 @@ object Dependencies {
   //projects
 
   val apiDependencies = Seq(sentryRavenLogback, identityCookie, identityPlayAuth, identityTestUsers, scalaUri,
-    playWS, playCache, playFilters, awsWrap, awsDynamo, awsCloudWatch, scalaz, membershipCommon,
+    playWS, playCache, playFilters, scanamo, awsWrap, awsDynamo, awsCloudWatch, scalaz, membershipCommon,
     specs2, scalaTest)
 
 }


### PR DESCRIPTION
The editorial choice is that we only want to tailor articles based on a value that won't potentially just increase and increase over time (ie all articles on EU Referendum read by the user since the start of time). So the threshold for an 'expert' user can be '10 articles in the last week' for instance.

We're finally using Scanamo to read the results (thanks @philwills!) because we've changed the data format to not use a custom-column for each tag:

https://github.com/guardian/friendly-tailor/pull/11

cc @annebyrne 