### PR TITLE
Add CORS headers for hitting members-data-api endpoint

### DIFF
--- a/membership-attribute-service/app/configuration/Config.scala
+++ b/membership-attribute-service/app/configuration/Config.scala
@@ -50,6 +50,10 @@ object Config {
     allowedOrigins = config.getStringList("mma.cors.allowedOrigins").asScala.toSet
   )
 
+  val ftCorsConfig = CORSConfig.denyAll.copy(
+    allowedOrigins = config.getStringList("ft.cors.allowedOrigins").asScala.toSet
+  )
+
   lazy val mmaCardCorsConfig = Config.mmaCorsConfig.copy(
     isHttpHeaderAllowed = Seq("accept", "content-type", "csrf-token", "origin").contains(_),
     isHttpMethodAllowed = _ == "POST",

--- a/membership-attribute-service/app/controllers/FriendlyTailor.scala
+++ b/membership-attribute-service/app/controllers/FriendlyTailor.scala
@@ -13,7 +13,7 @@ import scala.concurrent.Future
 
 class FriendlyTailor extends Controller with LazyLogging {
 
-  def lookup(tags: Seq[String]) = CORSActionBuilder(Config.corsConfig).async { request =>
+  def lookup(tags: Seq[String]) = CORSActionBuilder(Config.ftCorsConfig).async { request =>
     require(tags.nonEmpty)
     require(tags.size < 5)
 

--- a/membership-attribute-service/conf/DEV.conf
+++ b/membership-attribute-service/conf/DEV.conf
@@ -26,3 +26,7 @@ play.filters.cors.allowedOrigins = [
 mma.cors.allowedOrigins = [
   "https://profile.thegulocal.com"
 ]
+
+ft.cors.allowedOrigins = [
+  "https://interactive.guimlocal.co.uk"
+]

--- a/membership-attribute-service/conf/PROD.conf
+++ b/membership-attribute-service/conf/PROD.conf
@@ -24,3 +24,7 @@ mma.cors.allowedOrigins = [
   "https://profile.theguardian.com",
   "https://profile.code.dev-theguardian.com",
 ]
+
+ft.cors.allowedOrigins = [
+  "https://interactive.guim.co.uk"
+]

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -18,3 +18,4 @@ POST       /salesforce-hook                                 controllers.Salesfor
 POST       /stripe-hook                                     controllers.StripeHookController.process
 
 GET        /tailor/me                                       controllers.FriendlyTailor.lookup(tag: Seq[String])
+OPTIONS    /tailor/me                                       controllers.FriendlyTailor.lookup(tag: Seq[String])


### PR DESCRIPTION
This will allow us to retrieve user article history to tailor additional content on Brexit (interactive-brexit-companion).


cc @philwills @rtyley 