### PR TITLE
Fix Salesforce Parser in order to tolerate multiple objects per message

### DIFF
--- a/membership-attribute-service/app/controllers/SalesforceHookController.scala
+++ b/membership-attribute-service/app/controllers/SalesforceHookController.scala
@@ -6,15 +6,15 @@ import com.gu.memsub.subsv2.SubscriptionPlan
 import com.typesafe.scalalogging.LazyLogging
 import models.ApiErrors
 import monitoring.CloudWatch
-import parsers.Salesforce.{MembershipDeletion, MembershipUpdate, OrgIdMatchingError, ParsingError}
+import parsers.Salesforce._
 import parsers.{Salesforce => SFParser}
-import play.Logger
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.mvc.BodyParsers.parse
 import play.api.mvc.Results.Ok
 import com.gu.memsub.subsv2.reads.SubPlanReads._
 import com.gu.memsub.subsv2.reads.ChargeListReads._
 import scala.concurrent.Future
+import scala.util.{Failure, Success}
 import scalaz.std.scalaFuture._
 import scalaz.{-\/, OptionT, \/-}
 
@@ -39,48 +39,65 @@ class SalesforceHookController extends LazyLogging {
     </soapenv:Envelope>
   )
 
-  def createAttributes = BackendFromSalesforceAction.async(parse.xml) { request =>
-    val touchpoint = request.touchpoint
-    val validOrgId = touchpoint.sfOrganisationId
-    val attributeService = touchpoint.attrService
-    implicit val pf = Membership
+def createAttributes = BackendFromSalesforceAction.async(parse.xml) { request =>
 
-    SFParser.parseOutboundMessage(request.body, validOrgId) match {
-      case \/-(MembershipDeletion(userId)) =>
-        attributeService.delete(userId).map { x =>
-          logger.info(s"Successfully deleted user $userId from ${touchpoint.dynamoTable}.")
-          metrics.put("Delete", 1)
-          ack
-        }.recover { case e: Throwable =>
-          logger.warn(s"Failed to delete user $userId from ${touchpoint.dynamoTable}. Salesforce should retry.", e)
-          ApiErrors.internalError
-        }
-      case \/-(MembershipUpdate(attrs)) =>
-        (for {
-          sfId <- OptionT(touchpoint.contactRepo.get(attrs.UserId))
-          membershipSubscription <- OptionT(touchpoint.subService.current[SubscriptionPlan.Member](sfId).map(_.headOption))
-        } yield {
-          val tierFromSalesforceWebhook = attrs.Tier
-          val tierFromZuora = membershipSubscription.plan.charges.benefit.id
-          if (tierFromZuora != tierFromSalesforceWebhook) logger.error(s"Differing tier info for $sfId : sf=$tierFromSalesforceWebhook zuora=$tierFromZuora")
-          attrs.copy(Tier = tierFromZuora)
-        }).run.flatMap { attrsUpdatedWithZuoraOpt =>
-          if (attrsUpdatedWithZuoraOpt.isEmpty) logger.error(s"Couldn't update $attrs with information from Zuora")
-          attributeService.set(attrsUpdatedWithZuoraOpt.getOrElse(attrs)).map { putItemResult =>
-            logger.info(s"Successfully inserted ${attrsUpdatedWithZuoraOpt.getOrElse(attrs)} into ${touchpoint.dynamoTable}.")
-            metrics.put("Update", 1)
-            ack
-          }.recover { case e: Throwable =>
-            logger.warn(s"Failed to insert ${attrsUpdatedWithZuoraOpt.getOrElse(attrs)} into ${touchpoint.dynamoTable}. Salesforce should retry.", e)
-            ApiErrors.internalError
-          }
-        }
-      case -\/(ParsingError(msg)) =>
-        Logger.error(s"Could not parse payload ${request.body}:\n$msg")
-        Future(ApiErrors.badRequest(msg))
-      case -\/(OrgIdMatchingError(orgId)) =>
-        Logger.error(s"Wrong organization Id: $orgId")
-        Future(ApiErrors.unauthorized.copy("Wrong organization Id"))
+  val touchpoint = request.touchpoint
+  val validOrgId = touchpoint.sfOrganisationId
+  val attributeService = touchpoint.attrService
+  implicit val pf = Membership
+
+  def processDeletion(membershipDeletion: MembershipDeletion) = {
+    val userId = membershipDeletion.userId
+    attributeService.delete(userId).map { x =>
+      logger.info(s"Successfully deleted user $userId from ${touchpoint.dynamoTable}.")
+      metrics.put("Delete", 1)
+      Success
+    }.recover { case e: Throwable =>
+      logger.warn(s"Failed to delete user $userId from ${touchpoint.dynamoTable}. Salesforce should retry.", e)
+      Failure
     }
   }
+
+  def processUpdate(membershipUpdate: MembershipUpdate) = {
+    val attrs = membershipUpdate.attributes
+    (for {
+      sfId <- OptionT(touchpoint.contactRepo.get(attrs.UserId))
+      membershipSubscription <- OptionT(touchpoint.subService.current[SubscriptionPlan.Member](sfId).map(_.headOption))
+    } yield {
+      val tierFromSalesforceWebhook = attrs.Tier
+      val tierFromZuora = membershipSubscription.plan.charges.benefit.id
+      if (tierFromZuora != tierFromSalesforceWebhook) logger.error(s"Differing tier info for $sfId : sf=$tierFromSalesforceWebhook zuora=$tierFromZuora")
+      attrs.copy(Tier = tierFromZuora)
+    }).run.flatMap { attrsUpdatedWithZuoraOpt =>
+      if (attrsUpdatedWithZuoraOpt.isEmpty) logger.error(s"Couldn't update $attrs with information from Zuora")
+      attributeService.set(attrsUpdatedWithZuoraOpt.getOrElse(attrs)).map { putItemResult =>
+        logger.info(s"Successfully inserted ${attrsUpdatedWithZuoraOpt.getOrElse(attrs)} into ${touchpoint.dynamoTable}.")
+        metrics.put("Update", 1)
+        Success
+      }.recover { case e: Throwable =>
+        logger.warn(s"Failed to insert ${attrsUpdatedWithZuoraOpt.getOrElse(attrs)} into ${touchpoint.dynamoTable}. Salesforce should retry.", e)
+        Failure
+      }
+    }
+  }
+
+  SFParser.parseOutboundMessage(request.body, validOrgId) match {
+    case -\/(ParsingError(msg)) =>
+      logger.error(s"Could not parse payload. \n$msg")
+      Future(ApiErrors.badRequest(msg))
+    case -\/(OrgIdMatchingError(orgId)) =>
+      logger.error(s"Wrong organization Id: $orgId")
+      Future(ApiErrors.unauthorized.copy("Wrong organization Id"))
+    // On successful parse, we should end up with a Seq of Salesforce objects to update
+    case \/-(outboundMessageChanges @ Seq(_*)) =>
+      logger.info(s"Parsed Salesforce message successfully. Salesforce sent ${outboundMessageChanges.length} objects to update: $outboundMessageChanges")
+      // Take the Seq and apply the appropriate action for each notification item, based on its type
+      val updates = outboundMessageChanges.map( outboundMessage => outboundMessage match {
+        case membershipDelete: MembershipDeletion => processDeletion(membershipDelete)
+        case membershipUpdate: MembershipUpdate => processUpdate(membershipUpdate)
+      })
+      // Gather up the results of the futures and check for failures. Only send a success response to Salesforce if every processUpdate/processDeletion for the message succeeds
+      Future.sequence(updates).map { updateSeq => if (updateSeq.contains(Failure)) ApiErrors.internalError else ack }
+  }
+ }
 }

--- a/membership-attribute-service/app/parsers/Salesforce.scala
+++ b/membership-attribute-service/app/parsers/Salesforce.scala
@@ -1,30 +1,33 @@
 package parsers
 
 import models.Attributes
-
-import scala.xml._
+import scala.xml.{Node, _}
 import scalaz.Scalaz._
-import scalaz.\/
+import scalaz.{-\/, \/, \/-}
 
 object Salesforce {
   type UserId = String
 
   sealed trait OutboundMessageChange
+
   case class MembershipUpdate(attributes: Attributes) extends OutboundMessageChange
+
   case class MembershipDeletion(userId: String) extends OutboundMessageChange
 
   sealed trait OutboundMessageParseError
+
   case class OrgIdMatchingError(organizationId: String) extends OutboundMessageParseError
+
   case class ParsingError(msg: String) extends OutboundMessageParseError
 
   /**
-   * @param payload The outbound message content coming from Salesforce
-   * @param organizationId  The id that qualifies the originating Salesforce account. This is to make sure that
-   *                        the service do not process outbound messages from SF environments created by duplicating
-   *                        Prod
-   * @return
-   */
-  def parseOutboundMessage(payload: NodeSeq, organizationId: String): OutboundMessageParseError \/ OutboundMessageChange = {
+    * @param payload        The outbound message content coming from Salesforce
+    * @param organizationId The id that qualifies the originating Salesforce account. This is to make sure that
+    *                       the service do not process outbound messages from SF environments created by duplicating
+    *                       Prod
+    * @return
+    */
+  def parseOutboundMessage(payload: NodeSeq, organizationId: String): OutboundMessageParseError \/ Seq[OutboundMessageChange] = {
     implicit class NodeSeqOps(ns: NodeSeq) {
       def getTag(tag: String): OutboundMessageParseError \/ Node =
         (ns \ tag).headOption \/> ParsingError(s"Error while parsing the outbound message: $tag not found.\n $payload")
@@ -32,17 +35,39 @@ object Salesforce {
       def getText(tag: String): OutboundMessageParseError \/ String = getTag(tag).map(_.text)
     }
 
-    for {
-      orgId <- (payload \\ "notifications").getText("OrganizationId")
-      _ <- if (orgId === organizationId) ().right else OrgIdMatchingError(orgId).left
-      obj <- (payload \\ "Notification").getTag("sObject")
-      id <- obj.getText("IdentityID__c")
-    } yield {
-      val tier = (obj \ "Membership_Tier__c").map(_.text).headOption
-      tier.fold[OutboundMessageChange](MembershipDeletion(id)) { t =>
-        val num = (obj \ "Membership_Number__c").headOption.map(_.text)
-        MembershipUpdate(Attributes(id, t, num))
+    def orgIdValidation: OutboundMessageParseError \/ Boolean = {
+      for {
+        orgId <- (payload \\ "notifications").getText("OrganizationId")
+        isValid <- if (orgId === organizationId) true.right else OrgIdMatchingError(orgId).left
+      } yield isValid
+    }
+
+    def getSalesforceObjects: OutboundMessageParseError \/ NodeSeq = {
+        val salesforceObjects = (payload \\ "sObject")
+        if (salesforceObjects.isEmpty) {
+          ParsingError(s"No Salesforce Objects were found when parsing the message. \n $payload").left
+        }
+        else salesforceObjects.right
+    }
+
+    def processSalesforceObject(salesforceObject: Node): OutboundMessageChange = {
+      val id = (salesforceObject \ "IdentityID__c").map(_.text).head
+      val tier = (salesforceObject \ "Membership_Tier__c").map(_.text).headOption
+      val num = (salesforceObject \ "Membership_Number__c").headOption.map(_.text)
+      // Match on the Tier to determine the required action
+      tier match {
+        // If Salesforce Contact object has no Tier, we assume the user has expired/cancelled and mark them for deletion
+        case None => MembershipDeletion(id)
+        // If the Salesforce Contact has a Tier, we mark them for an update
+        case Some(tier) => MembershipUpdate(Attributes(id, tier, num))
       }
+    }
+
+    orgIdValidation match {
+      case -\/(ParsingError(msg)) => ParsingError(msg).left
+      case -\/(OrgIdMatchingError(orgId)) => OrgIdMatchingError(orgId).left
+      // If we can validate the organization ID, then we get a Right and can attempt to process the notifications.
+      case \/-(_) => getSalesforceObjects.map { _.map(sfObject => processSalesforceObject(sfObject)) }
     }
   }
 }

--- a/membership-attribute-service/test/parsers/SalesforceTest.scala
+++ b/membership-attribute-service/test/parsers/SalesforceTest.scala
@@ -2,7 +2,8 @@ package parsers
 
 import models.Attributes
 import org.specs2.mutable.Specification
-import parsers.Salesforce.{MembershipDeletion, MembershipUpdate, OrgIdMatchingError}
+import parsers.Salesforce.{MembershipDeletion, MembershipUpdate, OrgIdMatchingError, ParsingError}
+
 import scalaz.syntax.either._
 
 class SalesforceTest extends Specification {
@@ -31,8 +32,8 @@ class SalesforceTest extends Specification {
           </soapenv:Body>
         </soapenv:Envelope>
 
-      val updateAction = MembershipUpdate(Attributes("identity_id", "Supporter", Some("membership_number")))
-      Salesforce.parseOutboundMessage(payload, orgId) shouldEqual updateAction.right
+      val updateActionSeq = Seq(MembershipUpdate(Attributes("identity_id", "Supporter", Some("membership_number"))))
+      Salesforce.parseOutboundMessage(payload, orgId) shouldEqual updateActionSeq.right
     }
 
     "deserialize a valid update Salesforce Outbound Message without MembershipNumber" in {
@@ -57,8 +58,44 @@ class SalesforceTest extends Specification {
           </soapenv:Body>
         </soapenv:Envelope>
 
-      val updateAction = MembershipUpdate(Attributes("identity_id", "Supporter", None))
-      Salesforce.parseOutboundMessage(payload, orgId) shouldEqual updateAction.right
+      val updateActionSeq = Seq(MembershipUpdate(Attributes("identity_id", "Supporter", None)))
+      Salesforce.parseOutboundMessage(payload, orgId) shouldEqual updateActionSeq.right
+    }
+
+    "deserialize a valid update Salesforce Outbound Message which includes multiple notifications" in {
+      val payload =
+        <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <soapenv:Body>
+            <notifications xmlns="http://soap.sforce.com/2005/09/outbound">
+              <OrganizationId>{orgId}</OrganizationId>
+              <ActionId>action_id</ActionId>
+              <SessionId xsi:nil="true"/>
+              <EnterpriseUrl>https://cs17.salesforce.com/services/Soap/c/34.0/enterprise_id</EnterpriseUrl>
+              <PartnerUrl>https://cs17.salesforce.com/services/Soap/u/34.0/enterprise_id</PartnerUrl>
+              <Notification>
+                <Id>notification_id1</Id>
+                <sObject xsi:type="sf:Contact" xmlns:sf="urn:sobject.enterprise.soap.sforce.com">
+                  <sf:Id>id1</sf:Id>
+                  <sf:IdentityID__c>123</sf:IdentityID__c>
+                  <sf:Membership_Number__c>12345</sf:Membership_Number__c>
+                  <sf:Membership_Tier__c>Supporter</sf:Membership_Tier__c>
+                </sObject>
+              </Notification>
+              <Notification>
+                <Id>notification_id2</Id>
+                <sObject xsi:type="sf:Contact" xmlns:sf="urn:sobject.enterprise.soap.sforce.com">
+                  <sf:Id>id2</sf:Id>
+                  <sf:IdentityID__c>321</sf:IdentityID__c>
+                  <sf:Membership_Number__c>54321</sf:Membership_Number__c>
+                  <sf:Membership_Tier__c>Supporter</sf:Membership_Tier__c>
+                </sObject>
+              </Notification>
+            </notifications>
+          </soapenv:Body>
+        </soapenv:Envelope>
+
+      val updateActionSeq = Seq(MembershipUpdate(Attributes("123", "Supporter", Some("12345"))), MembershipUpdate(Attributes("321", "Supporter", Some("54321"))))
+      Salesforce.parseOutboundMessage(payload, orgId) shouldEqual updateActionSeq.right
     }
 
     "deserialize a valid delete Salesforce Outbound Message" in {
@@ -82,8 +119,52 @@ class SalesforceTest extends Specification {
           </soapenv:Body>
         </soapenv:Envelope>
 
-      val deleteAction = MembershipDeletion("identity_id")
-      Salesforce.parseOutboundMessage(payload, orgId) shouldEqual deleteAction.right
+      val deleteActionSeq = Seq(MembershipDeletion("identity_id"))
+      Salesforce.parseOutboundMessage(payload, orgId) shouldEqual deleteActionSeq.right
+    }
+
+    "deserialize a Salesforce Outbound Message which includes a combination of delete and update notifications" in {
+      val payload =
+        <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <soapenv:Body>
+            <notifications xmlns="http://soap.sforce.com/2005/09/outbound">
+              <OrganizationId>{orgId}</OrganizationId>
+              <ActionId>action_id</ActionId>
+              <SessionId xsi:nil="true"/>
+              <EnterpriseUrl>https://cs17.salesforce.com/services/Soap/c/34.0/enterprise_id</EnterpriseUrl>
+              <PartnerUrl>https://cs17.salesforce.com/services/Soap/u/34.0/enterprise_id</PartnerUrl>
+              <Notification>
+                <Id>notification_id1</Id>
+                <sObject xsi:type="sf:Contact" xmlns:sf="urn:sobject.enterprise.soap.sforce.com">
+                  <sf:Id>id1</sf:Id>
+                  <sf:IdentityID__c>identity_id1</sf:IdentityID__c>
+                  <sf:Membership_Tier__c>Supporter</sf:Membership_Tier__c>
+                </sObject>
+              </Notification>
+              <Notification>
+                <Id>notification_id2</Id>
+                <sObject xsi:type="sf:Contact" xmlns:sf="urn:sobject.enterprise.soap.sforce.com">
+                  <sf:Id>id2</sf:Id>
+                  <sf:IdentityID__c>identity_id2</sf:IdentityID__c>
+                </sObject>
+              </Notification>
+              <Notification>
+                <Id>notification_id3</Id>
+                <sObject xsi:type="sf:Contact" xmlns:sf="urn:sobject.enterprise.soap.sforce.com">
+                  <sf:Id>id3</sf:Id>
+                  <sf:IdentityID__c>identity_id3</sf:IdentityID__c>
+                  <sf:Membership_Number__c>membership_number</sf:Membership_Number__c>
+                  <sf:Membership_Tier__c>Partner</sf:Membership_Tier__c>
+                </sObject>
+              </Notification>
+            </notifications>
+          </soapenv:Body>
+        </soapenv:Envelope>
+
+      val sfNotifications = Seq(MembershipUpdate(Attributes("identity_id1", "Supporter", None)),
+                                MembershipDeletion("identity_id2"),
+                                MembershipUpdate(Attributes("identity_id3", "Partner", Some("membership_number"))))
+      Salesforce.parseOutboundMessage(payload, orgId) shouldEqual sfNotifications.right
     }
 
     "returns an error if the organization does not match the expected one" in {
@@ -109,6 +190,26 @@ class SalesforceTest extends Specification {
         </soapenv:Envelope>
 
       Salesforce.parseOutboundMessage(payload, orgId) shouldEqual OrgIdMatchingError("wrong org").left
+    }
+
+    "returns an error if there are no Salesforce Objects" in {
+      val payload =
+        <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <soapenv:Body>
+            <notifications xmlns="http://soap.sforce.com/2005/09/outbound">
+              <OrganizationId>{orgId}</OrganizationId>
+              <ActionId>action_id</ActionId>
+              <SessionId xsi:nil="true"/>
+              <EnterpriseUrl>https://cs17.salesforce.com/services/Soap/c/34.0/enterprise_id</EnterpriseUrl>
+              <PartnerUrl>https://cs17.salesforce.com/services/Soap/u/34.0/enterprise_id</PartnerUrl>
+              <Notification>
+                <Id>notification_id</Id>
+              </Notification>
+            </notifications>
+          </soapenv:Body>
+        </soapenv:Envelope>
+
+      Salesforce.parseOutboundMessage(payload, orgId) shouldEqual ParsingError(s"No Salesforce Objects were found when parsing the message. \n $payload").left
     }
   }
 }


### PR DESCRIPTION
This PR allows our Salesforce Parser to handle multiple objects/notifications sent within a single message.

Previously the assumption seems to have been that each message would only include one sfObject, however the Salesforce docs show that multiple sfObjects can be included in a single message:
https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_om_outboundmessaging_notifications.htm
https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_om_outboundmessaging_wsdl.htm

The important parts are:

_A single SOAP message can include up to 100 notifications. Each notification contains the object ID and a reference to the associated sObject data. Note that if the information in the object changes after the notification is queued but before it is sent, only the updated information will be delivered.
...
If you issue multiple discrete calls, the calls may be batched together into one or more SOAP messages._

And later:

_This element is the schema for sending an acknowledgement (ack) response to Salesforce.
...
You acknowledge all notifications in the message if there is more than one._

We have seen huge numbers of members missing from Dynamo DB in the recent period of heavy traffic, and I suspect that this may be why. The logging included in this PR will also allow us to know for sure whether we are getting multiple sfObjects per message.

@paulbrown1982 @mario-galic @johnduffell 