### PR TITLE
Add Guardian dentity headers

### DIFF
--- a/membership-attribute-service/app/Global.scala
+++ b/membership-attribute-service/app/Global.scala
@@ -1,13 +1,19 @@
-import filters.{AddEC2InstanceHeader, LogRequestsFilter}
+import filters.AddEC2InstanceHeader
 import models.ApiErrors._
 import monitoring.SentryLogging
-import play.api.{Application, Logger}
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.mvc.{RequestHeader, Result, WithFilters}
+import play.api.{Application, Logger}
 import play.filters.csrf._
+
 import scala.concurrent.Future
 
-object Global extends WithFilters(CSRFFilter(), AddEC2InstanceHeader) {
+
+object Global extends WithFilters(
+  CheckCacheHeadersFilter,
+  CSRFFilter(),
+  AddEC2InstanceHeader
+) {
 
   private val logger = Logger(this.getClass)
 

--- a/membership-attribute-service/app/actions/package.scala
+++ b/membership-attribute-service/app/actions/package.scala
@@ -1,8 +1,20 @@
 import components.TouchpointComponents
-import play.api.mvc.{WrappedRequest, Request, Action}
+import controllers.NoCache
+import play.api.mvc._
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
 
 package object actions {
-  val BackendFromCookieAction = Action andThen WithBackendFromCookieAction
-  val BackendFromSalesforceAction = Action andThen WithBackendFromSalesforceAction
+  def noCache(result: Result): Result = NoCache(result)
+
+  val NoCacheAction = resultModifier(noCache)
+
+  val BackendFromCookieAction = NoCacheAction andThen WithBackendFromCookieAction
+  val BackendFromSalesforceAction = NoCacheAction andThen WithBackendFromSalesforceAction
   class BackendRequest[A](val touchpoint: TouchpointComponents, request: Request[A]) extends WrappedRequest[A](request)
+
+  private def resultModifier(f: Result => Result) = new ActionBuilder[Request] {
+    def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) = block(request).map(f)
+  }
 }

--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -27,8 +27,8 @@ class AccountController {
   lazy val authenticationService: AuthenticationService = IdentityAuthService
   lazy val corsCardFilter = CORSActionBuilder(Config.mmaCardCorsConfig)
   lazy val mmaCorsFilter = CORSActionBuilder(Config.mmaCorsConfig)
-  lazy val mmaAction = mmaCorsFilter andThen BackendFromCookieAction
-  lazy val mmaCardAction = corsCardFilter andThen BackendFromCookieAction
+  lazy val mmaAction = NoCacheAction andThen mmaCorsFilter andThen BackendFromCookieAction
+  lazy val mmaCardAction = NoCacheAction andThen corsCardFilter andThen BackendFromCookieAction
 
   def updateCard[P <: SubscriptionPlan.AnyPlan : SubPlanReads] = mmaCardAction.async { implicit request =>
     val updateForm = Form { single("stripeToken" -> nonEmptyText) }

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -25,7 +25,7 @@ import scalaz.{EitherT, \/}
 class AttributeController extends Controller with LazyLogging {
 
   lazy val corsFilter = CORSActionBuilder(Config.corsConfig)
-  lazy val backendAction = corsFilter andThen BackendFromCookieAction
+  lazy val backendAction = NoCacheAction andThen corsFilter andThen BackendFromCookieAction
   lazy val authenticationService: AuthenticationService = IdentityAuthService
   lazy val metrics = Metrics("AttributesController")
 

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -55,7 +55,10 @@ class AttributeController extends Controller with LazyLogging {
       authenticationService.userId(request).map[Future[Result]] { id =>
         request.touchpoint.attrService.get(id).map {
           case Some(attrs) =>
-            onSuccess(attrs)
+            onSuccess(attrs).withHeaders(
+              "X-Gu-Membership-Tier" -> attrs.Tier,
+              "X-Gu-Membership-Is-Paid-Tier" -> attrs.isPaidTier.toString
+            )
           case None =>
             onNotFound getOrElse ApiError("Not found", s"User not found in DynamoDB: userId=${id}; stage=${Config.stage}; dynamoTable=${request.touchpoint.dynamoAttributesTable}", 404)
         }

--- a/membership-attribute-service/app/controllers/StripeHookController.scala
+++ b/membership-attribute-service/app/controllers/StripeHookController.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import actions.NoCacheAction
 import com.gu.stripe.Stripe
 import com.typesafe.scalalogging.LazyLogging
 import play.api.libs.concurrent.Execution.Implicits._
@@ -17,7 +18,7 @@ import scalaz.OptionT
 
 class StripeHookController extends Controller with LazyLogging {
 
-  def updatePrefs = Action.async { implicit request =>
+  def updatePrefs = NoCacheAction.async { implicit request =>
     request.body.asJson.map(Json.fromJson[Event[StripeObject]](_)).fold[Future[Result]] {
       Future.successful(BadRequest("No JSON found in request body"))
     } { event =>
@@ -37,7 +38,7 @@ class StripeHookController extends Controller with LazyLogging {
   }
 
 
-  def publishToSns = Action.async { implicit request =>
+  def publishToSns = NoCacheAction.async { implicit request =>
     request.body.asJson.map(Json.fromJson[Event[StripeObject]](_)).fold[Future[Result]] {
       Future.successful(BadRequest("No JSON found in request body"))
     } { event =>

--- a/membership-attribute-service/app/filters/AddGuIdentityHeaders.scala
+++ b/membership-attribute-service/app/filters/AddGuIdentityHeaders.scala
@@ -1,0 +1,29 @@
+package filters
+
+import configuration.Config
+import play.api.http.HeaderNames
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import play.api.mvc._
+import services.IdentityAuthService
+
+import scala.concurrent.Future
+
+/*
+ * This is a candidate for inclusion in https://github.com/guardian/memsub-common-play-auth ,
+ * this particular version is a tweaked copy from https://github.com/guardian/subscriptions-frontend/blob/ea805479/app/filters/AddGuIdentityHeaders.scala
+ */
+object AddGuIdentityHeaders extends Filter with HeaderNames {
+
+  def apply(nextFilter: RequestHeader => Future[Result])(request: RequestHeader): Future[Result] = for {
+    result <- nextFilter(request)
+  } yield headersFor(request, result)
+
+  def headersFor(request: RequestHeader, result: Result) = (for {
+    user <- IdentityAuthService.playAuthService.authenticatedUserFor(request)
+  } yield result.withHeaders(
+    "X-Gu-Identity-Id" -> user.id,
+    "X-Gu-Identity-Credentials-Type" -> user.credentials.getClass.getSimpleName,
+    "X-Gu-Membership-Test-User" -> Config.testUsernames.isValid(user.id).toString
+  )).getOrElse(result)
+
+}

--- a/membership-attribute-service/app/filters/CheckCacheHeadersFilter.scala
+++ b/membership-attribute-service/app/filters/CheckCacheHeadersFilter.scala
@@ -1,0 +1,20 @@
+package filters
+
+import controllers.Cached.suitableForCaching
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import play.api.mvc._
+
+import scala.concurrent.Future
+
+object CheckCacheHeadersFilter extends Filter {
+
+  def apply(nextFilter: RequestHeader => Future[Result])(requestHeader: RequestHeader): Future[Result] = {
+    nextFilter(requestHeader).map { result =>
+      if (suitableForCaching(result)) {
+        val hasCacheControl = result.header.headers.contains("Cache-Control")
+        assert(hasCacheControl, s"Cache-Control not set. Ensure controller response has Cache-Control header set for ${requestHeader.path}. Throwing exception... ")
+      }
+      result
+    }
+  }
+}

--- a/membership-attribute-service/app/models/Features.scala
+++ b/membership-attribute-service/app/models/Features.scala
@@ -11,13 +11,15 @@ object Features {
   implicit val jsWrite = Json.writes[Features]
 
   implicit def toResult(attrs: Features): Result =
-    Ok(Json.toJson(attrs))
+    Ok(Json.toJson(attrs)).withHeaders(
+      "X-Gu-Ad-Free" -> attrs.adFree.toString
+    )
 
   def fromAttributes(attributes: Attributes) = {
     Features(
       userId = Some(attributes.UserId),
       adFree = attributes.isAdFree,
-      adblockMessage = !(attributes.isPaidTier)
+      adblockMessage = !attributes.isPaidTier
     )
   }
 


### PR DESCRIPTION
@alfavata on the Mobile team had seen a recent spike in new errors coming from the members-data-api - a total of 17K errors starting Feb 1st, with a couple of spikes on Feb 2nd (3pm and 10pm). This is in addition to the 'regular background noise' of empty-response errors that the iOS app says it gets from the members-data-api.

After trying to investigate this, I feel that better logging on the members-data-api is required to understand what's going on : specifically, we need to turn on Fastly logging (it's not currently turned on for the members-data-api), and we need to add Guardian Identity information to the response headers so that it can be recorded in the Fastly logs. At the very least, this should allow us to look at a specific example of an error and say - _"this is how Fastly says we responded to that request"_.

The "Ensure cache headers are set on all HTTP responses" commit was added because in the past we've only returned Guardian Identity

Unfortunately, although we normally just add the relevant headers with the `AddGuIdentityHeaders` filter, these response headers are thrown away for `onBadRequest`, `onHandlerNotFound` and `onError` (eg a HTTP 500 internal server error response). Because we're particularly concerned about these, I've added the Identity response headers into the error handlers in `Global` as well.

https://trello.com/c/i3BzCE6i/320-add-fastly-logging-to-members-data-api-to-help-diagnose-errors

cc @paulbrown1982 