### PR TITLE
Track incomplete checkouts with email

### DIFF
--- a/membership-attribute-service/app/controllers/BehaviourController.scala
+++ b/membership-attribute-service/app/controllers/BehaviourController.scala
@@ -1,19 +1,15 @@
 package controllers
 
 import actions._
-import com.amazonaws.services.dynamodbv2.model.DeleteItemResult
 import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
-import models.{ApiErrors, Behaviour}
+import models.Behaviour
 import monitoring.Metrics
-import org.joda.time.DateTime
-import org.joda.time.format.ISODateTimeFormat
-import play.api.libs.json.{JsValue, Json}
-import play.api.mvc.{AnyContent, Result, Controller}
-import services.{IdentityAuthService, AuthenticationService}
 import play.api.libs.concurrent.Execution.Implicits._
-import play.api.mvc.Controller
+import play.api.libs.json.JsValue
+import play.api.mvc.{AnyContent, Controller}
 import play.filters.cors.CORSActionBuilder
+import services.{AuthenticationService, IdentityAuthService}
 
 class BehaviourController extends Controller with LazyLogging {
 
@@ -23,7 +19,7 @@ class BehaviourController extends Controller with LazyLogging {
   lazy val metrics = Metrics("BehaviourController")
 
   def capture() = BackendFromCookieAction.async { implicit request =>
-    awsAction(request, "add")
+    awsAction(request, "upsert")
   }
 
   def remove = BackendFromCookieAction.async { implicit request =>
@@ -31,22 +27,31 @@ class BehaviourController extends Controller with LazyLogging {
   }
 
   private def awsAction(request: BackendRequest[AnyContent], action: String) = {
-    val behaviour = behaviourFromBody(request.body.asJson)
+    val receivedBehaviour = behaviourFromBody(request.body.asJson)
     action match {
-      case "add" =>
-        val addResult = for {
-          addItemResult <- request.touchpoint.behaviourService.set(behaviour)
-        } yield addItemResult
-        addResult.map { r =>
-          logger.info(s"recorded ${behaviour.activity} on ${behaviour.lastObserved} for ${behaviour.userId} with note ${behaviour.note}")
-          Ok(Behaviour.asJson(behaviour))
+      case "upsert" =>
+        val updateResult = for {
+          current <- request.touchpoint.behaviourService.get(receivedBehaviour.userId)
+          upserted = current.map { bhv =>
+            bhv.copy(
+              activity = receivedBehaviour.activity.orElse(bhv.activity),
+              lastObserved = receivedBehaviour.lastObserved.orElse(bhv.lastObserved),
+              note = receivedBehaviour.note.orElse(bhv.note),
+              email = receivedBehaviour.email.orElse(bhv.email),
+              emailed = receivedBehaviour.emailed.orElse(bhv.emailed))
+          }.getOrElse(receivedBehaviour)
+          res <- request.touchpoint.behaviourService.set(upserted)
+        } yield res
+        updateResult.map { r =>
+          logger.info(s"upserted ${receivedBehaviour.userId}")
+          Ok(Behaviour.asEmptyJson)
         }
       case _ =>
         val deleteResult = for {
-          deleteItemResult <- request.touchpoint.behaviourService.delete(behaviour.userId)
+          deleteItemResult <- request.touchpoint.behaviourService.delete(receivedBehaviour.userId)
         } yield deleteItemResult
         deleteResult.map { r =>
-          logger.info(s"removed ${behaviour.activity} for ${behaviour.userId}")
+          logger.info(s"removed ${receivedBehaviour.userId}")
           Ok(Behaviour.asEmptyJson)
         }
     }
@@ -55,11 +60,13 @@ class BehaviourController extends Controller with LazyLogging {
   private def behaviourFromBody(requestBodyJson: Option[JsValue]): Behaviour = {
     requestBodyJson.map { jval =>
       val id = (jval \ "userId").as[String]
-      val activity = (jval \ "activity").as[String]
-      val dateTime = (jval \ "dateTime").as[String]
-      val note = (jval \ "note").as[String]
-      Behaviour(id, activity, DateTime.parse(dateTime).toString(ISODateTimeFormat.dateTime.withZoneUTC), note)
-    }.getOrElse(Behaviour("","","",""))
+      val activity = (jval \ "activity").asOpt[String]
+      val dateTime = (jval \ "dateTime").asOpt[String]
+      val note = (jval \ "note").asOpt[String]
+      val email = (jval \ "email").asOpt[String]
+      val emailed = (jval \ "email").asOpt[Boolean]
+      Behaviour(id, activity, dateTime, note, email, emailed)
+    }.getOrElse(Behaviour.empty)
   }
 
 }

--- a/membership-attribute-service/app/controllers/BehaviourController.scala
+++ b/membership-attribute-service/app/controllers/BehaviourController.scala
@@ -33,10 +33,10 @@ class BehaviourController extends Controller with LazyLogging {
       paidTier <- request.touchpoint.attrService.get(receivedBehaviour.userId).map(_.exists(_.isPaidTier))
       user <- request.touchpoint.identityService.user(IdentityId(receivedBehaviour.userId))
       emailAddress = (user \ "user" \ "primaryEmailAddress").as[String]
-      marketingPrefs = true // TODO - needs a PR in identity API to expose in above user <- ... call
+      gnmMarketingPrefs = true // TODO - needs an Identity API PR to send statusFields.receiveGnmMarketing in above user <- ... call
     } yield {
-        val msg = if (paidTier || !marketingPrefs) {
-          logger.info(s"### NOT sending email because paidTier: $paidTier marketingPrefs: $marketingPrefs")
+        val msg = if (paidTier || !gnmMarketingPrefs) {
+          logger.info(s"### NOT sending email because paidTier: $paidTier gnmMarketingPrefs: $gnmMarketingPrefs")
           request.touchpoint.behaviourService.delete(receivedBehaviour.userId)
           logger.info(s"### deleted reminder record")
           "user has paid or is not accepting emails"
@@ -63,7 +63,6 @@ class BehaviourController extends Controller with LazyLogging {
               activity = receivedBehaviour.activity.orElse(bhv.activity),
               lastObserved = receivedBehaviour.lastObserved.orElse(bhv.lastObserved),
               note = receivedBehaviour.note.orElse(bhv.note),
-              email = receivedBehaviour.email.orElse(bhv.email),
               emailed = receivedBehaviour.emailed.orElse(bhv.emailed))
           }.getOrElse(receivedBehaviour)
           res <- request.touchpoint.behaviourService.set(upserted)
@@ -89,9 +88,8 @@ class BehaviourController extends Controller with LazyLogging {
       val activity = (jval \ "activity").asOpt[String]
       val dateTime = (jval \ "dateTime").asOpt[String]
       val note = (jval \ "note").asOpt[String]
-      val email = (jval \ "email").asOpt[String]
       val emailed = (jval \ "email").asOpt[Boolean]
-      Behaviour(id, activity, dateTime, note, email, emailed)
+      Behaviour(id, activity, dateTime, note, emailed)
     }.getOrElse(Behaviour.empty)
   }
 

--- a/membership-attribute-service/app/controllers/BehaviourController.scala
+++ b/membership-attribute-service/app/controllers/BehaviourController.scala
@@ -46,7 +46,7 @@ class BehaviourController extends Controller with LazyLogging {
           // compile and send the email here
           logger.info(s"### updating behaviour record emailed: true")
           request.touchpoint.behaviourService.set(receivedBehaviour.copy(emailed = Some(true)))
-          "email sent - reminder record deleted"
+          "email sent - reminder record updated"
         }
       Ok(msg)
     }
@@ -88,7 +88,7 @@ class BehaviourController extends Controller with LazyLogging {
       val activity = (jval \ "activity").asOpt[String]
       val dateTime = (jval \ "dateTime").asOpt[String]
       val note = (jval \ "note").asOpt[String]
-      val emailed = (jval \ "email").asOpt[Boolean]
+      val emailed = (jval \ "emailed").asOpt[Boolean]
       Behaviour(id, activity, dateTime, note, emailed)
     }.getOrElse(Behaviour.empty)
   }

--- a/membership-attribute-service/app/models/Behaviour.scala
+++ b/membership-attribute-service/app/models/Behaviour.scala
@@ -9,15 +9,17 @@ import org.joda.time.DateTime
 import scala.language.implicitConversions
 import play.api.libs.functional.syntax._
 
-case class Behaviour(userId: String, activity: String, lastObserved: String, note: String)
+case class Behaviour(userId: String, activity: Option[String], lastObserved: Option[String], note: Option[String], email: Option[String], emailed: Option[Boolean])
 
 object Behaviour {
 
   implicit val jsWrite: OWrites[Behaviour] = (
     (__ \ "userId").write[String] and
-    (__ \ "activity").write[String] and
-    (__ \ "lastObserved").write[String] and
-    (__ \ "note").write[String]
+    (__ \ "activity").writeNullable[String] and
+    (__ \ "lastObserved").writeNullable[String] and
+    (__ \ "note").writeNullable[String] and
+    (__ \ "email").writeNullable[String] and
+    (__ \ "emailed").writeNullable[Boolean]
   )(unlift(Behaviour.unapply))
 
   implicit def toResult(bhv: Behaviour): Result =
@@ -25,6 +27,8 @@ object Behaviour {
 
   def asJson(bhv: Behaviour) = Json.toJson(bhv)
 
-  def asEmptyJson = asJson(Behaviour("","","",""))
+  def asEmptyJson = asJson(Behaviour("",None,None,None,None,None))
+
+  def empty = Behaviour("",None,None,None,None,None)
 
 }

--- a/membership-attribute-service/app/models/Behaviour.scala
+++ b/membership-attribute-service/app/models/Behaviour.scala
@@ -9,7 +9,7 @@ import org.joda.time.DateTime
 import scala.language.implicitConversions
 import play.api.libs.functional.syntax._
 
-case class Behaviour(userId: String, activity: Option[String], lastObserved: Option[String], note: Option[String], email: Option[String], emailed: Option[Boolean])
+case class Behaviour(userId: String, activity: Option[String], lastObserved: Option[String], note: Option[String], emailed: Option[Boolean])
 
 object Behaviour {
 
@@ -18,7 +18,6 @@ object Behaviour {
     (__ \ "activity").writeNullable[String] and
     (__ \ "lastObserved").writeNullable[String] and
     (__ \ "note").writeNullable[String] and
-    (__ \ "email").writeNullable[String] and
     (__ \ "emailed").writeNullable[Boolean]
   )(unlift(Behaviour.unapply))
 
@@ -27,8 +26,8 @@ object Behaviour {
 
   def asJson(bhv: Behaviour) = Json.toJson(bhv)
 
-  def asEmptyJson = asJson(Behaviour("",None,None,None,None,None))
+  def asEmptyJson = asJson(Behaviour("",None,None,None,None))
 
-  def empty = Behaviour("",None,None,None,None,None)
+  def empty = Behaviour("",None,None,None,None)
 
 }

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -16,6 +16,7 @@ OPTIONS    /user-attributes/me/digitalpack-update-card      controllers.AccountC
 
 POST       /user-behaviour/capture                          controllers.BehaviourController.capture
 POST       /user-behaviour/remove                           controllers.BehaviourController.remove
+POST       /abandoned-cart/email                            controllers.BehaviourController.sendCartReminderEmail
 
 POST       /salesforce-hook                                 controllers.SalesforceHookController.createAttributes
 POST       /stripe-hook                                     controllers.StripeHookController.updatePrefs


### PR DESCRIPTION
Change abandoned cart DynamoDb `add` to be an `upsert` operation instead. This makes it far easier and cleaner to send updates to the database.

Also, this PR adds an `abandonded-cart/email` route for the abandonedCartWatcher lambda to call back to when it encounters old-enough records. Currently this is a logging feature only while we test it and prepare an actual email generation pipeline for it. The data received from the lambda is used to check the Identity record for the user id before any email is sent, and doing this means we don't have to store the email address anywhere other than in Identity.

There is a corresponding PR in membership-frontend (https://github.com/guardian/membership-frontend/pull/1518)



