### PR TITLE
Use the new wildcard cert for *.thegulocal.com, clean up Nginx config

### DIFF
--- a/nginx/members-data-api.conf
+++ b/nginx/members-data-api.conf
@@ -1,19 +1,10 @@
 server {
-    server_name members-data-api.thegulocal.com;
-
-    location / {
-        proxy_pass http://localhost:9400/;
-          proxy_set_header Host $http_host;
-    }
-}
-
-server {
     listen 443;
     server_name members-data-api.thegulocal.com;
 
     ssl on;
-    ssl_certificate keys/members-data-api.crt;
-    ssl_certificate_key keys/members-data-api.key;
+    ssl_certificate wildcard-thegulocal-com-exp2019-01-09.crt; ## Supplied by https://github.com/guardian/identity-platform#setup-nginx-for-local-development
+    ssl_certificate_key wildcard-thegulocal-com-exp2019-01-09.key; ## ditto
 
     ssl_session_timeout 5m;
 

--- a/nginx/setup.sh
+++ b/nginx/setup.sh
@@ -1,20 +1,12 @@
 #!/bin/bash
 
-GU_KEYS="${HOME}/.gu/keys"
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NGINX_HOME=$(nginx -V 2>&1 | grep 'configure arguments:' | sed 's#.*conf-path=\([^ ]*\)/nginx\.conf.*#\1#g')
 
-sudo mkdir -p $NGINX_HOME/sites-enabled
+printf "\nUsing NGINX_HOME=$NGINX_HOME\n\n"
+printf "Note that you need to have already completed the Identity Platform setup:\n"
+printf "https://github.com/guardian/identity-platform#setup-nginx-for-local-development\n\n"
+
 sudo ln -fs $DIR/members-data-api.conf $NGINX_HOME/sites-enabled/members-data-api.conf
 
-cd  ${GU_KEYS}
-openssl genrsa -out "members-data-api.key" 2048
-openssl req -new -key "members-data-api.key" -out "members-data-api.csr"
-openssl x509 -req -in "members-data-api.csr" -signkey "members-data-api.key" -out "members-data-api.crt"
-
-
-sudo ln -fs ${GU_KEYS}/ $NGINX_HOME/keys
-
-sudo nginx -s stop
-sudo nginx
-
+printf "\n\nNow restart Nginx!\n\n"


### PR DESCRIPTION
Relying on the new CA-signed wildcard-cert that's provided by https://github.com/guardian/identity-platform/pull/149 means we can delete some code - there's not much point in us having different certificates for our dev environment, and Membership needs the Identity Platform to have been configured in order to work in dev.

This mirrors the work done in:

* https://github.com/guardian/membership-frontend/pull/1447
* https://github.com/guardian/subscriptions-frontend/pull/781

cc @JustinPinner 