### PR TITLE
Fix 'Cache-Control not set' error on robots.txt and other pages

### DIFF
--- a/membership-attribute-service/app/Global.scala
+++ b/membership-attribute-service/app/Global.scala
@@ -25,12 +25,12 @@ object Global extends WithFilters(
 
   override def onBadRequest(request: RequestHeader, error: String): Future[Result] = {
     logger.debug(s"Bad request: $request, error: $error")
-    Future { AddGuIdentityHeaders.headersFor(request, badRequest(error)) }
+    Future { badRequest(error) }
   }
 
   override def onHandlerNotFound(request: RequestHeader): Future[Result] = {
     logger.debug(s"Handler not found for request: $request")
-    Future { AddGuIdentityHeaders.headersFor(request, notFound) }
+    Future { notFound }
   }
 
   override def onError(request: RequestHeader, ex: Throwable): Future[Result] = {

--- a/membership-attribute-service/app/models/ApiError.scala
+++ b/membership-attribute-service/app/models/ApiError.scala
@@ -1,5 +1,6 @@
 package models
 
+import controllers.NoCache
 import play.api.libs.json._
 import play.api.mvc._
 
@@ -16,6 +17,6 @@ object ApiError {
     )
   }
   implicit def apiErrorToResult(err: ApiError): Result = {
-    Results.Status(err.statusCode)(Json.toJson(err))
+    NoCache(Results.Status(err.statusCode)(Json.toJson(err)))
   }
 }


### PR DESCRIPTION
Unfortunately the `CheckCacheHeadersFilter` added with https://github.com/guardian/members-data-api/pull/157/commits/0bcf6afca233862d37a5e55d8cb5487de3950c90 ...was throwing a lot of noisy errors because our error pages didn't have cache headers set :) Those are triggered on 404s (eg robots.txt) and other pages.

https://sentry.io/the-guardian/members-data-api/issues/215640173/

...also it turns out that the `AddGuIdentityHeaders.headersFor()` wrapping is only necessary for `onError()`, as the `AddGuIdentityHeaders` filter-added response-headers are not wiped out for `onHandlerNotFound()` and `onBadRequest()`

cc @svillafe @paulbrown1982 