### PR TITLE
Abandoned cart SQS plumbing for membership-workflow

### DIFF
--- a/membership-attribute-service/app/configuration/Config.scala
+++ b/membership-attribute-service/app/configuration/Config.scala
@@ -81,4 +81,6 @@ object Config {
     supportsCredentials = true
   )
 
+  val abandonedCartEmailQueue = config.getString("abandoned.cart.email.queue")
+
 }

--- a/membership-attribute-service/app/controllers/BehaviourController.scala
+++ b/membership-attribute-service/app/controllers/BehaviourController.scala
@@ -66,8 +66,8 @@ class BehaviourController extends Controller with LazyLogging {
     val testEmailAddress = "justin.pinner@theguardian.com"
     val recipient = Json.obj(
       "Address" -> testEmailAddress,
-      "FirstName" -> firstName.getOrElse(""),
-      "LastName" -> lastName.getOrElse("")
+      "FirstName" -> firstName.getOrElse[String](""),
+      "LastName" -> lastName.getOrElse[String]("")
     )
     val completionLink = Json.obj(
       "CompletionLink" -> "https://membership.theguardian.com/supporter"

--- a/membership-attribute-service/app/services/SQSAbandonedCartEmailService.scala
+++ b/membership-attribute-service/app/services/SQSAbandonedCartEmailService.scala
@@ -1,0 +1,17 @@
+package services
+
+import com.amazonaws.regions.{Regions, Region}
+import com.amazonaws.services.sqs.AmazonSQSClient
+import com.amazonaws.services.sqs.model.{SendMessageRequest, CreateQueueRequest}
+import com.gu.aws._
+import configuration.Config
+
+object SQSAbandonedCartEmailService {
+  private val sqsClient = new AmazonSQSClient(CredentialsProvider)
+  sqsClient.setRegion(Region.getRegion(Regions.EU_WEST_1))
+  private val emailQueueUrl = sqsClient.createQueue(new CreateQueueRequest(Config.abandonedCartEmailQueue)).getQueueUrl
+
+  def sendMessage(msg: String) = {
+    sqsClient.sendMessage(new SendMessageRequest(emailQueueUrl, msg))
+  }
+}

--- a/membership-attribute-service/conf/DEV.conf
+++ b/membership-attribute-service/conf/DEV.conf
@@ -38,3 +38,5 @@ publicTierSet.cors.allowedOrigins = [
 ]
 
 publicTierGet.cors.allowedOrigins = []
+
+abandoned.cart.email.queue=supporter-abandoned-checkout-email-dev

--- a/membership-attribute-service/conf/PROD.conf
+++ b/membership-attribute-service/conf/PROD.conf
@@ -40,3 +40,5 @@ publicTierGet.cors.allowedOrigins = [
 ft.cors.allowedOrigins = [
   "https://interactive.guim.co.uk"
 ]
+
+abandoned.cart.email.queue=supporter-abandoned-checkout-email


### PR DESCRIPTION
Rather than burden the API with the additional complications of interacting with ExactTarget, we can just make use of the existing features of membership-workflow which already does all this for us, with the additional benefit of coping with backend outages because we only interact with it through the queues.

This PR sends messages into the queue, and a corresponding one in workflow (https://github.com/guardian/membership-workflow/pull/66) processes those messages via ET.

Note: the message format here is subject to change, if only to remove the test elements when we're about to go live.

cc: @Ap0c @svillafe @rupertbates @rtyley 