### PR TITLE
Mma monthly contributor endpoint

### DIFF
--- a/membership-attribute-service/app/actions/WithBackendFromCookieAction.scala
+++ b/membership-attribute-service/app/actions/WithBackendFromCookieAction.scala
@@ -10,7 +10,10 @@ import scala.concurrent.Future
 
 object WithBackendFromCookieAction extends ActionRefiner[Request, BackendRequest] {
   override protected def refine[A](request: Request[A]): Future[Either[Result, BackendRequest[A]]] = Future {
-    val backendConf = if (IdentityAuthService.username(request).exists(Config.testUsernames.isValid)) {
+    val firstName = IdentityAuthService.username(request).flatMap(_.split(' ').headOption) //Identity checks for test users by first name
+    val exists = firstName.exists(Config.testUsernames.isValid)
+
+    val backendConf = if (exists) {
       TestTouchpointComponents
     } else {
       NormalTouchpointComponents

--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -59,5 +59,6 @@ class AccountController {
   def digitalPackUpdateCard = updateCard[SubscriptionPlan.Digipack]
 
   def membershipDetails = paymentDetails[SubscriptionPlan.PaidMember, SubscriptionPlan.FreeMember]
+  def monthlyContributionDetails = paymentDetails[SubscriptionPlan.Contributor, Nothing]
   def digitalPackDetails = paymentDetails[SubscriptionPlan.Digipack, Nothing]
 }

--- a/membership-attribute-service/conf/DEV.conf
+++ b/membership-attribute-service/conf/DEV.conf
@@ -1,6 +1,5 @@
 include "touchpoint.DEV.conf"
 include "touchpoint.UAT.conf"
-include "application.conf"
 
 identity {
   production.keys = false
@@ -40,3 +39,5 @@ publicTierSet.cors.allowedOrigins = [
 publicTierGet.cors.allowedOrigins = []
 
 abandoned.cart.email.queue=supporter-abandoned-checkout-email-dev
+
+include "application.conf" //Needs to go at the bottom of this file because it overrides the values in the identity block above

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -7,6 +7,7 @@ POST       /user-attributes/me/update                       controllers.Attribut
 
 GET        /user-attributes/me/mma-digitalpack              controllers.AccountController.digitalPackDetails
 GET        /user-attributes/me/mma-membership               controllers.AccountController.membershipDetails
+GET        /user-attributes/me/mma-monthlycontribution      controllers.AccountController.monthlyContributionDetails
 
 POST       /user-attributes/me/membership-update-card       controllers.AccountController.membershipUpdateCard
 OPTIONS    /user-attributes/me/membership-update-card       controllers.AccountController.membershipUpdateCard

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSNS = "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.360"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.383"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
 
   //projects


### PR DESCRIPTION
This PR adds a new endpoint /user-attributes/me/mma-monthlycontribution which retrieves information about whether a user is signed up for monthly contributions.

Note that this should be merged after #169 

### An example response:

```
{
  "tier": "Contributor",
  "isPaidTier": true,
  "regNumber": "507433",
  "joinDate": "2017-04-03",
  "optIn": true,
  "subscription": {
    "paymentMethod": "Card",
    "card": {
      "last4": "4242",
      "type": "Visa"
    },
    "start": "2017-04-03",
    "end": "2017-05-03",
    "nextPaymentPrice": 500,
    "nextPaymentDate": "2017-05-03",
    "renewalDate": "2018-04-03",
    "cancelledAt": false,
    "subscriberId": "A-S00068792",
    "trialLength": 0,
    "plan": {
      "name": "Contributor",
      "amount": 500,
      "currency": "£",
      "interval": "month"
    }
  }
}
```
