### PR TITLE
Remove lookup metrics

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -52,10 +52,8 @@ class AttributeController extends Controller with LazyLogging {
       authenticationService.userId(request).map[Future[Result]] { id =>
         request.touchpoint.attrService.get(id).map {
           case Some(attrs) =>
-            metrics.put(s"$endpointDescription-lookup-successful", 1)
             onSuccess(attrs)
           case None =>
-            metrics.put(s"$endpointDescription-user-not-found", 1)
             ApiError("Not found", s"User not found in DynamoDB: userId=${id}; stage=${Config.stage}; dynamoTable=${request.touchpoint.dynamoTable}", 404)
         }
       }.getOrElse {


### PR DESCRIPTION
@paulbrown1982 

[Trello card](https://trello.com/c/YIhjG1c8/19-optimise-cloudwatch-monitoring-costs)

**Save over £1000 per month.**

The culprit for our high CloudWatch cost were the following 4 metrics:

* `membership-user-not-found`
* `features-user-not-found`
* `membership-lookup-successful`
* `features-lookup-successful`

As the graph below shows these metrics were posted to cloudwatch around **five million** times per day, which at pricing of $0.01 per 1,000 `PutMetricData` API requests, adds to around $1500 per month:

![image](https://cloud.githubusercontent.com/assets/13835317/16764044/e38b6384-4823-11e6-9e8e-5c87170e574c.png)

Beside being expensive, these metrics do not add much value. For instance, the fact that user is not in DynamoDB does not represent an error, it simply means the user has not become member yet.