### PR TITLE
Configure Prout to add Sentry Releases

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -1,5 +1,8 @@
 {
   "checkpoints": {
     "PROD": { "url": "https://members-data-api.theguardian.com/healthcheck", "overdue": "14M" }
+  },
+  "sentry": {
+    "projects": ["members-data-api"]
   }
 }


### PR DESCRIPTION
Sentry recently released some [interesting functionality around tracking issues related to specific code-changes](https://blog.sentry.io/2017/05/01/release-commits.html), and Prout now has some [basic support](https://github.com/guardian/prout/issues/47#issuecomment-302468156) for this.

![image](https://docs.sentry.io/_images/releases-overview.png)

To activate Prout's support, you just need to ensure Sentry has 'connected' to your GitHub repo in https://sentry.io/organizations/the-guardian/repos/, and then add a stanza like this to your `.prout.json`:

```
"sentry": {
  "projects": ["members-data-api"]
}
```

...that project slug corresponds to the Sentry project used with this stack:

* https://sentry.io/the-guardian/members-data-api/
