### PR TITLE
Load user ad-free status from database

### DIFF
--- a/membership-attribute-service/app/configuration/Config.scala
+++ b/membership-attribute-service/app/configuration/Config.scala
@@ -83,6 +83,4 @@ object Config {
     supportsCredentials = true
   )
 
-  // TODO: remove once the adfree feature is generally available to the public
-  val preReleaseUsersIds = config.getStringList("identity.prerelease-users").asScala.toSet
 }

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -15,13 +15,14 @@ object ContentAccess {
   implicit val jsWrite = Json.writes[ContentAccess]
 }
 
-case class Attributes(UserId: String, Tier: String, MembershipNumber: Option[String], PublicTier: Option[Boolean] = None) {
+case class Attributes(UserId: String, Tier: String, MembershipNumber: Option[String], PublicTier: Option[Boolean] = None, AdFree: Option[Boolean] = None) {
   require(Tier.nonEmpty)
   require(UserId.nonEmpty)
 
   lazy val allowsPublicTierDisplay = PublicTier.exists(identity)
   lazy val isFriendTier = Tier.equalsIgnoreCase("friend")
   lazy val isPaidTier = !isFriendTier
+  lazy val isAdFree = AdFree.exists(identity)
 
   lazy val contentAccess = ContentAccess(member = true, paidMember = isPaidTier) // we want to include staff!
 }
@@ -33,6 +34,7 @@ object Attributes {
     (__ \ "userId").write[String] and
     (__ \ "tier").write[String] and
     (__ \ "membershipNumber").writeNullable[String] and
+    (__ \ "adFree").writeNullable[Boolean] and
     ignore
   )(unlift(Attributes.unapply)).addField("contentAccess", _.contentAccess)
 

--- a/membership-attribute-service/app/models/Features.scala
+++ b/membership-attribute-service/app/models/Features.scala
@@ -14,13 +14,9 @@ object Features {
     Ok(Json.toJson(attrs))
 
   def fromAttributes(attributes: Attributes) = {
-    // TODO: Once this officially launches, this should be:
-    // attributes.isPaidTier && (user has opted INTO the ad free experience)
-    val adfreeEnabled = attributes.isPaidTier && Config.preReleaseUsersIds.contains(attributes.UserId)
-    
     Features(
       userId = Some(attributes.UserId),
-      adFree = adfreeEnabled,
+      adFree = attributes.isAdFree,
       adblockMessage = !(attributes.isPaidTier)
     )
   }


### PR DESCRIPTION
In preparation for the ad-free trial, we now read the user's ad-free participation state from Dynamo DB.

We can manually update the table for specific users while we're preparing the backend services that will switch people in or out of the trial. This will work in conjunction with dotcom frontend changes to enable the trial.

