### PR TITLE
let members-data-api log to kibana

### DIFF
--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -86,6 +86,7 @@ Mappings:
       DynamoDBBehaviourTable: arn:aws:dynamodb:*:*:table/MembershipBehaviour-UAT
       DynamoDBBehaviourTableTestUsers: arn:aws:dynamodb:*:*:table/MembershipBehaviour-UAT
       GiraffeTopic: giraffe-code
+      SSLCertificate: arn:aws:iam::865473395570:server-certificate/members-data-api.theguardian.com
 
 Resources:
   MembershipRole:

--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -60,6 +60,12 @@ Parameters:
   VulnerabilityScanningSecurityGroup:
     Description: Security group that grants access to the account's Vulnerability Scanner
     Type: AWS::EC2::SecurityGroup::Id
+  LoggingKinesisStream:
+    Description: Kinesis stream id to send logging to e.g. elk-stack-ElkKinesisStream-12345
+    Type: String
+  LoggingPolicy:
+    Description: Policy needed to access the kinesis stream
+    Type: String
 Mappings:
   StageVariables:
     PROD:
@@ -158,6 +164,8 @@ Resources:
             - logs:*
             Resource: "*"
             Effect: Allow
+      ManagedPolicyArns:
+      - !Ref 'LoggingPolicy'
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
@@ -267,6 +275,14 @@ Resources:
               aws --region ${AWS::Region} s3 cp s3://members-data-api-private/${Stage}/members-data-api.private.conf /etc/gu
               chown membership-attribute-service /etc/gu/members-data-api.private.conf
               chmod 0600 /etc/gu/members-data-api.private.conf
+
+              cat <<EOF >>/etc/gu/members-data-api.private.conf
+              param.logstash {
+                stream="${LoggingKinesisStream}"
+                streamRegion="${AWS::Region}"
+              }
+              EOF
+
               wget https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py
               sed -i -e "s/__DATE/$(date +%F)/" -e 's/__STAGE/${Stage}/' $CONF_DIR/logger.conf
               python awslogs-agent-setup.py -nr ${AWS::Region} -c $CONF_DIR/logger.conf

--- a/membership-attribute-service/app/Global.scala
+++ b/membership-attribute-service/app/Global.scala
@@ -1,5 +1,7 @@
 
+import configuration.Config
 import filters.{AddEC2InstanceHeader, AddGuIdentityHeaders, CheckCacheHeadersFilter}
+import loghandling.Logstash
 import models.ApiErrors._
 import monitoring.SentryLogging
 import play.api.libs.concurrent.Execution.Implicits._
@@ -21,6 +23,7 @@ object Global extends WithFilters(
 
   override def onStart(app: Application) {
     SentryLogging.init()
+    Logstash.init(Config)
   }
 
   override def onBadRequest(request: RequestHeader, error: String): Future[Result] = {

--- a/membership-attribute-service/app/configuration/Config.scala
+++ b/membership-attribute-service/app/configuration/Config.scala
@@ -6,6 +6,7 @@ import com.amazonaws.regions.Regions
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
 import com.amazonaws.services.sns.AmazonSNSAsyncClient
 import com.amazonaws.services.sqs.AmazonSQSAsyncClient
+import com.getsentry.raven.dsn.Dsn
 import com.github.dwhjames.awswrap.dynamodb.{AmazonDynamoDBScalaClient, AmazonDynamoDBScalaMapper}
 import com.github.dwhjames.awswrap.sns.AmazonSNSScalaClient
 import com.github.dwhjames.awswrap.sqs.AmazonSQSScalaClient
@@ -13,12 +14,12 @@ import com.gu.aws.CredentialsProvider
 import com.gu.identity.cookie.{PreProductionKeys, ProductionKeys}
 import com.gu.identity.testing.usernames.{Encoder, TestUsernames}
 import com.typesafe.config.ConfigFactory
-import net.kencochrane.raven.dsn.Dsn
 import play.api.Configuration
 import play.filters.cors.CORSConfig
 
 import scala.collection.JavaConverters._
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
+
 import scala.util.Try
 
 object Config {
@@ -91,5 +92,12 @@ object Config {
   )
 
   val abandonedCartEmailQueue = config.getString("abandoned.cart.email.queue")
+
+  object Logstash {
+    private val param = Try{config.getConfig("param.logstash")}.toOption
+    val stream = Try{param.map(_.getString("stream"))}.toOption.flatten
+    val streamRegion = Try{param.map(_.getString("streamRegion"))}.toOption.flatten
+    val enabled = Try{config.getBoolean("logstash.enabled")}.toOption.contains(true)
+  }
 
 }

--- a/membership-attribute-service/app/loghandling/LogbackConfig.scala
+++ b/membership-attribute-service/app/loghandling/LogbackConfig.scala
@@ -1,0 +1,79 @@
+package loghandling
+
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.classic.{Logger => LogbackLogger, LoggerContext}
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.gu.logback.appender.kinesis.KinesisAppender
+import net.logstash.logback.layout.LogstashLayout
+import org.slf4j.{Logger => SLFLogger, LoggerFactory}
+import play.api.{Logger => PlayLogger}
+
+object LogbackConfig {
+
+  lazy val loggingContext = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
+
+  case class KinesisAppenderConfig(stream: String,
+    region: String,
+    awsCredentialsProvider: AWSCredentialsProvider,
+    bufferSize: Int)
+
+  def makeCustomFields(customFields: Map[String, String]): String = {
+    "{" + (for((k, v) <- customFields) yield s""""${k}":"${v}"""").mkString(",") + "}"
+  }
+
+  def makeLayout(customFields: String) = {
+    val l = new LogstashLayout()
+    l.setCustomFields(customFields)
+    l
+  }
+
+  def makeKinesisAppender(layout: LogstashLayout, context: LoggerContext, appenderConfig: KinesisAppenderConfig) = {
+    val a = new KinesisAppender[ILoggingEvent]()
+    a.setName("LoggingKinesisAppender")
+    a.setStreamName(appenderConfig.stream)
+    a.setRegion(appenderConfig.region)
+    a.setCredentialsProvider(appenderConfig.awsCredentialsProvider)
+    a.setBufferSize(appenderConfig.bufferSize)
+
+    a.setContext(context)
+    a.setLayout(layout)
+
+    layout.start()
+    a.start()
+    a
+  }
+
+  def init(config: LogStashConf) = {
+    if (config.enabled) {
+      try {
+        val rootLogger = LoggerFactory.getLogger(SLFLogger.ROOT_LOGGER_NAME)
+        rootLogger match {
+          case lb: LogbackLogger =>
+            lb.info("Kinesis logging - Configuring Logback")
+            val context = lb.getLoggerContext
+            val layout = makeLayout(makeCustomFields(config.customFields))
+            val bufferSize = 1000
+            val appender = makeKinesisAppender(
+              layout,
+              context,
+              KinesisAppenderConfig(
+                config.stream,
+                config.region,
+                config.awsCredentialsProvider,
+                bufferSize
+              )
+            )
+            lb.addAppender(appender)
+            lb.info("Kinesis logging - Configured Logback")
+          case _ =>
+            PlayLogger.info("Kinesis logging failed - not running using logback")
+        }
+      } catch {
+        case ex: Throwable => PlayLogger.info(s"Kinesis logging failed with exception: $ex")
+      }
+    } else {
+      PlayLogger.info("Kinesis logging not enabled by default (e.g. DEV mode)")
+    }
+  }
+
+}

--- a/membership-attribute-service/app/loghandling/Logstash.scala
+++ b/membership-attribute-service/app/loghandling/Logstash.scala
@@ -1,0 +1,44 @@
+package loghandling
+
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.util.EC2MetadataUtils
+import configuration.Config
+import play.api.Configuration
+import com.gu.aws.CredentialsProvider
+import com.typesafe.scalalogging.StrictLogging
+
+case class LogStashConf(enabled: Boolean,
+  stream: String,
+  region: String,
+  awsCredentialsProvider: AWSCredentialsProvider,
+  customFields: Map[String, String])
+
+object Logstash extends StrictLogging {
+
+  def customFields(playConfig: Config.type) = Map(
+    "stack" -> "unknownStack",// all TODO
+    "app" -> Config.applicationName,
+    "stage" -> playConfig.stage,
+    "build" -> "unknownBuild",
+    "revision" -> "unknownRevision",
+    "ec2_instance" -> Option(EC2MetadataUtils.getInstanceId).getOrElse("Not running on ec2")
+  )
+
+  def config(playConfig: Config.type) = for {
+    stream <- playConfig.Logstash.stream
+    region <- playConfig.Logstash.streamRegion
+  } yield {
+    LogStashConf(
+      playConfig.Logstash.enabled,
+      stream,
+      region,
+      CredentialsProvider,
+      customFields(playConfig)
+    )
+  }
+
+  def init(playConfig: Config.type): Unit = {
+    config(playConfig).fold(logger.info("Logstash config is missing"))(LogbackConfig.init)
+  }
+
+}

--- a/membership-attribute-service/app/loghandling/Logstash.scala
+++ b/membership-attribute-service/app/loghandling/Logstash.scala
@@ -17,7 +17,7 @@ object Logstash extends StrictLogging {
 
   def customFields(playConfig: Config.type) = Map(
     "stack" -> "unknownStack",// all TODO
-    "app" -> Config.applicationName,
+    "app" -> playConfig.applicationName,
     "stage" -> playConfig.stage,
     "build" -> "unknownBuild",
     "revision" -> "unknownRevision",

--- a/membership-attribute-service/app/monitoring/SentryLogging.scala
+++ b/membership-attribute-service/app/monitoring/SentryLogging.scala
@@ -2,9 +2,9 @@ package monitoring
 
 import ch.qos.logback.classic.filter.ThresholdFilter
 import ch.qos.logback.classic.{Logger, LoggerContext}
+import com.getsentry.raven.RavenFactory
+import com.getsentry.raven.logback.SentryAppender
 import configuration.Config
-import net.kencochrane.raven.RavenFactory
-import net.kencochrane.raven.logback.SentryAppender
 import org.slf4j.Logger.ROOT_LOGGER_NAME
 import org.slf4j.LoggerFactory
 

--- a/membership-attribute-service/conf/CODE.public.conf
+++ b/membership-attribute-service/conf/CODE.public.conf
@@ -1,0 +1,3 @@
+include "DEV.public"
+
+logstash.enabled=true

--- a/membership-attribute-service/conf/PROD.public.conf
+++ b/membership-attribute-service/conf/PROD.public.conf
@@ -41,3 +41,5 @@ ft.cors.allowedOrigins = [
 ]
 
 abandoned.cart.email.queue=supporter-abandoned-checkout-email
+
+logstash.enabled=true

--- a/membership-attribute-service/conf/TEST.public.conf
+++ b/membership-attribute-service/conf/TEST.public.conf
@@ -1,6 +1,4 @@
 include "DEV.public"
 include "application"
 
-
-
-
+logstash.enabled=true

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   //versions
   val awsClientVersion = "1.10.62"
   //libraries
-  val sentryRavenLogback = "net.kencochrane.raven" % "raven-logback" % "6.0.0"
+  val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "8.0.3"
   val identityCookie = "com.gu.identity" %% "identity-cookie" % "3.51"
   val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "0.18"
   val identityTestUsers =  "com.gu" %% "identity-test-users" % "0.6"
@@ -22,11 +22,14 @@ object Dependencies {
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
   val membershipCommon = "com.gu" %% "membership-common" % "0.417"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
+  val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.0"
+  val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"
+  val jacksonCbor = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % "2.8.7"
 
   //projects
 
   val apiDependencies = Seq(sentryRavenLogback, identityCookie, identityPlayAuth, identityTestUsers, scalaUri,
     playWS, playCache, playFilters, scanamo, awsWrap, awsDynamo, awsSNS, awsCloudWatch, scalaz, membershipCommon,
-    specs2)
+    specs2, kinesis, logstash, jacksonCbor)
 
 }


### PR DESCRIPTION
based on https://github.com/guardian/subscriptions-frontend/pull/946
Pushing logs into kinesis and thereafter kibana from members-data-api
This all part of my evil plan to have one source of truth for tech/debug that's easy to search so we can diagnose issues more reliably.

Comments/suggestions/:+1:s! @guardian/membership-and-subscriptions 