### PR TITLE
use membership common that understands frontend ids

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSNS = "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.354"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.359"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
 
   //projects

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSNS = "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.359"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.360"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
 
   //projects


### PR DESCRIPTION
https://github.com/guardian/membership-common/pull/419 understand free id
edit:
guardian/membership-common#424 don't read the untagged rateplans
guardian/membership-common#425 use billing period as an object not a case class

===

This can't merge because the "paypal" config is needed by touchpoint backend.  however I'm not sure that members data api needs it
was added in https://github.com/guardian/membership-common/pull/418