### PR TITLE
Update membership-common to 0.395

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSNS = "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.389"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.395"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
 
   //projects


### PR DESCRIPTION
Use the newest version of membership common. This includes [my change](https://github.com/guardian/membership-common/pull/460) that ensures that membership common will use the execution context passed implicitly from members-data-api instead of creating another one within the common. 