### PR TITLE
Card expiry date in /features

### DIFF
--- a/membership-attribute-service/app/configuration/Config.scala
+++ b/membership-attribute-service/app/configuration/Config.scala
@@ -71,20 +71,6 @@ object Config {
     allowedOrigins = config.getStringList("ft.cors.allowedOrigins").asScala.toSet
   )
 
-  val publicTierSetCorsConfig = CORSConfig.denyAll.copy(
-    isHttpHeaderAllowed = Seq("accept", "content-type", "csrf-token", "origin", "x-requested-with").contains(_),
-    allowedOrigins = config.getStringList("publicTierSet.cors.allowedOrigins").asScala.toSet,
-    isHttpMethodAllowed = _ == "POST",
-    supportsCredentials = true
-  )
-
-  val publicTierGetCorsConfig = CORSConfig.denyAll.copy(
-    isHttpHeaderAllowed = Seq("accept", "content-type", "csrf-token", "origin").contains(_),
-    allowedOrigins = config.getStringList("publicTierGet.cors.allowedOrigins").asScala.toSet,
-    isHttpMethodAllowed = _ == "GET",
-    supportsCredentials = true
-  )
-
   lazy val mmaCardCorsConfig = Config.mmaCorsConfig.copy(
     isHttpHeaderAllowed = Seq("accept", "content-type", "csrf-token", "origin").contains(_),
     isHttpMethodAllowed = _ == "POST",

--- a/membership-attribute-service/app/controllers/SalesforceHookController.scala
+++ b/membership-attribute-service/app/controllers/SalesforceHookController.scala
@@ -95,7 +95,8 @@ def createAttributes = BackendFromSalesforceAction.async(parse.xml) { request =>
       val cardExpiryFromStripeF = (for {
         account <- OptionT(touchpoint.zuoraService.getAccount(membershipSubscription.accountId).map(Option(_)))
         paymentMethod <- OptionT(touchpoint.zuoraService.getPaymentMethod(account.defaultPaymentMethodId.get).map(Option(_)))
-        stripeCustomer <- OptionT(touchpoint.stripeService.Customer.read(paymentMethod.secondTokenId.get).map(Option(_)))
+        customerToken <- OptionT(Future.successful(paymentMethod.secondTokenId))
+        stripeCustomer <- OptionT(touchpoint.stripeService.Customer.read(customerToken).map(Option(_)))
       } yield {
         (stripeCustomer.card.exp_month, stripeCustomer.card.exp_year)
       }).run

--- a/membership-attribute-service/app/controllers/SalesforceHookController.scala
+++ b/membership-attribute-service/app/controllers/SalesforceHookController.scala
@@ -6,7 +6,7 @@ import com.gu.memsub.subsv2.SubscriptionPlan
 import com.gu.memsub.subsv2.reads.ChargeListReads._
 import com.gu.memsub.subsv2.reads.SubPlanReads._
 import com.typesafe.scalalogging.LazyLogging
-import models.ApiErrors
+import models.{ApiErrors, Attributes}
 import monitoring.Metrics
 import parsers.Salesforce._
 import parsers.{Salesforce => SFParser}
@@ -65,28 +65,49 @@ def createAttributes = BackendFromSalesforceAction.async(parse.xml) { request =>
 
   def updateMemberRecord(membershipUpdate: MembershipUpdate): Future[Object] = {
 
-    val attrs = membershipUpdate.attributes
-    logger.info(s"Salesforce called has been parsed. Request Id: $requestId. Attrs: $attrs")
-
-    (for {
-      sfId <- OptionT(touchpoint.contactRepo.get(attrs.UserId))
-      membershipSubscription <- OptionT(touchpoint.subService.current[SubscriptionPlan.Member](sfId).map(_.headOption))
-    } yield {
-      val tierFromSalesforceWebhook = attrs.Tier
-      val tierFromZuora = membershipSubscription.plan.charges.benefit.id
-      if (tierFromZuora != tierFromSalesforceWebhook) logger.error(s"Differing tier info for $sfId : sf=$tierFromSalesforceWebhook zuora=$tierFromZuora")
-      // If the tier info does not match, we trust the info we get from Zuora, instead of the tier sent to us in the outbound message from Salesforce
-      attrs.copy(Tier = tierFromZuora)
-    }).run.flatMap { attrsUpdatedWithZuoraOpt =>
-      if (attrsUpdatedWithZuoraOpt.isEmpty) logger.error(s"Couldn't update $attrs with information from Zuora")
-      attributeService.set(attrsUpdatedWithZuoraOpt.getOrElse(attrs)).map { putItemResult =>
-        logger.info(s"Successfully inserted ${attrsUpdatedWithZuoraOpt.getOrElse(attrs)} into ${touchpoint.dynamoAttributesTable}.")
+    def updateDynamo(attributes: Attributes) = {
+      attributeService.set(attributes).map { putItemResult =>
+        logger.info(s"Successfully inserted $attributes into ${touchpoint.dynamoAttributesTable}.")
         metrics.put("Update", 1)
         putItemResult
       }.recover { case e: Throwable =>
-        logger.warn(s"Failed to insert ${attrsUpdatedWithZuoraOpt.getOrElse(attrs)} into ${touchpoint.dynamoAttributesTable}. Salesforce should retry.", e)
+        logger.warn(s"Failed to insert $attributes into ${touchpoint.dynamoAttributesTable}. Salesforce should retry.", e)
         Failure
       }
+    }
+
+    val salesforceAttributes: Attributes = membershipUpdate.attributes
+
+    logger.info(s"Salesforce called has been parsed. Request Id: $requestId. Attrs: $salesforceAttributes")
+
+    (for {
+      sfId <- OptionT(touchpoint.contactRepo.get(salesforceAttributes.UserId))
+      membershipSubscription <- OptionT(touchpoint.subService.current[SubscriptionPlan.Member](sfId).map(_.headOption))
+    } yield {
+
+      // If the tier info does not match, we trust the info we get from Zuora, instead of the tier sent to us in the outbound message from Salesforce
+      val tierFromZuora = membershipSubscription.plan.charges.benefit.id
+      val tierFromSalesforce = salesforceAttributes.Tier
+      if (tierFromZuora != tierFromSalesforce) logger.error(s"Differing tier info for $sfId : sf=$tierFromSalesforce zuora=$tierFromZuora")
+
+      // If we have the card expiry date in Stripe, add them to Dynamo too
+      val cardExpiryFromStripeF = (for {
+        account <- OptionT(touchpoint.zuoraService.getAccount(membershipSubscription.accountId).map(Option(_)))
+        paymentMethod <- OptionT(touchpoint.zuoraService.getPaymentMethod(account.defaultPaymentMethodId.get).map(Option(_)))
+        stripeCustomer <- OptionT(touchpoint.stripeService.Customer.read(paymentMethod.secondTokenId.get).map(Option(_)))
+      } yield {
+        (stripeCustomer.card.exp_month, stripeCustomer.card.exp_year)
+      }).run
+
+      cardExpiryFromStripeF.map {
+        case Some((expMonth, expYear)) => salesforceAttributes.copy(Tier = tierFromZuora, CardExpirationMonth = Some(expMonth), CardExpirationYear = Some(expYear))
+        case None => salesforceAttributes.copy(Tier = tierFromZuora)
+      }
+    }).run.flatMap {
+      case Some(zuoraAttributesF) => zuoraAttributesF.flatMap(updateDynamo)
+      case None =>
+        logger.error(s"Couldn't update $salesforceAttributes with information from Zuora")
+        updateDynamo(salesforceAttributes)
     }
   }
 

--- a/membership-attribute-service/app/controllers/SalesforceHookController.scala
+++ b/membership-attribute-service/app/controllers/SalesforceHookController.scala
@@ -90,7 +90,8 @@ def createAttributes = BackendFromSalesforceAction.async(parse.xml) { request =>
       val tierFromSalesforce = salesforceAttributes.Tier
       if (tierFromZuora != tierFromSalesforce) logger.error(s"Differing tier info for $sfId : sf=$tierFromSalesforce zuora=$tierFromZuora")
 
-      // If we have the card expiry date in Stripe, add them to Dynamo too
+      // If we have the card expiry date in Stripe, add them to Dynamo too.
+      // TODO - refactor to use touchpoint.paymentService - requires membership-common model tweak first.
       val cardExpiryFromStripeF = (for {
         account <- OptionT(touchpoint.zuoraService.getAccount(membershipSubscription.accountId).map(Option(_)))
         paymentMethod <- OptionT(touchpoint.zuoraService.getPaymentMethod(account.defaultPaymentMethodId.get).map(Option(_)))

--- a/membership-attribute-service/app/models/Features.scala
+++ b/membership-attribute-service/app/models/Features.scala
@@ -1,6 +1,6 @@
 package models
 
-import configuration.Config
+import org.joda.time.LocalDate
 import play.api.libs.json.Json
 import play.api.mvc.Result
 import play.api.mvc.Results.Ok
@@ -8,6 +8,7 @@ import play.api.mvc.Results.Ok
 import scala.language.implicitConversions
 
 object Features {
+
   implicit val jsWrite = Json.writes[Features]
 
   implicit def toResult(attrs: Features): Result =
@@ -19,11 +20,13 @@ object Features {
     Features(
       userId = Some(attributes.UserId),
       adFree = attributes.isAdFree,
-      adblockMessage = !attributes.isPaidTier
+      adblockMessage = !attributes.isPaidTier,
+      cardHasExpired = attributes.maybeCardHasExpired,
+      cardExpires = attributes.cardExpires
     )
   }
 
-  val unauthenticated = Features(None, adFree = false, adblockMessage = true)
+  val unauthenticated = Features(None, adFree = false, adblockMessage = true, None, None)
 }
 
-case class Features(userId: Option[String], adFree: Boolean, adblockMessage: Boolean)
+case class Features(userId: Option[String], adFree: Boolean, adblockMessage: Boolean, cardHasExpired: Option[Boolean], cardExpires: Option[LocalDate])

--- a/membership-attribute-service/conf/DEV.public.conf
+++ b/membership-attribute-service/conf/DEV.public.conf
@@ -32,10 +32,4 @@ ft.cors.allowedOrigins = [
   "https://interactive.guimlocal.co.uk"
 ]
 
-publicTierSet.cors.allowedOrigins = [
-  "https://mem.thegulocal.com"
-]
-
-publicTierGet.cors.allowedOrigins = []
-
 abandoned.cart.email.queue=supporter-abandoned-checkout-email-dev

--- a/membership-attribute-service/conf/PROD.public.conf
+++ b/membership-attribute-service/conf/PROD.public.conf
@@ -26,16 +26,6 @@ mma.cors.allowedOrigins = [
   "https://profile.code.dev-theguardian.com",
 ]
 
-publicTierSet.cors.allowedOrigins = [
-  "https://membership.theguardian.com",
-  "https://mem.thegulocal.com"
-]
-
-publicTierGet.cors.allowedOrigins = [
-  "https://www.theguardian.com",
-  "http://www.theguardian.com"
-]
-
 ft.cors.allowedOrigins = [
   "https://interactive.guim.co.uk"
 ]

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -21,7 +21,9 @@ class AttributeControllerTest extends Specification with AfterAll {
 
   private val validUserId = "123"
   private val invalidUserId = "456"
-  private val attributes = Attributes(validUserId, "patron", Some("abc"))
+  private val attributes = Attributes(
+    UserId = validUserId, Tier = "patron", MembershipNumber = Some("abc"), AdFree = Some(false), CardExpirationMonth = Some(3), CardExpirationYear = Some(2018)
+  )
 
   private val validUserCookie = Cookie("validUser", "true")
   private val invalidUserCookie = Cookie("invalidUser", "true")
@@ -67,6 +69,9 @@ class AttributeControllerTest extends Specification with AfterAll {
         |   "tier": "patron",
         |   "membershipNumber": "abc",
         |   "userId": "123",
+        |   "cardExpirationMonth": 3,
+        |   "cardExpirationYear": 2018,
+        |   "adFree": false,
         |   "contentAccess":{"member":true,"paidMember":true}
         | }
       """.stripMargin)

--- a/membership-attribute-service/test/models/AttributesTest.scala
+++ b/membership-attribute-service/test/models/AttributesTest.scala
@@ -5,7 +5,7 @@ import org.specs2.mutable.Specification
 class AttributesTest extends Specification {
 
   "AttributesTest" should {
-    val attrs = Attributes("123", "tier", None)
+    val attrs = Attributes(UserId = "123", Tier = "tier", MembershipNumber = None)
 
     "isPaidTier returns" should {
       "true if the user is not a Guardian Friend" in {
@@ -14,6 +14,15 @@ class AttributesTest extends Specification {
 
       "false if the user is a Guardian Friend" in {
         attrs.copy(Tier = "Friend").isPaidTier shouldEqual false
+      }
+    }
+
+    "maybeCardHasExpired returns" should {
+      "true if the card expiry is in the past" in {
+        attrs.copy(CardExpirationMonth = Some(1), CardExpirationYear = Some(2017)).maybeCardHasExpired shouldEqual Some(true)
+      }
+      "false if the card expiry is in the past" in {
+        attrs.copy(CardExpirationMonth = Some(1), CardExpirationYear = Some(3000)).maybeCardHasExpired shouldEqual Some(false)
       }
     }
   }


### PR DESCRIPTION
- Updated the Attributes case class to contain the card expiry year and month. This will get serialised to DynamoDB during the Salesforce webhook callback or a backfill of data from Stripe.
- Updated the Features case class to return a boolean of whether the card has expired already alongside the expiry local date in YYYY-mm-dd format.
- Fully removed old PublicTier stuff as this was hackday code.

cc @johnduffell @pvighi @jacobwinch @lmath @AWare @rtyley 