### PR TITLE
Add sns path for prod and dev

### DIFF
--- a/membership-attribute-service/conf/touchpoint.DEV.conf
+++ b/membership-attribute-service/conf/touchpoint.DEV.conf
@@ -1,7 +1,7 @@
 touchpoint.backend.environments {
   DEV {
     dynamodb.table = MembershipAttributes-DEV
-    giraffe.sns = giraffe-dev
+    giraffe.sns = "arn:aws:sns:eu-west-1:865473395570:giraffe-dev"
     salesforce {
       hook-secret = "secret-key"
       organization-id = "orgIdxxxxxxxxxxxxx"

--- a/membership-attribute-service/conf/touchpoint.PROD.conf
+++ b/membership-attribute-service/conf/touchpoint.PROD.conf
@@ -1,7 +1,7 @@
 touchpoint.backend.environments {
   PROD {
     dynamodb.table = MembershipAttributes-PROD
-    giraffe.sns = giraffe-prod
+    giraffe.sns = "arn:aws:sns:eu-west-1:865473395570:giraffe-dev"
     salesforce {
       hook-secret = null
       organization-id = null


### PR DESCRIPTION
As we are going to route all charges through the same stripe -> sns -> lambda pipeline, the sns path should be the same for live and test 