### PR TITLE
Make the api work properly with test users

### DIFF
--- a/membership-attribute-service/app/actions/WithBackendFromCookieAction.scala
+++ b/membership-attribute-service/app/actions/WithBackendFromCookieAction.scala
@@ -10,7 +10,10 @@ import scala.concurrent.Future
 
 object WithBackendFromCookieAction extends ActionRefiner[Request, BackendRequest] {
   override protected def refine[A](request: Request[A]): Future[Either[Result, BackendRequest[A]]] = Future {
-    val backendConf = if (IdentityAuthService.username(request).exists(Config.testUsernames.isValid)) {
+    val firstName = IdentityAuthService.username(request).flatMap(_.split(' ').headOption) //Identity checks for test users by first name
+    val exists = firstName.exists(Config.testUsernames.isValid)
+
+    val backendConf = if (exists) {
       TestTouchpointComponents
     } else {
       NormalTouchpointComponents

--- a/membership-attribute-service/conf/DEV.conf
+++ b/membership-attribute-service/conf/DEV.conf
@@ -1,6 +1,5 @@
 include "touchpoint.DEV.conf"
 include "touchpoint.UAT.conf"
-include "application.conf"
 
 identity {
   production.keys = false
@@ -40,3 +39,5 @@ publicTierSet.cors.allowedOrigins = [
 publicTierGet.cors.allowedOrigins = []
 
 abandoned.cart.email.queue=supporter-abandoned-checkout-email-dev
+
+include "application.conf" //Needs to go at the bottom of this file because it overrides the values in the identity block above


### PR DESCRIPTION
There were 2 separate issues which were causing problems:
* The lookup to see if a user was a test user was being done by the full name rather than first name which is what Identity expects
* In DEV the identity.test.users.secret config key was always being overwritten by the dummy value in DEV.conf because of the ordering of config imports

Trello card is [here](https://trello.com/c/p24hSehz/419-members-data-api-is-not-recognising-test-users)

NB: To get this to work locally you will need to refetch the private conf from aws, as the key was not set in the previous version.

`aws s3 cp s3://members-data-api-private/DEV/members-data-api.conf /etc/gu/ --profile membership`