### PR TITLE
Fix Salesforce sync

### DIFF
--- a/membership-attribute-service/app/services/AttributeService.scala
+++ b/membership-attribute-service/app/services/AttributeService.scala
@@ -1,12 +1,12 @@
 package services
 
+import com.amazonaws.services.dynamodbv2.model.{DeleteItemResult, PutItemResult}
 import models.Attributes
-
 import scala.concurrent.Future
 
 trait AttributeService {
   def get(userId: String): Future[Option[Attributes]]
   def getMany(userIds: List[String]): Future[Seq[Attributes]]
-  def delete(userId: String): Future[Unit]
-  def set(attributes: Attributes): Future[Unit]
+  def delete(userId: String): Future[DeleteItemResult]
+  def set(attributes: Attributes): Future[PutItemResult]
 }

--- a/membership-attribute-service/conf/logback.xml
+++ b/membership-attribute-service/conf/logback.xml
@@ -11,7 +11,7 @@
         </rollingPolicy>
 
         <encoder>
-            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{3}</pattern>
+            <pattern>%date [%.-30thread] %logger[%file:%L] %highlight(%level: %msg%n%xException{3})</pattern>
         </encoder>
     </appender>
 

--- a/membership-attribute-service/test/controllers/TierPublicityControllerTest.scala
+++ b/membership-attribute-service/test/controllers/TierPublicityControllerTest.scala
@@ -1,4 +1,6 @@
 package controllers
+
+import com.amazonaws.services.dynamodbv2.model.{DeleteItemResult, PutItemResult}
 import models.Attributes
 import services.AttributeService
 import scala.concurrent.duration._
@@ -9,8 +11,8 @@ class TierPublicityControllerTest extends Specification {
 
   val ctrl = new TierPublicityController()
   val dynamoStub = new AttributeService {
-    override def delete(userId: String): Future[Unit] = ???
-    override def set(attributes: Attributes): Future[Unit] = ???
+    override def delete(userId: String): Future[DeleteItemResult] = ???
+    override def set(attributes: Attributes): Future[PutItemResult] = ???
     override def get(userId: String): Future[Option[Attributes]] = ???
     override def getMany(userIds: List[String]): Future[Seq[Attributes]] = Future.successful(Seq(
       Attributes("1234", "Partner", None, Some(true)),


### PR DESCRIPTION
@paulbrown1982 @tomverran 

[Trello ticket](https://trello.com/c/PquWKnxV/42-membership-dynamo-db-out-of-sync)

The issue was that we were returning OK to Salesforce in all cases, even if insertion into DynamoDB failed. Call to DynamoDB was executed in separate Future, after which we would immediately return OK without checking the result of the Future: [SalesforceHookController.scala: L54](https://github.com/guardian/members-data-api/compare/fix-salesforce-sync?expand=1#diff-69104f1fecf890597795bd8d7aadf135L54)