### PR TITLE
Update membership-common version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSNS = "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.282"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.285"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
 
   //projects


### PR DESCRIPTION
This PR bumps membership-common to use the latest version, which includes a fix to stop us spamming AWS with huge numbers of Custom Metrics (see guardian/membership-common#335).