### PR TITLE
Switch to async SQS 

### DIFF
--- a/membership-attribute-service/app/configuration/Config.scala
+++ b/membership-attribute-service/app/configuration/Config.scala
@@ -5,8 +5,10 @@ import java.time.Duration
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
 import com.amazonaws.services.sns.AmazonSNSAsyncClient
+import com.amazonaws.services.sqs.AmazonSQSAsyncClient
 import com.github.dwhjames.awswrap.dynamodb.{AmazonDynamoDBScalaClient, AmazonDynamoDBScalaMapper}
 import com.github.dwhjames.awswrap.sns.AmazonSNSScalaClient
+import com.github.dwhjames.awswrap.sqs.AmazonSQSScalaClient
 import com.gu.aws.CredentialsProvider
 import com.gu.identity.cookie.{PreProductionKeys, ProductionKeys}
 import com.gu.identity.testing.usernames.{Encoder, TestUsernames}
@@ -45,6 +47,13 @@ object Config {
     awsSnsClient.configureRegion(AWS.region)
     val snsClient = new AmazonSNSScalaClient(awsSnsClient)
     snsClient
+  }
+
+  lazy val sqsClient = {
+    val awsSqsClient = new AmazonSQSAsyncClient(CredentialsProvider)
+    awsSqsClient.configureRegion(AWS.region)
+    val sqsClient = new AmazonSQSScalaClient(awsSqsClient, global)
+    sqsClient
   }
 
   lazy val testUsernames = TestUsernames(Encoder.withSecret(config.getString("identity.test.users.secret")), Duration.ofDays(2))

--- a/membership-attribute-service/app/services/SQSAbandonedCartEmailService.scala
+++ b/membership-attribute-service/app/services/SQSAbandonedCartEmailService.scala
@@ -7,10 +7,9 @@ object SQSAbandonedCartEmailService {
   private val sqsClient = Config.sqsClient
   private val emailQueueUrl = sqsClient.getQueueUrl(Config.abandonedCartEmailQueue)
   def sendMessage(msg: String) = {
-    val result = for {
+    for {
       queueUrl <- emailQueueUrl
-      res <- sqsClient.sendMessage(queueUrl, msg)
-    } yield res
-    result
+      result <- sqsClient.sendMessage(queueUrl, msg)
+    } yield result
   }
 }


### PR DESCRIPTION
Following on from https://github.com/guardian/members-data-api/pull/165 and the weird errors recorded in the logs when the new code was invoked, this PR switches the SQS notifier over to its async equivalent to prevent errors arising from the behaviour service affecting other unrelated things (e.g. the Zuora healthcheck ping!)

The errors turned out to occur because of the absence of permissions to SQS, so there will be forthcoming change to cloudformation for this too. 

Meanwhile I want to explore the effect this change has to the aforementioned errors.

As a side note, we found that the identity API doesn't return first name and last name values by default, so we will have to either a) add that to the upcoming identity PR to expose the marketing preferences, or b) fall back to addressing the user by their full display name. To allow for the latter we now send the display name value with the recipient data.

cc @Ap0c 