### PR TITLE
Parse Guardian Identity cookies and use them to perform lookup of stats

### DIFF
--- a/membership-attribute-service/app/controllers/FriendlyTailor.scala
+++ b/membership-attribute-service/app/controllers/FriendlyTailor.scala
@@ -2,14 +2,23 @@ package controllers
 
 import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
-import play.api.libs.json.{JsObject, Json}
-import play.api.libs.json.Json.toJson
+import play.api.libs.json.Json
 import play.api.mvc.Controller
 import play.filters.cors.CORSActionBuilder
-import repositories.BrowserIdStats
+import repositories.BrowserIdStats._
+import services.IdentityAuthService
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+
+case class LookupResponse(
+  userId: Option[String],
+  viewedTags: Map[String,Int]
+)
+
+object LookupResponse {
+  implicit val writesLookupResponse = Json.writes[LookupResponse]
+}
 
 class FriendlyTailor extends Controller with LazyLogging {
 
@@ -17,10 +26,17 @@ class FriendlyTailor extends Controller with LazyLogging {
     require(tags.nonEmpty)
     require(tags.size < 5)
 
-    request.cookies.get("bwid").fold(Future.successful(NotFound("No browser id!"))) { bwidCookie =>
+    val userIdOpt = IdentityAuthService.userId(request)
+    val statsByRequestUserId = userIdOpt.map(getStatsForUserId)
+
+    val statsByRequestBrowserId = request.cookies.get("bwid").map(bwidCookie => getStatsForBrowserId(bwidCookie.value))
+
+    val preferredStatsSupplierOpt = Seq(statsByRequestUserId, statsByRequestBrowserId).flatten.headOption
+
+    preferredStatsSupplierOpt.fold(Future.successful(NotFound("No browser or user id!"))) { preferredStatsSupplier =>
       for {
-        pathsByTag <- BrowserIdStats.getPathsByTagFor(bwidCookie.value, tags.toSet)
-      } yield Ok(Json.obj("viewedTags" -> toJson(pathsByTag.mapValues(_.size))))
+        pathsByTag <- preferredStatsSupplier(tags.toSet)
+      } yield Ok(Json.toJson(LookupResponse(userIdOpt, pathsByTag.mapValues(_.size))))
     }
   }
 }


### PR DESCRIPTION
This means that the page view stats returned by the Friendly Tailor /tailor/me endpoint will be for the logged-in user, across all their devices, if the user is logged in. Otherwise the stats are based on the
Ophan browser cookie as before.

The response will include the user id if it found one, to make it clearer where the stats are coming from.

This follows on from https://github.com/guardian/friendly-tailor/pull/12

cc @philwills 