### PR TITLE
HackDay: Allow users to verify themselves by donating to charity

### DIFF
--- a/cloudformation/membership-attribute-service.json
+++ b/cloudformation/membership-attribute-service.json
@@ -164,6 +164,14 @@
               {
                 "Effect": "Allow",
                 "Action": [
+                  "dynamodb:PutItem",
+                  "dynamodb:GetItem"
+                ],
+                "Resource": "arn:aws:dynamodb:*:*:table/hackday-user-reputation"
+              },
+              {
+                "Effect": "Allow",
+                "Action": [
                   "dynamodb:Query"
                 ],
                 "Resource": "arn:aws:dynamodb:*:*:table/friendly-tailor-PROD"

--- a/membership-attribute-service/app/controllers/UserReputation.scala
+++ b/membership-attribute-service/app/controllers/UserReputation.scala
@@ -1,0 +1,43 @@
+package controllers
+
+import com.gu.identity.play.AuthenticatedIdUser
+import com.typesafe.scalalogging.LazyLogging
+import controllers.UVAuth._
+import play.api.libs.json.Json.toJson
+import play.api.mvc.Security.{AuthenticatedBuilder, AuthenticatedRequest}
+import play.api.mvc.{ActionBuilder, Controller}
+import repositories.Reputation
+import services.IdentityAuthService
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+object UVAuth {
+
+  type AuthRequest[A] = AuthenticatedRequest[A, AuthenticatedIdUser]
+
+  def authenticated(): ActionBuilder[AuthRequest] =
+    new AuthenticatedBuilder(IdentityAuthService.playAuthService.authenticatedIdUserProvider)
+}
+
+class UserReputation extends Controller with LazyLogging {
+
+  def reputation()  = authenticated().async { idRequest =>
+    Reputation.getUserVerification(idRequest.user.id).map(v => Ok(toJson(v)))
+  }
+
+  def verifyJustGiving(donationId: Long, returnUrl: String) = authenticated().async { request =>
+    // TODO actually get donation status....
+    //    val req = new Request.Builder().url(s"http://api.justgiving.com/v1/donation/$donationId").build()
+    //    new OkHttpClient().execute(req).map {
+    //      resp =>
+    //        Json.fromJson(Json.parse(resp.body().byteStream())).get
+    //
+    //    }
+
+    for {
+      _ <- Reputation.putJustGivingDonation(request.user.id, donationId)
+    } yield {
+        SeeOther(returnUrl)
+    }
+  }
+}

--- a/membership-attribute-service/app/repositories/Reputation.scala
+++ b/membership-attribute-service/app/repositories/Reputation.scala
@@ -1,0 +1,41 @@
+package repositories
+
+import cats.data.Xor
+import com.gu.scanamo._
+import com.gu.scanamo.error.DynamoReadError
+import com.gu.scanamo.syntax._
+import configuration.Config
+import play.api.libs.json.Json
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+
+case class Reputation(userId: String, justGiving: Option[Reputation.JustGiving])
+
+object Reputation {
+
+  case class JustGiving(donationId: Long)
+
+  implicit val writesJustGiving = Json.writes[JustGiving]
+  implicit val writesVerification = Json.writes[Reputation]
+
+  val table = Table[Reputation](s"hackday-user-reputation")
+
+  val client = Config.dynamoMapper.client.client
+
+  def getUserVerification(userId: String): Future[Reputation]= {
+
+    for {
+      result: Option[Xor[DynamoReadError, Reputation]] <- ScanamoAsync.exec(client)(table.get('userId -> userId))
+    } yield {
+      result.get.toOption.get
+    }
+  }
+
+  // TODO ...make this an update, not a put! Scanamo currently doesn't support updates
+  def putJustGivingDonation(userId: String, donationId: Long) =
+    ScanamoAsync.exec(client)(table.put(Reputation(userId, Some(JustGiving(donationId)))))
+
+
+}

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -23,3 +23,6 @@ POST       /stripe-hook                                     controllers.StripeHo
 
 GET        /tailor/me                                       controllers.FriendlyTailor.lookup(tag: Seq[String])
 OPTIONS    /tailor/me                                       controllers.FriendlyTailor.lookup(tag: Seq[String])
+
+GET        /verify/justgiving                               controllers.UserReputation.verifyJustGiving(jgDonationId: Long, returnUrl)
+GET        /reputation                                      controllers.UserReputation.reputation()


### PR DESCRIPTION
When a user wants to post to a contentious article, they can verify themselves by first donating to a nominated charity. See also JustGiving's 'Simple Donation Integration': https://developer.justgiving.com/apidocs/sdi

For instance, for this charity: https://www.justgiving.com/fundraising/roberto-tyley ...we would construct a link like this, and offer it to the user as a verification method:

https://www.justgiving.com/roberto-tyley/4w350m3/donate?amount=2.00&exitUrl=https%3A%2F%2Fmembers-data-api.theguardian.com%2Fverify%2Fjustgiving%3FreturnUrl%3Dhttp%253A%252F%252Fwww.theguardian.com%252Fpolitics%252F2016%252Fjun%252F10%252Fno-single-market-access-for-uk-after-brexit-wolfgang-schauble-says%26jgDonationId%3DJUSTGIVING-DONATION-ID&currency=GBP&reference=ghackday&defaultMessage=test%20message

The user gets taken to a JustGiving page like this:

![image](https://cloud.githubusercontent.com/assets/52038/15962750/2a167772-2f05-11e6-953d-a3f8af035c83.png)

JustGiving lets us specify an exit url that the user is redirected to after the donation occurs. In our case, the exit url is this `/verify/justgiving` endpoint on the members-data API:

https://members-data-api.theguardian.com/verify/justgiving?returnUrl=http%3A%2F%2Fwww.theguardian.com%2Fpolitics%2F2016%2Fjun%2F10%2Fno-single-market-access-for-uk-after-brexit-wolfgang-schauble-says

...note that this also accepts a return url(!). Once the donation has been recorded to our database, we redirect to the page the user was originally intending to comment upon. On that page, a call to the new `/reputation` endpoint can be made, to see if the user now has enough reputation to proceed.

We could use this reputation assessment to allow users to skip pre-moderation, and also surface the total donated on the page.

cc @paulmr @katebee @SiAdcock @tomverran 