### PR TITLE
Add sns publish permissions for giraffe to membership IAM role

### DIFF
--- a/cloudformation/membership-attribute-service.json
+++ b/cloudformation/membership-attribute-service.json
@@ -127,6 +127,11 @@
                 "Effect": "Allow"
               },
               {
+                "Effect":"Allow",
+                "Action":["sns:Publish"],
+                "Resource":{"Ref":"TopicGiraffe"}
+              },
+              {
                 "Action": [
                   "logs:*"
                 ],
@@ -409,6 +414,13 @@
             "CidrIp": "0.0.0.0/0"
           }
         ]
+      }
+    },
+
+    "TopicGiraffe": {
+      "Type": "AWS::SNS::Topic",
+      "Properties": {
+        "TopicName": "giraffe-dev"
       }
     }
   },

--- a/cloudformation/membership-attribute-service.json
+++ b/cloudformation/membership-attribute-service.json
@@ -420,7 +420,7 @@
     "TopicGiraffe": {
       "Type": "AWS::SNS::Topic",
       "Properties": {
-        "TopicName": "giraffe-dev"
+        "TopicName": "giraffe"
       }
     }
   },

--- a/membership-attribute-service/conf/touchpoint.PROD.conf
+++ b/membership-attribute-service/conf/touchpoint.PROD.conf
@@ -1,7 +1,7 @@
 touchpoint.backend.environments {
   PROD {
     dynamodb.table = MembershipAttributes-PROD
-    giraffe.sns = "arn:aws:sns:eu-west-1:865473395570:giraffe-dev"
+    giraffe.sns = "arn:aws:sns:eu-west-1:865473395570:giraffe"
     salesforce {
       hook-secret = null
       organization-id = null


### PR DESCRIPTION
Add sns publish permissions for giraffe to membership IAM role.
Create new SNS topic in cloudformation for giraffe prod
Configure prod touchpoint backend to point to new SNS topic

This sns topic is used to send Stripe charge events to a lambda