### PR TITLE
Fix error in lastObserved extraction

### DIFF
--- a/membership-attribute-service/app/controllers/BehaviourController.scala
+++ b/membership-attribute-service/app/controllers/BehaviourController.scala
@@ -89,10 +89,10 @@ class BehaviourController extends Controller with LazyLogging {
     requestBodyJson.map { jval =>
       val id = (jval \ "userId").as[String]
       val activity = (jval \ "activity").asOpt[String]
-      val dateTime = (jval \ "dateTime").asOpt[String]
+      val lastObserved = (jval \ "lastObserved").asOpt[String]
       val note = (jval \ "note").asOpt[String]
       val emailed = (jval \ "emailed").asOpt[Boolean]
-      Behaviour(id, activity, dateTime, note, emailed)
+      Behaviour(id, activity, lastObserved, note, emailed)
     }.getOrElse(Behaviour.empty)
   }
 


### PR DESCRIPTION
I made an error in the decoding of the behaviour data 😞 

It's an issue when we're trying to test the email generation, and results in losing the `lastObserved` value when we're writing the `emailed` value back to dynamo.

This will prevent that from happening.

