### PR TITLE
Fix DynamoDB Local download by upgrading sbt-dynamodb to v1.5.3

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,4 +8,4 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.6")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.3.2")
 
-addSbtPlugin("com.localytics" % "sbt-dynamodb" % "1.4.0")
+addSbtPlugin("com.localytics" % "sbt-dynamodb" % "1.5.3")


### PR DESCRIPTION
Just like https://github.com/guardian/membership-common/pull/420, to get the fix in https://github.com/localytics/sbt-dynamodb/pull/30 for AWS shifting their download url.

cc @rupertbates 