### PR TITLE
Grant access to behaviour tables via role for abandoned checkouts

### DIFF
--- a/cloudformation/membership-attribute-service.json
+++ b/cloudformation/membership-attribute-service.json
@@ -91,7 +91,9 @@
         "NotificationAlarmPeriod": 1200,
         "InstanceName": "PROD:membership-attribute-service",
         "DynamoDBTable": "arn:aws:dynamodb:*:*:table/MembershipAttributes-PROD",
-        "DynamoDBTableTestUsers": "arn:aws:dynamodb:*:*:table/MembershipAttributes-UAT"
+        "DynamoDBTableTestUsers": "arn:aws:dynamodb:*:*:table/MembershipAttributes-UAT",
+        "DynamoDBBehaviourTable": "arn:aws:dynamodb:*:*:table/MembershipBehaviour-PROD",
+        "DynamoDBBehaviourTableTestUsers": "arn:aws:dynamodb:*:*:table/MembershipBehaviour-UAT"
       }
     }
   },
@@ -171,6 +173,36 @@
                   "Fn::FindInMap": ["StageVariables", {
                     "Ref": "Stage"
                   }, "DynamoDBTableTestUsers"]
+                },
+                "Effect": "Allow"
+              },
+              {
+                "Action": [
+                  "dynamodb:PutItem",
+                  "dynamodb:GetItem",
+                  "dynamodb:UpdateItem",
+                  "dynamodb:DeleteItem",
+                  "dynamodb:BatchGetItem"
+                ],
+                "Resource": {
+                  "Fn::FindInMap": ["StageVariables", {
+                    "Ref": "Stage"
+                  }, "DynamoDBBehaviourTable"]
+                },
+                "Effect": "Allow"
+              },
+              {
+                "Action": [
+                  "dynamodb:PutItem",
+                  "dynamodb:GetItem",
+                  "dynamodb:UpdateItem",
+                  "dynamodb:DeleteItem",
+                  "dynamodb:BatchGetItem"
+                ],
+                "Resource": {
+                  "Fn::FindInMap": ["StageVariables", {
+                    "Ref": "Stage"
+                  }, "DynamoDBBehaviourTableTestUsers"]
                 },
                 "Effect": "Allow"
               },


### PR DESCRIPTION
We've got a couple* of new tables for tracking abandoned carts at the checkout stage, and for those to be updated we need to grant relevant permissions.

(In support of https://github.com/guardian/members-data-api/pull/155)

*Same `MembershipBehaviour` concept, `-PROD` and `-UAT` variants.
