### PR TITLE
Fix features response when user not found

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -56,9 +56,7 @@ class AttributeController extends Controller with LazyLogging {
           case Some(attrs) =>
             onSuccess(attrs)
           case None =>
-            onNotFound getOrElse {
-              ApiError("Not found", s"User not found in DynamoDB: userId=${id}; stage=${Config.stage}; dynamoTable=${request.touchpoint.dynamoTable}", 404)
-            }
+            onNotFound getOrElse ApiError("Not found", s"User not found in DynamoDB: userId=${id}; stage=${Config.stage}; dynamoTable=${request.touchpoint.dynamoTable}", 404)
         }
       }.getOrElse {
         metrics.put(s"$endpointDescription-cookie-auth-failed", 1)


### PR DESCRIPTION
Revert the /features controller to work as it did pre-June 1st: serving its own custom error response, and not falling back to the  default which /membership uses.

This means we don't need to do: https://github.com/guardian/frontend/pull/14920

cc @philwills @mario-galic @rtyley @jacobwinch 