### PR TITLE
Allow the code env to get features of test users via AJAX

### DIFF
--- a/membership-attribute-service/conf/PROD.conf
+++ b/membership-attribute-service/conf/PROD.conf
@@ -13,6 +13,7 @@ touchpoint.backend.default=PROD
 touchpoint.backend.test=UAT
 
 play.filters.cors.allowedOrigins = [
+  "https://m.code.dev-theguardian.com",
   "http://www.theguardian.com",
   "https://www.theguardian.com",
   "https://membership.theguardian.com",


### PR DESCRIPTION
Open up dotcom code domain for CORS, like is already enabled for MMA.

Required for https://trello.com/c/8wU248o4/29-refresh-ad-block-banner

cc @tomverran @nlindblad 