### PR TITLE
Add converted amount and country to Stripe object before sending to SNS

### DIFF
--- a/membership-attribute-service/app/controllers/StripeHookController.scala
+++ b/membership-attribute-service/app/controllers/StripeHookController.scala
@@ -45,9 +45,9 @@ class StripeHookController extends Controller with LazyLogging {
         e <- OptionT(Future.successful(event.asOpt))
         tp = if (e.liveMode) NormalTouchpointComponents else TestTouchpointComponents
         eventFromStripe <- OptionT(tp.giraffeStripeService.Event.findCharge(e.id))
-        eventWithConvertedAmount <- OptionT(tp.giraffeStripeService.BalanceTransaction.read(eventFromStripe.`object`))
+        eventWithConvertedAmountAndCountry <- OptionT(tp.giraffeStripeService.BalanceTransaction.read(eventFromStripe.`object`))
       } yield {
-        tp.snsGiraffeService.publish(eventWithConvertedAmount)
+        tp.snsGiraffeService.publish(eventWithConvertedAmountAndCountry)
         Ok(Json.obj("event " + eventFromStripe.id + " found, sent to " + tp.giraffeSns -> true))
       }).getOrElse(Ok(Json.obj("event found" -> false)))
     }

--- a/membership-attribute-service/app/controllers/StripeHookController.scala
+++ b/membership-attribute-service/app/controllers/StripeHookController.scala
@@ -45,10 +45,10 @@ class StripeHookController extends Controller with LazyLogging {
         e <- OptionT(Future.successful(event.asOpt))
         tp = if (e.liveMode) NormalTouchpointComponents else TestTouchpointComponents
         eventFromStripe <- OptionT(tp.giraffeStripeService.Event.findCharge(e.id))
-        eventWithConvertedAmountAndCountry <- OptionT(tp.giraffeStripeService.BalanceTransaction.read(eventFromStripe.`object`))
+        balanceTransaction <- OptionT(tp.giraffeStripeService.BalanceTransaction.read(eventFromStripe.`object`.balance_transaction))
       } yield {
-        tp.snsGiraffeService.publish(eventWithConvertedAmountAndCountry)
-        Ok(Json.obj("event " + eventFromStripe.id + " found, sent to " + tp.giraffeSns -> true))
+        tp.snsGiraffeService.publish(eventFromStripe.`object`, balanceTransaction)
+        Ok(Json.obj("event " + eventFromStripe.id + " was found, sent to " + tp.giraffeSns -> true))
       }).getOrElse(Ok(Json.obj("event found" -> false)))
     }
   }

--- a/membership-attribute-service/app/controllers/StripeHookController.scala
+++ b/membership-attribute-service/app/controllers/StripeHookController.scala
@@ -45,8 +45,9 @@ class StripeHookController extends Controller with LazyLogging {
         e <- OptionT(Future.successful(event.asOpt))
         tp = if (e.liveMode) NormalTouchpointComponents else TestTouchpointComponents
         eventFromStripe <- OptionT(tp.giraffeStripeService.Event.findCharge(e.id))
+        eventWithConvertedAmount <- OptionT(tp.giraffeStripeService.BalanceTransaction.read(eventFromStripe.`object`))
       } yield {
-        tp.snsGiraffeService.publish(eventFromStripe.`object`)
+        tp.snsGiraffeService.publish(eventWithConvertedAmount)
         Ok(Json.obj("event " + eventFromStripe.id + " found, sent to " + tp.giraffeSns -> true))
       }).getOrElse(Ok(Json.obj("event found" -> false)))
     }

--- a/membership-attribute-service/app/services/SNSGiraffeService.scala
+++ b/membership-attribute-service/app/services/SNSGiraffeService.scala
@@ -2,19 +2,23 @@ package services
 
 import com.github.dwhjames.awswrap.sns.AmazonSNSScalaClient
 import com.gu.stripe.Stripe
-import com.gu.stripe.Stripe.{Event, StripeObject}
+import com.gu.stripe.Stripe._
 import configuration.Config
-import play.api.libs.json.Json
+import play.api.libs.json.{Json}
 
 object SNSGiraffeService {
   def apply(arn: String): SNSGiraffeService = new SNSGiraffeService(Config.snsClient, arn)
 }
 
 class SNSGiraffeService(snsClient: AmazonSNSScalaClient, arn: String) {
+  implicit val sourceFormat = Json.format[Source]
+  implicit val writesCharge = Json.writes[Stripe.Charge]
+  implicit val writesBalanceTransaction = Json.writes[Stripe.BalanceTransaction]
 
 
-   def publish(charge: Stripe.ChargeWithBalanceAndCountry): Unit = {
-    snsClient.publish(arn, Json.toJson(charge).toString)
+   def publish(charge: Stripe.Charge, balanceTransaction: BalanceTransaction) : Unit = {
+     val json = Json.toJson(Map("charge" -> Json.toJson(charge), "balanceTransaction" -> Json.toJson(balanceTransaction))).toString
+     snsClient.publish(arn, json)
   }
 
 }

--- a/membership-attribute-service/app/services/SNSGiraffeService.scala
+++ b/membership-attribute-service/app/services/SNSGiraffeService.scala
@@ -13,9 +13,7 @@ object SNSGiraffeService {
 class SNSGiraffeService(snsClient: AmazonSNSScalaClient, arn: String) {
 
 
-  implicit val writesCharge = Json.writes[Stripe.Charge]
-
-  def publish(charge: Stripe.Charge): Unit = {
+   def publish(charge: Stripe.ChargeWithBalanceAndCountry): Unit = {
     snsClient.publish(arn, Json.toJson(charge).toString)
   }
 

--- a/membership-attribute-service/app/services/SNSGiraffeService.scala
+++ b/membership-attribute-service/app/services/SNSGiraffeService.scala
@@ -16,8 +16,6 @@ class SNSGiraffeService(snsClient: AmazonSNSScalaClient, arn: String) {
   implicit val writesCharge = Json.writes[Stripe.Charge]
 
   def publish(charge: Stripe.Charge): Unit = {
-
-    val c = charge
     snsClient.publish(arn, Json.toJson(charge).toString)
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSNS = "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.233"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.240"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
 
   //projects


### PR DESCRIPTION
 We needed to have the converted amount and the card country in the stripe event for data analysis purposes. 

As the converted amount is not in the Stripe Charge object that comes from the webhook, we need to make a call to the Stripe API to get the Balance Transaction object, which we then send to SNS along with the Charge object