### PR TITLE
Use play's defaultContext execution context

### DIFF
--- a/membership-attribute-service/app/BatchLoader.scala
+++ b/membership-attribute-service/app/BatchLoader.scala
@@ -11,7 +11,7 @@ import repositories.MembershipAttributesSerializer
 import sources.SalesforceCSVExport
 
 import scala.collection.JavaConverters._
-import scala.concurrent.ExecutionContext.Implicits.global
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
 object BatchLoader {
   private val table = NormalTouchpointComponents.dynamoAttributesTable

--- a/membership-attribute-service/app/actions/package.scala
+++ b/membership-attribute-service/app/actions/package.scala
@@ -3,7 +3,7 @@ import controllers.NoCache
 import play.api.mvc._
 
 import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits.global
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
 package object actions {
   def noCache(result: Result): Result = NoCache(result)

--- a/membership-attribute-service/app/configuration/Config.scala
+++ b/membership-attribute-service/app/configuration/Config.scala
@@ -18,7 +18,7 @@ import play.api.Configuration
 import play.filters.cors.CORSConfig
 
 import scala.collection.JavaConverters._
-import scala.concurrent.ExecutionContext.Implicits.global
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import scala.util.Try
 
 object Config {
@@ -52,7 +52,7 @@ object Config {
   lazy val sqsClient = {
     val awsSqsClient = new AmazonSQSAsyncClient(CredentialsProvider)
     awsSqsClient.configureRegion(AWS.region)
-    val sqsClient = new AmazonSQSScalaClient(awsSqsClient, global)
+    val sqsClient = new AmazonSQSScalaClient(awsSqsClient, defaultContext)
     sqsClient
   }
 

--- a/membership-attribute-service/test/repositories/DynamoAttributeServiceTest.scala
+++ b/membership-attribute-service/test/repositories/DynamoAttributeServiceTest.scala
@@ -13,7 +13,7 @@ import repositories.MembershipAttributesSerializer.AttributeNames
 import services.ScanamoAttributeService
 
 import scala.concurrent.{Await, Future}
-import scala.concurrent.ExecutionContext.Implicits.global
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import scala.concurrent.duration._
 import org.specs2.concurrent.ExecutionEnv
 


### PR DESCRIPTION
Using the Play's default context is considered best practice:
https://www.playframework.com/documentation/2.5.x/ThreadPools

So, this change is to use play's defaultContext executionContext rather than Scala's global execution context. 

This isn't to address a particular performance problem, just a matter of moving to best practice. 

See also: 
https://trello.com/c/7CTCozNx/58-use-play-s-default-execution-context

cc @paulbrown1982 @jacobwinch @mario-galic @johnduffell @pvighi