### PR TITLE
Make PayPal payment details available through the api

### DIFF
--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -67,6 +67,6 @@ class TouchpointComponents(stage: String)(implicit system: ActorSystem) {
   lazy val catalogService = new CatalogService[Future](productIds, simpleClient, Await.result(_, 10.seconds), stage)
 
   lazy val futureCatalog: Future[CatalogMap] = catalogService.catalog.map(_.fold[CatalogMap](error => {println(s"error: ${error.list.mkString}"); Map()}, _.map))
-  lazy val subService = new SubscriptionService[Future](productIds, futureCatalog, simpleClient, zuoraService.getAccountIds, () => LocalDate.now)
+  lazy val subService = new SubscriptionService[Future](productIds, futureCatalog, simpleClient, zuoraService.getAccountIds)
   lazy val paymentService = new PaymentService(stripeService, zuoraService, catalogService.unsafeCatalog.productMap)
 }

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -21,6 +21,8 @@ object AccountDetails {
       val endDate = paymentDetails.chargedThroughDate
         .getOrElse(paymentDetails.termEndDate)
 
+      val payPalEmail = paymentDetails.payPalEmail.fold(Json.obj())(e => Json.obj("payPalEmail" -> e))
+
       val card = paymentDetails.card.fold(Json.obj())(card => Json.obj(
         "card" -> Json.obj(
           "last4" -> card.last4,
@@ -31,7 +33,7 @@ object AccountDetails {
       Json.obj(
         "joinDate" -> paymentDetails.startDate,
         "optIn" -> !paymentDetails.pendingCancellation,
-        "subscription" -> (card ++ Json.obj(
+        "subscription" -> (card ++ payPalEmail ++ Json.obj(
           "start" -> paymentDetails.lastPaymentDate,
           "end" -> endDate,
           "nextPaymentPrice" -> paymentDetails.nextPaymentPrice,

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -1,5 +1,5 @@
 package models
-import com.gu.memsub.{PayPalMethod, PaymentCard}
+import com.gu.memsub.{GoCardless, PayPalMethod, PaymentCard}
 import com.gu.salesforce._
 import com.gu.services.model._
 import play.api.libs.json._
@@ -32,6 +32,12 @@ object AccountDetails {
           "card" -> Json.obj(
             "last4" -> card.lastFourDigits,
             "type" -> card.cardType
+          )
+        )
+        case dd: GoCardless => Json.obj(
+          "paymentMethod" -> "DirectDebit",
+          "account" -> Json.obj(
+            "accountName" -> dd.accountName
           )
         )
       }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSNS = "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.332-SNAPSHOT"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.346"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
 
   //projects

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSNS = "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.328"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.332-SNAPSHOT"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
 
   //projects

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSNS = "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.317"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.328"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
 
   //projects


### PR DESCRIPTION
Trello card for this work is [here](https://trello.com/c/eOtuebKl/276-update-members-data-api-to-cope-with-paypal-users) 

It depends on [this PR in membership-common](https://github.com/guardian/membership-common/pull/405)

Currently the members data api can't cope with users who have been created in Zuora with a PayPal payment method. 

Hitting the endpoint /user-attributes/me/mma-membership

results in the error:
`2017-01-12 16:53:26,892 [application-akka.actor.default] Global[Global.scala:29] ERROR: Error handling request request: GET /user-attributes/me/mma-membership
scala.MatchError: PayPal (of class java.lang.String)
at com.gu.memsub.services.PaymentService.com$gu$memsub$services$PaymentService$$buildPaymentMethod(PaymentService.scala:46) ~[membership-common_2.11-0.318.jar:0.318]
at com.gu.memsub.services.PaymentService$$anonfun$getPaymentMethod$1.apply(PaymentService.scala:65) ~[membership-common_2.11-0.318.jar:0.318]
at com.gu.memsub.services.PaymentService$$anonfun$getPaymentMethod$1.apply(PaymentService.scala:65) ~[membership-common_2.11-0.318.jar:0.318]`

This PR fixes that error and makes PayPal payment data available through the mma-membership endpoint, it also introduces a 'paymentMethod' field into the response to make it easier to work with for clients.

Example response:
<img width="600" alt="screen shot 2017-01-13 at 17 56 43" src="https://cloud.githubusercontent.com/assets/181371/21939890/bc5a9ff0-d9b9-11e6-8950-cbf156f300ff.png">



