### PR TITLE
Track incomplete supporter checkouts

### DIFF
--- a/membership-attribute-service/app/BatchLoader.scala
+++ b/membership-attribute-service/app/BatchLoader.scala
@@ -14,7 +14,7 @@ import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 object BatchLoader {
-  private val table = NormalTouchpointComponents.dynamoTable
+  private val table = NormalTouchpointComponents.dynamoAttributesTable
   private val logger = LoggerFactory.getLogger(getClass)
   private implicit val serializer = MembershipAttributesSerializer(table)
 

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -56,7 +56,7 @@ class AttributeController extends Controller with LazyLogging {
           case Some(attrs) =>
             onSuccess(attrs)
           case None =>
-            onNotFound getOrElse ApiError("Not found", s"User not found in DynamoDB: userId=${id}; stage=${Config.stage}; dynamoTable=${request.touchpoint.dynamoTable}", 404)
+            onNotFound getOrElse ApiError("Not found", s"User not found in DynamoDB: userId=${id}; stage=${Config.stage}; dynamoTable=${request.touchpoint.dynamoAttributesTable}", 404)
         }
       }.getOrElse {
         metrics.put(s"$endpointDescription-cookie-auth-failed", 1)

--- a/membership-attribute-service/app/controllers/BehaviourController.scala
+++ b/membership-attribute-service/app/controllers/BehaviourController.scala
@@ -56,29 +56,10 @@ class BehaviourController extends Controller with LazyLogging {
         ApiErrors.badRequest(error)
       },
       success => {
-        logger.info(s"Recorded activities deleted for user ${result.getOrElse("!not found!")}")
-        Ok(Json.obj("captured" -> true))
+        logger.info("Recorded activities deleted for user")
+        Ok(Behaviour.asEmptyJson)
       }
     ))
   }
-
-  def behaviours = lookup("behaviours")
-
-  private def lookup(endpointDescription: String) = backendAction.async { request =>
-    authenticationService.userId(request).map[Future[Result]] { id =>
-      request.touchpoint.behaviourService.get(id).map {
-        case Some(bhv) =>
-          Behaviour.toResult(bhv)
-        case None =>
-          logger.error(s"User not found in DynamoDB: userId=${id}; stage=${Config.stage}; dynamoTable=${request.touchpoint.dynamoBehaviourTable}")
-          ApiError("Not found", s"User not found in DynamoDB: userId=${id}; stage=${Config.stage}; dynamoTable=${request.touchpoint.dynamoBehaviourTable}", 404)
-      }
-    }.getOrElse {
-      logger.info(s"$endpointDescription-cookie-auth-failed")
-      metrics.put(s"$endpointDescription-cookie-auth-failed", 1)
-      Future(unauthorized)
-    }
-  }
-
 
 }

--- a/membership-attribute-service/app/controllers/BehaviourController.scala
+++ b/membership-attribute-service/app/controllers/BehaviourController.scala
@@ -1,0 +1,84 @@
+package controllers
+
+import actions._
+import com.typesafe.scalalogging.LazyLogging
+import configuration.Config
+import models.ApiErrors._
+import models.{ApiErrors, Behaviour, ApiError, Attributes}
+import monitoring.CloudWatch
+import org.joda.time.DateTime
+import org.joda.time.format.ISODateTimeFormat
+import play.api.libs.json.Json
+import play.api.mvc.{Result, Controller}
+import play.filters.cors.CORSActionBuilder
+import services.{IdentityAuthService, AuthenticationService}
+import play.api.libs.concurrent.Execution.Implicits._
+import scala.concurrent.Future
+import scalaz.std.scalaFuture._
+import scalaz.{EitherT, \/}
+import scalaz.syntax.std.option._
+
+class BehaviourController extends Controller with LazyLogging {
+
+  lazy val corsFilter = CORSActionBuilder(Config.corsConfig)
+  lazy val backendAction = corsFilter andThen BackendFromCookieAction
+  lazy val authenticationService: AuthenticationService = IdentityAuthService
+  lazy val metrics = CloudWatch("BehaviourController")
+
+  def capture(activity: String) = BackendFromCookieAction.async { implicit request =>
+    val result: EitherT[Future, String, Behaviour] = for {
+      id <- EitherT(Future.successful(authenticationService.userId \/> "No user"))
+      behaviour = Behaviour(id, activity, DateTime.now.toString(ISODateTimeFormat.dateTime.withZoneUTC))
+      res <- EitherT(request.touchpoint.behaviourService.set(behaviour).map(\/.right))
+    } yield behaviour
+
+    result.run.map(_.fold(
+      error => {
+        logger.error(s"Failed to update attributes - $error")
+        ApiErrors.badRequest(error)
+      },
+      behaviour => {
+        logger.info(s"${behaviour.userId} -> ${behaviour.activity} -> ${behaviour.lastObserved}")
+        Ok(Behaviour.asJson(behaviour))
+      }
+    ))
+  }
+
+  def remove = BackendFromCookieAction.async { implicit request =>
+    val result: EitherT[Future, String, String] = for {
+      id <- EitherT(Future.successful(authenticationService.userId \/> "No user"))
+      _ <- EitherT(request.touchpoint.behaviourService.delete(id).map(\/.right))
+    } yield id
+
+    result.run.map(_.fold(
+      error => {
+        logger.error(s"Failed to remove activity for user ${result.getOrElse("!not found!")} - $error")
+        ApiErrors.badRequest(error)
+      },
+      success => {
+        logger.info(s"Recorded activities deleted for user ${result.getOrElse("!not found!")}")
+        Ok(Json.obj("captured" -> true))
+      }
+    ))
+  }
+
+  def behaviours = lookup("behaviours")
+
+  private def lookup(endpointDescription: String) = backendAction.async { request =>
+    authenticationService.userId(request).map[Future[Result]] { id =>
+      request.touchpoint.behaviourService.get(id).map {
+        case Some(bhv) =>
+          Behaviour.toResult(bhv)
+        case None =>
+          logger.error(s"User not found in DynamoDB: userId=${id}; stage=${Config.stage}; dynamoTable=${request.touchpoint.dynamoBehaviourTable}")
+          ApiError("Not found", s"User not found in DynamoDB: userId=${id}; stage=${Config.stage}; dynamoTable=${request.touchpoint.dynamoBehaviourTable}", 404)
+      }
+    }.getOrElse {
+      logger.info(s"$endpointDescription-cookie-auth-failed")
+      metrics.put(s"$endpointDescription-cookie-auth-failed", 1)
+      Future(unauthorized)
+    }
+  }
+
+
+}

--- a/membership-attribute-service/app/controllers/SalesforceHookController.scala
+++ b/membership-attribute-service/app/controllers/SalesforceHookController.scala
@@ -49,11 +49,11 @@ def createAttributes = BackendFromSalesforceAction.async(parse.xml) { request =>
   def deleteMemberRecord(membershipDeletion: MembershipDeletion): Future[Object] = {
     val userId = membershipDeletion.userId
     attributeService.delete(userId).map { deleteItemResult =>
-      logger.info(s"Successfully deleted user $userId from ${touchpoint.dynamoTable}.")
+      logger.info(s"Successfully deleted user $userId from ${touchpoint.dynamoAttributesTable}.")
       metrics.put("Delete", 1)
       deleteItemResult
     }.recover { case e: Throwable =>
-      logger.warn(s"Failed to delete user $userId from ${touchpoint.dynamoTable}. Salesforce should retry.", e)
+      logger.warn(s"Failed to delete user $userId from ${touchpoint.dynamoAttributesTable}. Salesforce should retry.", e)
       Failure
     }
   }
@@ -72,11 +72,11 @@ def createAttributes = BackendFromSalesforceAction.async(parse.xml) { request =>
     }).run.flatMap { attrsUpdatedWithZuoraOpt =>
       if (attrsUpdatedWithZuoraOpt.isEmpty) logger.error(s"Couldn't update $attrs with information from Zuora")
       attributeService.set(attrsUpdatedWithZuoraOpt.getOrElse(attrs)).map { putItemResult =>
-        logger.info(s"Successfully inserted ${attrsUpdatedWithZuoraOpt.getOrElse(attrs)} into ${touchpoint.dynamoTable}.")
+        logger.info(s"Successfully inserted ${attrsUpdatedWithZuoraOpt.getOrElse(attrs)} into ${touchpoint.dynamoAttributesTable}.")
         metrics.put("Update", 1)
         putItemResult
       }.recover { case e: Throwable =>
-        logger.warn(s"Failed to insert ${attrsUpdatedWithZuoraOpt.getOrElse(attrs)} into ${touchpoint.dynamoTable}. Salesforce should retry.", e)
+        logger.warn(s"Failed to insert ${attrsUpdatedWithZuoraOpt.getOrElse(attrs)} into ${touchpoint.dynamoAttributesTable}. Salesforce should retry.", e)
         Failure
       }
     }

--- a/membership-attribute-service/app/models/Behaviour.scala
+++ b/membership-attribute-service/app/models/Behaviour.scala
@@ -1,0 +1,27 @@
+package models
+
+import json._
+import play.api.libs.json._
+import play.api.mvc.Result
+import play.api.mvc.Results.Ok
+import org.joda.time.DateTime
+
+import scala.language.implicitConversions
+import play.api.libs.functional.syntax._
+
+case class Behaviour(userId: String, activity: String, lastObserved: String)
+
+object Behaviour {
+
+  implicit val jsWrite: OWrites[Behaviour] = (
+    (__ \ "userId").write[String] and
+    (__ \ "activity").write[String] and
+    (__ \ "lastObserved").write[String]
+  )(unlift(Behaviour.unapply))
+
+  implicit def toResult(bhv: Behaviour): Result =
+    Ok(asJson(bhv))
+
+  def asJson(bhv: Behaviour) = Json.toJson(bhv)
+
+}

--- a/membership-attribute-service/app/models/Behaviour.scala
+++ b/membership-attribute-service/app/models/Behaviour.scala
@@ -24,4 +24,6 @@ object Behaviour {
 
   def asJson(bhv: Behaviour) = Json.toJson(bhv)
 
+  def asEmptyJson = asJson(Behaviour("","",""))
+
 }

--- a/membership-attribute-service/app/services/BehaviourService.scala
+++ b/membership-attribute-service/app/services/BehaviourService.scala
@@ -1,0 +1,12 @@
+package services
+
+import com.amazonaws.services.dynamodbv2.model.{DeleteItemResult, PutItemResult}
+import models.Behaviour
+
+import scala.concurrent.Future
+
+trait BehaviourService {
+  def get(userId: String): Future[Option[Behaviour]]
+  def set(behaviour: Behaviour): Future[PutItemResult]
+  def delete(userId: String): Future[DeleteItemResult]
+}

--- a/membership-attribute-service/app/services/ScanamoBehaviourService.scala
+++ b/membership-attribute-service/app/services/ScanamoBehaviourService.scala
@@ -1,0 +1,23 @@
+package services
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
+import com.amazonaws.services.dynamodbv2.model.{DeleteItemResult, PutItemResult}
+import com.gu.scanamo.syntax._
+import com.gu.scanamo.{ScanamoAsync, Table}
+import com.typesafe.scalalogging.LazyLogging
+import models.Behaviour
+import play.api.libs.concurrent.Execution.Implicits._
+import scala.concurrent.Future
+
+class ScanamoBehaviourService(client: AmazonDynamoDBAsyncClient, table: String) extends BehaviourService with LazyLogging {
+
+  val scanamo = Table[Behaviour](table)
+  def run[T] = ScanamoAsync.exec[T](client) _
+
+  override def get(userId: String): Future[Option[Behaviour]] =
+    run(scanamo.get('userId -> userId).map(_.flatMap(_.toOption)))
+
+  override def set(behaviour: Behaviour): Future[PutItemResult] = run(scanamo.put(behaviour))
+
+  override def delete(userId: String): Future[DeleteItemResult] = run(scanamo.delete('userId -> userId))
+}

--- a/membership-attribute-service/conf/DEV.conf
+++ b/membership-attribute-service/conf/DEV.conf
@@ -20,7 +20,9 @@ play.filters.cors.allowedOrigins = [
   "https://membership.thegulocal.com",
   "https://mem.thegulocal.com",
   "http://m.thegulocal.com",
-  "https://m.thegulocal.com"
+  "https://m.thegulocal.com",
+  "http://thegulocal.com",
+  "https://thegulocal.com"
 ]
 
 mma.cors.allowedOrigins = [

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -14,9 +14,8 @@ OPTIONS    /user-attributes/me/membership-update-card       controllers.AccountC
 POST       /user-attributes/me/digitalpack-update-card      controllers.AccountController.digitalPackUpdateCard
 OPTIONS    /user-attributes/me/digitalpack-update-card      controllers.AccountController.digitalPackUpdateCard
 
-GET        /user-behaviour/me                               controllers.BehaviourController.behaviours
 POST       /user-behaviour/me/capture/:activity             controllers.BehaviourController.capture(activity)
-POST       /user-behaviour/me/remove                        controllers.BehaviourController.remove
+GET        /user-behaviour/me/remove                        controllers.BehaviourController.remove
 
 POST       /salesforce-hook                                 controllers.SalesforceHookController.createAttributes
 POST       /stripe-hook                                     controllers.StripeHookController.updatePrefs

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -14,6 +14,10 @@ OPTIONS    /user-attributes/me/membership-update-card       controllers.AccountC
 POST       /user-attributes/me/digitalpack-update-card      controllers.AccountController.digitalPackUpdateCard
 OPTIONS    /user-attributes/me/digitalpack-update-card      controllers.AccountController.digitalPackUpdateCard
 
+GET        /user-behaviour/me                               controllers.BehaviourController.behaviours
+POST       /user-behaviour/me/capture/:activity             controllers.BehaviourController.capture(activity)
+POST       /user-behaviour/me/remove                        controllers.BehaviourController.remove
+
 POST       /salesforce-hook                                 controllers.SalesforceHookController.createAttributes
 POST       /stripe-hook                                     controllers.StripeHookController.updatePrefs
 POST       /stripe-hook-sns                                 controllers.StripeHookController.publishToSns

--- a/membership-attribute-service/conf/touchpoint.DEV.conf
+++ b/membership-attribute-service/conf/touchpoint.DEV.conf
@@ -1,6 +1,7 @@
 touchpoint.backend.environments {
   DEV {
     dynamodb.table = MembershipAttributes-DEV
+    behaviour.dynamodb.table = MembershipBehaviour-DEV
     giraffe.sns = "arn:aws:sns:eu-west-1:865473395570:giraffe-dev"
     salesforce {
       hook-secret = "secret-key"

--- a/membership-attribute-service/conf/touchpoint.PROD.conf
+++ b/membership-attribute-service/conf/touchpoint.PROD.conf
@@ -1,6 +1,7 @@
 touchpoint.backend.environments {
   PROD {
     dynamodb.table = MembershipAttributes-PROD
+    behaviour.dynamodb.table = MembershipBehaviour-PROD
     giraffe.sns = "arn:aws:sns:eu-west-1:865473395570:giraffe"
     salesforce {
       hook-secret = null


### PR DESCRIPTION
This PR is the worker end of [this one in membership-frontend](https://github.com/guardian/membership-frontend/pull/1432).

Enable capturing of events for users, and the subsequent removal of those events when they've completed the supporter checkout process all the way through to payment.

