### PR TITLE
Allow http code env requests...

### DIFF
--- a/membership-attribute-service/conf/PROD.conf
+++ b/membership-attribute-service/conf/PROD.conf
@@ -13,6 +13,7 @@ touchpoint.backend.default=PROD
 touchpoint.backend.test=UAT
 
 play.filters.cors.allowedOrigins = [
+  "http://m.code.dev-theguardian.com",
   "https://m.code.dev-theguardian.com",
   "http://www.theguardian.com",
   "https://www.theguardian.com",


### PR DESCRIPTION
Prevent these errors in the code environment;

```No 'Access-Control-Allow-Origin' header is present on the requested resource. Origin 'http://m.code.dev-theguardian.com' is therefore not allowed access. The response had HTTP status code 403.```
