### PR TITLE
Remove PublicTier field from Attributes data model

### DIFF
--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -15,11 +15,14 @@ object ContentAccess {
   implicit val jsWrite = Json.writes[ContentAccess]
 }
 
-case class Attributes(UserId: String, Tier: String, MembershipNumber: Option[String], PublicTier: Option[Boolean] = None, AdFree: Option[Boolean] = None) {
+case class Attributes(
+                       UserId: String,
+                       Tier: String,
+                       MembershipNumber: Option[String],
+                       AdFree: Option[Boolean] = None) {
   require(Tier.nonEmpty)
   require(UserId.nonEmpty)
 
-  lazy val allowsPublicTierDisplay = PublicTier.exists(identity)
   lazy val isFriendTier = Tier.equalsIgnoreCase("friend")
   lazy val isPaidTier = !isFriendTier
   lazy val isAdFree = AdFree.exists(identity)
@@ -29,13 +32,11 @@ case class Attributes(UserId: String, Tier: String, MembershipNumber: Option[Str
 
 object Attributes {
 
-  val ignore = OWrites[Any](_ => Json.obj())
   implicit val jsWrite: OWrites[Attributes] = (
     (__ \ "userId").write[String] and
     (__ \ "tier").write[String] and
     (__ \ "membershipNumber").writeNullable[String] and
-    (__ \ "adFree").writeNullable[Boolean] and
-    ignore
+    (__ \ "adFree").writeNullable[Boolean]
   )(unlift(Attributes.unapply)).addField("contentAccess", _.contentAccess)
 
   implicit def toResult(attrs: Attributes): Result =


### PR DESCRIPTION
During the implementation of the contribution field in Members Data API, we discovered the `publicTier` field in the `Attributes.scala` file. After talking about this with @rtyley, he thinks that we are not using that field at all and probably the best thing to do, is to delete it. Therefore, this PR. 

cc: @paulbrown1982 @JustinPinner please review this PR.