### PR TITLE
Return status code in error json

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -56,7 +56,7 @@ class AttributeController extends Controller with LazyLogging {
             onSuccess(attrs)
           case None =>
             metrics.put(s"$endpointDescription-user-not-found", 1)
-            ApiError("User not found in DynamoDB", s"userId=${id}; stage=${Config.stage}; dynamoTable=${request.touchpoint.dynamoTable}", 404)
+            ApiError("Not found", s"User not found in DynamoDB: userId=${id}; stage=${Config.stage}; dynamoTable=${request.touchpoint.dynamoTable}", 404)
         }
       }.getOrElse {
         metrics.put(s"$endpointDescription-cookie-auth-failed", 1)

--- a/membership-attribute-service/app/models/ApiError.scala
+++ b/membership-attribute-service/app/models/ApiError.scala
@@ -11,7 +11,8 @@ object ApiError {
   implicit val apiErrorWrites = new Writes[ApiError] {
     override def writes(o: ApiError): JsValue = Json.obj(
       "message" -> o.message,
-      "details" -> o.details
+      "details" -> o.details,
+      "statusCode" -> o.statusCode
     )
   }
   implicit def apiErrorToResult(err: ApiError): Result = {

--- a/membership-attribute-service/test/models/ApiErrorTest.scala
+++ b/membership-attribute-service/test/models/ApiErrorTest.scala
@@ -12,7 +12,8 @@ class ApiErrorTest extends Specification {
         Json.parse("""
           | {
           |   "message": "message",
-          |   "details": "details"
+          |   "details": "details",
+          |   "statusCode": 400
           | }
         """.stripMargin)
     }


### PR DESCRIPTION
@tomverran 

Apps team would like to switch on the actual status code instead of on string.