### PR TITLE
update membership common with the deleted old code

### DIFF
--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -59,11 +59,10 @@ class TouchpointComponents(stage: String)(implicit system: ActorSystem) {
     RequestRunners.loggingRunner(metrics("zuora-soap")),
     RequestRunners.loggingRunner(metrics("zuora-soap"))
   )
-  lazy val restClient = new rest.Client(tpConfig.zuoraRest, metrics("zuora-rest"))
   lazy val contactRepo = new SimpleContactRepository(tpConfig.salesforce, system.scheduler, Config.applicationName)
   lazy val attrService: AttributeService = new ScanamoAttributeService(new AmazonDynamoDBAsyncClient().withRegion(Regions.EU_WEST_1), dynamoTable)
   lazy val snsGiraffeService: SNSGiraffeService = SNSGiraffeService(giraffeSns)
-  lazy val zuoraService = new ZuoraService(soapClient, restClient)
+  lazy val zuoraService = new ZuoraService(soapClient)
   lazy val simpleClient = new SimpleClient[Future](tpConfig.zuoraRest, RequestRunners.futureRunner)
   lazy val catalogService = new CatalogService[Future](productIds, simpleClient, Await.result(_, 10.seconds), stage)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSNS = "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.285"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.293"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
 
   //projects


### PR DESCRIPTION
So this pulls in the membership common PR with the deleted code - https://github.com/guardian/membership-common/pull/331

I ran the tests, which passed, but when I run locally, it's using a dataset that doesn't give me the directly testable endpoints.  Is it enough to run the tests, or should I be running it up myself pointing somewhere?

@paulbrown1982 @guardian/membership-and-subscriptions any comments or +1s? 