### PR TITLE
Fix "tried to do something before we had an auth token" error

### DIFF
--- a/membership-attribute-service/app/controllers/HealthCheckController.scala
+++ b/membership-attribute-service/app/controllers/HealthCheckController.scala
@@ -18,9 +18,11 @@ class BoolTest(name: String, exec: () => Boolean) extends Test {
 
 class HealthCheckController extends Results {
   lazy val zuora = NormalTouchpointComponents.zuoraService
+  lazy val salesforce = NormalTouchpointComponents.contactRepo.salesforce
 
   val tests: Seq[Test] = Seq(
-    new BoolTest("ZuoraPing", () => zuora.lastPingTimeWithin(2.minutes))
+    new BoolTest("ZuoraPing", () => zuora.lastPingTimeWithin(2.minutes)),
+    new BoolTest("Salesforce", () => salesforce.isAuthenticated)
   )
 
   def healthCheck() = Action {


### PR DESCRIPTION
This comes from the work around https://github.com/guardian/membership-common/pull/399 ...the server can start up and serve requests without having authenticated with Salesforce. So the first few requests get an error like this:

https://sentry.io/the-guardian/members-data-api/issues/215630864/

...the slightly-hacky fix is to add Salesforce to the HealthCheck, as in:

https://github.com/guardian/membership-frontend/pull/1433

...so the ELB won't allow the box to serve requests until Salesforce is authenticated.

cc @paulbrown1982 @AWare 