### PR TITLE
store membership join date in dynamo and return from /features call

### DIFF
--- a/membership-attribute-service/app/controllers/SalesforceHookController.scala
+++ b/membership-attribute-service/app/controllers/SalesforceHookController.scala
@@ -40,99 +40,153 @@ class SalesforceHookController extends LazyLogging {
     </soapenv:Envelope>
   )
 
-def createAttributes = BackendFromSalesforceAction.async(parse.xml) { request =>
+  def createAttributes = BackendFromSalesforceAction.async(parse.xml) { request =>
 
-  val touchpoint = request.touchpoint
-  val validOrgId = touchpoint.sfOrganisationId
-  val attributeService = touchpoint.attrService
-  val requestId = scala.util.Random.nextInt
+    val touchpoint = request.touchpoint
+    val validOrgId = touchpoint.sfOrganisationId
+    val attributeService = touchpoint.attrService
 
-  implicit val pf = Membership
+    object ContextLogging {
+      case class RequestId(value: Int)
+      implicit val requestId = RequestId(scala.util.Random.nextInt)
+      def info(message: String)(implicit requestId: RequestId) =
+        logger.info(s"$requestId: $message")
+      def warn(message: String)(implicit requestId: RequestId) =
+        logger.warn(s"$requestId: $message")
+      def warn(message: String, e: Throwable)(implicit requestId: RequestId) =
+        logger.warn(s"$requestId: $message", e)
+      def error(message: String)(implicit requestId: RequestId) =
+        logger.error(s"$requestId: $message")
 
-  logger.info(s"Called from Saleforce to modify the Members Data API. Request Id: $requestId")
+      implicit class FutureContextLoggable[T](future: Future[T]) {
+        def logWith(message: String, extractor: T => Any = identity): Future[T] = {
+          future.foreach(any => info(s"$message {${extractor(any)}}"))
+          future
+        }
 
-  def deleteMemberRecord(membershipDeletion: MembershipDeletion): Future[Object] = {
-    val userId = membershipDeletion.userId
-    attributeService.delete(userId).map { deleteItemResult =>
-      logger.info(s"Successfully deleted user $userId from ${touchpoint.dynamoAttributesTable}.")
-      metrics.put("Delete", 1)
-      deleteItemResult
-    }.recover { case e: Throwable =>
-      logger.warn(s"Failed to delete user $userId from ${touchpoint.dynamoAttributesTable}. Salesforce should retry.", e)
-      Failure
+      }
+      implicit class ContextLoggable[T](t: T) {
+        def logWith(message: String): T = {
+          t match {
+            case future: Future[_] => future.foreach(any => info(s"$message {$any}"))
+            case any => info(s"$message {$any}")
+          }
+          t
+        }
+
+      }
+
     }
-  }
+    import ContextLogging._
 
-  def updateMemberRecord(membershipUpdate: MembershipUpdate): Future[Object] = {
+    implicit val pf = Membership
 
-    def updateDynamo(attributes: Attributes) = {
-      attributeService.set(attributes).map { putItemResult =>
-        logger.info(s"Successfully inserted $attributes into ${touchpoint.dynamoAttributesTable}.")
-        metrics.put("Update", 1)
-        putItemResult
+    info(s"Called from Saleforce to modify the Members Data API")
+
+    def deleteMemberRecord(membershipDeletion: MembershipDeletion): Future[Object] = {
+      val userId = membershipDeletion.userId
+      attributeService.delete(userId).map { deleteItemResult =>
+        info(s"Successfully deleted user $userId from ${touchpoint.dynamoAttributesTable}.")
+        metrics.put("Delete", 1)
+        deleteItemResult
       }.recover { case e: Throwable =>
-        logger.warn(s"Failed to insert $attributes into ${touchpoint.dynamoAttributesTable}. Salesforce should retry.", e)
+        warn(s"Failed to delete user $userId from ${touchpoint.dynamoAttributesTable}. Salesforce should retry.", e)
         Failure
       }
     }
 
-    val salesforceAttributes: Attributes = membershipUpdate.attributes
+    def updateMemberRecord(membershipUpdate: MembershipUpdate): Future[Object] = {
 
-    logger.info(s"Salesforce called has been parsed. Request Id: $requestId. Attrs: $salesforceAttributes")
-
-    (for {
-      sfId <- OptionT(touchpoint.contactRepo.get(salesforceAttributes.UserId))
-      membershipSubscription <- OptionT(touchpoint.subService.current[SubscriptionPlan.Member](sfId).map(_.headOption))
-    } yield {
-
-      // If the tier info does not match, we trust the info we get from Zuora, instead of the tier sent to us in the outbound message from Salesforce
-      val tierFromZuora = membershipSubscription.plan.charges.benefit.id
-      val tierFromSalesforce = salesforceAttributes.Tier
-      if (tierFromZuora != tierFromSalesforce) logger.error(s"Differing tier info for $sfId : sf=$tierFromSalesforce zuora=$tierFromZuora")
-
-      // If we have the card expiry date in Stripe, add them to Dynamo too.
-      // TODO - refactor to use touchpoint.paymentService - requires membership-common model tweak first.
-      val cardExpiryFromStripeF = (for {
-        account <- OptionT(touchpoint.zuoraService.getAccount(membershipSubscription.accountId).map(Option(_)))
-        paymentMethodId <- OptionT(Future.successful(account.defaultPaymentMethodId))
-        paymentMethod <- OptionT(touchpoint.zuoraService.getPaymentMethod(paymentMethodId).map(Option(_)))
-        customerToken <- OptionT(Future.successful(paymentMethod.secondTokenId))
-        stripeCustomer <- OptionT(touchpoint.stripeService.Customer.read(customerToken).map(Option(_)))
-      } yield {
-        (stripeCustomer.card.exp_month, stripeCustomer.card.exp_year)
-      }).run
-
-      cardExpiryFromStripeF.map {
-        case Some((expMonth, expYear)) => salesforceAttributes.copy(Tier = tierFromZuora, CardExpirationMonth = Some(expMonth), CardExpirationYear = Some(expYear))
-        case None => salesforceAttributes.copy(Tier = tierFromZuora)
+      def updateDynamo(attributes: Attributes) = {
+        attributeService.set(attributes).map { putItemResult =>
+          info(s"Successfully inserted $attributes into ${touchpoint.dynamoAttributesTable}.")
+          metrics.put("Update", 1)
+          putItemResult
+        }.recover { case e: Throwable =>
+          warn(s"Failed to insert $attributes into ${touchpoint.dynamoAttributesTable}. Salesforce should retry.", e)
+          Failure
+        }
       }
-    }).run.flatMap {
-      case Some(zuoraAttributesF) => zuoraAttributesF.flatMap(updateDynamo)
-      case None =>
-        logger.error(s"Couldn't update $salesforceAttributes with information from Zuora")
-        updateDynamo(salesforceAttributes)
+
+      info(s"Salesforce called has been parsed. Attrs: $membershipUpdate")
+
+      (for {
+        sfId <- OptionT(touchpoint.contactRepo.get(membershipUpdate.UserId).logWith("contact id from SF", _.map(_.salesforceContactId)))
+        membershipSubscription <- OptionT(touchpoint.subService.current[SubscriptionPlan.Member](sfId).logWith("current subscriptions", _.map(_.id)).map(_.headOption))
+      } yield {
+
+        // If the tier info does not match, we trust the info we get from Zuora, instead of the tier sent to us in the outbound message from Salesforce
+        val tierFromZuora = membershipSubscription.plan.charges.benefit.id
+        val tierFromSalesforce = membershipUpdate.Tier
+        if (tierFromZuora != tierFromSalesforce) error(s"Differing tier info for $sfId : sf=$tierFromSalesforce zuora=$tierFromZuora")
+
+        // If we have the card expiry date in Stripe, add them to Dynamo too.
+        // TODO - refactor to use touchpoint.paymentService - requires membership-common model tweak first.
+        val cardExpiryFromStripeF = (for {
+          account <- OptionT(touchpoint.zuoraService.getAccount(membershipSubscription.accountId).map(Option(_)))
+          paymentMethodId <- OptionT(Future.successful(account.defaultPaymentMethodId))
+          paymentMethod <- OptionT(touchpoint.zuoraService.getPaymentMethod(paymentMethodId).map(Option(_)))
+          customerToken <- OptionT(Future.successful(paymentMethod.secondTokenId))
+          stripeCustomer <- OptionT(touchpoint.stripeService.Customer.read(customerToken).map(Option(_)))
+        } yield {
+          (stripeCustomer.card.exp_month, stripeCustomer.card.exp_year)
+        }).run
+
+        val startDate = membershipSubscription.startDate // acceptanceDate is the date of first payment, but we want to know the signup date - contract effective date
+
+        cardExpiryFromStripeF.map {
+          case Some((expMonth, expYear)) =>
+            Attributes(
+              UserId = membershipUpdate.UserId,
+              Tier = tierFromZuora,
+              MembershipNumber = membershipUpdate.MembershipNumber,
+              AdFree = None,
+              CardExpirationMonth = Some(expMonth),
+              CardExpirationYear = Some(expYear),
+              StartDate = Some(startDate)
+            )
+          case None =>
+            Attributes(
+              UserId = membershipUpdate.UserId,
+              Tier = tierFromZuora,
+              MembershipNumber = membershipUpdate.MembershipNumber,
+              AdFree = None,
+              CardExpirationMonth = None,
+              CardExpirationYear = None,
+              StartDate = Some(startDate)
+            )
+        }
+      }).run.flatMap {
+        case Some(zuoraAttributesF) =>
+          zuoraAttributesF.onSuccess{ case attr =>
+            info(s"ready to update dynamo with $attr")
+          }
+          zuoraAttributesF.flatMap(updateDynamo)
+        case None =>
+          error(s"Couldn't update $membershipUpdate with information from Zuora")
+          Future.successful(Failure)
+      }
+    }
+
+    SFParser.parseOutboundMessage(request.body, validOrgId) match {
+      case -\/(ParsingError(msg)) =>
+        error(s"Could not parse payload. \n$msg")
+        Future(ApiErrors.badRequest(msg))
+      case -\/(OrgIdMatchingError(orgId)) =>
+        error(s"Wrong organization Id: $orgId")
+        Future(ApiErrors.unauthorized.copy("Wrong organization Id"))
+      // On successful parse, we should end up with a Seq of Salesforce objects to update
+      case \/-(outboundMessageChanges @ Seq(_*)) =>
+        info(s"Parsed Salesforce message successfully. Salesforce sent ${outboundMessageChanges.length} objects to update: $outboundMessageChanges")
+        // Take the Seq and apply the appropriate action for each notification item, based on its type
+        val updates = outboundMessageChanges.map {
+          case membershipDelete: MembershipDeletion => deleteMemberRecord(membershipDelete)
+          case membershipUpdate: MembershipUpdate => updateMemberRecord(membershipUpdate)
+        }
+        // Gather up the results of the futures and check for failures. Only send a success response to Salesforce if every processUpdate/processDeletion for the message succeeds
+        Future.sequence(updates).map { updateSeq =>
+          if (updateSeq.contains(Failure)) ApiErrors.internalError else ack
+        }
     }
   }
-
-  SFParser.parseOutboundMessage(request.body, validOrgId) match {
-    case -\/(ParsingError(msg)) =>
-      logger.error(s"Could not parse payload. \n$msg")
-      Future(ApiErrors.badRequest(msg))
-    case -\/(OrgIdMatchingError(orgId)) =>
-      logger.error(s"Wrong organization Id: $orgId")
-      Future(ApiErrors.unauthorized.copy("Wrong organization Id"))
-    // On successful parse, we should end up with a Seq of Salesforce objects to update
-    case \/-(outboundMessageChanges @ Seq(_*)) =>
-      logger.info(s"Parsed Salesforce message successfully. Salesforce sent ${outboundMessageChanges.length} objects to update: $outboundMessageChanges")
-      // Take the Seq and apply the appropriate action for each notification item, based on its type
-      val updates = outboundMessageChanges.map {
-        case membershipDelete: MembershipDeletion => deleteMemberRecord(membershipDelete)
-        case membershipUpdate: MembershipUpdate => updateMemberRecord(membershipUpdate)
-      }
-      // Gather up the results of the futures and check for failures. Only send a success response to Salesforce if every processUpdate/processDeletion for the message succeeds
-      Future.sequence(updates).map { updateSeq =>
-        if (updateSeq.contains(Failure)) ApiErrors.internalError else ack
-      }
-  }
- }
 }

--- a/membership-attribute-service/app/controllers/SalesforceHookController.scala
+++ b/membership-attribute-service/app/controllers/SalesforceHookController.scala
@@ -140,7 +140,7 @@ class SalesforceHookController extends LazyLogging {
         }.map { case (expMonth, expYear) =>
           Attributes(
             UserId = membershipUpdate.UserId,
-            Tier = tierFromZuora,
+            Tier = Some(tierFromZuora),
             MembershipNumber = membershipUpdate.MembershipNumber,
             AdFree = None,
             CardExpirationMonth = expMonth,

--- a/membership-attribute-service/app/controllers/SalesforceHookController.scala
+++ b/membership-attribute-service/app/controllers/SalesforceHookController.scala
@@ -136,25 +136,19 @@ class SalesforceHookController extends LazyLogging {
 
         cardExpiryFromStripeF.map {
           case Some((expMonth, expYear)) =>
-            Attributes(
-              UserId = membershipUpdate.UserId,
-              Tier = tierFromZuora,
-              MembershipNumber = membershipUpdate.MembershipNumber,
-              AdFree = None,
-              CardExpirationMonth = Some(expMonth),
-              CardExpirationYear = Some(expYear),
-              StartDate = Some(startDate)
-            )
+            (Some(expMonth),Some(expYear))
           case None =>
-            Attributes(
-              UserId = membershipUpdate.UserId,
-              Tier = tierFromZuora,
-              MembershipNumber = membershipUpdate.MembershipNumber,
-              AdFree = None,
-              CardExpirationMonth = None,
-              CardExpirationYear = None,
-              StartDate = Some(startDate)
-            )
+            (None, None)
+        }.map { case (expMonth, expYear) =>
+          Attributes(
+            UserId = membershipUpdate.UserId,
+            Tier = tierFromZuora,
+            MembershipNumber = membershipUpdate.MembershipNumber,
+            AdFree = None,
+            CardExpirationMonth = expMonth,
+            CardExpirationYear = expYear,
+            StartDate = Some(startDate)
+          )
         }
       }).run.flatMap {
         case Some(zuoraAttributesF) =>

--- a/membership-attribute-service/app/controllers/SalesforceHookController.scala
+++ b/membership-attribute-service/app/controllers/SalesforceHookController.scala
@@ -132,7 +132,7 @@ class SalesforceHookController extends LazyLogging {
           (stripeCustomer.card.exp_month, stripeCustomer.card.exp_year)
         }).run
 
-        val startDate = membershipSubscription.startDate // acceptanceDate is the date of first payment, but we want to know the signup date - contract effective date
+        val membershipJoinDate = membershipSubscription.startDate // acceptanceDate is the date of first payment, but we want to know the signup date - contract effective date
 
         cardExpiryFromStripeF.map {
           case Some((expMonth, expYear)) =>
@@ -147,7 +147,7 @@ class SalesforceHookController extends LazyLogging {
             AdFree = None,
             CardExpirationMonth = expMonth,
             CardExpirationYear = expYear,
-            StartDate = Some(startDate)
+            MembershipJoinDate = Some(membershipJoinDate)
           )
         }
       }).run.flatMap {

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -1,6 +1,5 @@
 package models
 
-import com.gu.memsub.subsv2.CatalogPlan.Contributor
 import json._
 import org.joda.time.LocalDate
 import org.joda.time.LocalDate.now
@@ -20,12 +19,12 @@ object ContentAccess {
 case class Attributes(
   UserId: String,
   Tier: Option[String] = None,
-  MembershipNumber: Option[String],
+  MembershipNumber: Option[String] = None,
   AdFree: Option[Boolean] = None,
   CardExpirationMonth: Option[Int] = None,
   CardExpirationYear: Option[Int] = None,
   ContributionFrequency: Option[String] = None,
-  MembershipJoinDate: Option[LocalDate] // TODO startDate shouldn't be optional once we've backfilled it everywhere
+  MembershipJoinDate: Option[LocalDate] = None
 ) {
 
   require(UserId.nonEmpty)

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -17,12 +17,14 @@ object ContentAccess {
 }
 
 case class Attributes(
-                       UserId: String,
-                       Tier: String,
-                       MembershipNumber: Option[String],
-                       AdFree: Option[Boolean] = None,
-                       CardExpirationMonth: Option[Int] = None,
-                       CardExpirationYear: Option[Int] = None) {
+  UserId: String,
+  Tier: String,
+  MembershipNumber: Option[String],
+  AdFree: Option[Boolean] = None,
+  CardExpirationMonth: Option[Int] = None,
+  CardExpirationYear: Option[Int] = None,
+  StartDate: Option[LocalDate] // TODO startDate shouldn't be optional once we've backfilled it everywhere
+) {
   require(Tier.nonEmpty)
   require(UserId.nonEmpty)
 
@@ -48,7 +50,8 @@ object Attributes {
     (__ \ "membershipNumber").writeNullable[String] and
     (__ \ "adFree").writeNullable[Boolean] and
     (__ \ "cardExpirationMonth").writeNullable[Int] and
-    (__ \ "cardExpirationYear").writeNullable[Int]
+    (__ \ "cardExpirationYear").writeNullable[Int] and
+      (__ \ "startDate").writeNullable[LocalDate]
   )(unlift(Attributes.unapply)).addField("contentAccess", _.contentAccess)
 
   implicit def toResult(attrs: Attributes): Result =

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -58,7 +58,7 @@ object Attributes {
     (__ \ "adFree").writeNullable[Boolean] and
     (__ \ "cardExpirationMonth").writeNullable[Int] and
     (__ \ "cardExpirationYear").writeNullable[Int] and
-    (__ \ "contributionFrequency").writeNullable[String]
+    (__ \ "contributionFrequency").writeNullable[String] and
       (__ \ "membershipJoinDate").writeNullable[LocalDate]
   )(unlift(Attributes.unapply)).addField("contentAccess", _.contentAccess)
 

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -23,7 +23,7 @@ case class Attributes(
   AdFree: Option[Boolean] = None,
   CardExpirationMonth: Option[Int] = None,
   CardExpirationYear: Option[Int] = None,
-  StartDate: Option[LocalDate] // TODO startDate shouldn't be optional once we've backfilled it everywhere
+  MembershipJoinDate: Option[LocalDate] // TODO startDate shouldn't be optional once we've backfilled it everywhere
 ) {
   require(Tier.nonEmpty)
   require(UserId.nonEmpty)
@@ -51,7 +51,7 @@ object Attributes {
     (__ \ "adFree").writeNullable[Boolean] and
     (__ \ "cardExpirationMonth").writeNullable[Int] and
     (__ \ "cardExpirationYear").writeNullable[Int] and
-      (__ \ "startDate").writeNullable[LocalDate]
+      (__ \ "membershipJoinDate").writeNullable[LocalDate]
   )(unlift(Attributes.unapply)).addField("contentAccess", _.contentAccess)
 
   implicit def toResult(attrs: Attributes): Result =

--- a/membership-attribute-service/app/models/Features.scala
+++ b/membership-attribute-service/app/models/Features.scala
@@ -23,7 +23,7 @@ object Features {
       adblockMessage = !attributes.isPaidTier,
       cardHasExpired = attributes.maybeCardHasExpired,
       cardExpires = attributes.cardExpires,
-      startDate = attributes.StartDate
+      membershipJoinDate = attributes.MembershipJoinDate
     )
   }
 
@@ -36,5 +36,5 @@ case class Features(
   adblockMessage: Boolean,
   cardHasExpired: Option[Boolean],
   cardExpires: Option[LocalDate],
-  startDate: Option[LocalDate]
+  membershipJoinDate: Option[LocalDate]
 )

--- a/membership-attribute-service/app/models/Features.scala
+++ b/membership-attribute-service/app/models/Features.scala
@@ -22,11 +22,19 @@ object Features {
       adFree = attributes.isAdFree,
       adblockMessage = !attributes.isPaidTier,
       cardHasExpired = attributes.maybeCardHasExpired,
-      cardExpires = attributes.cardExpires
+      cardExpires = attributes.cardExpires,
+      startDate = attributes.StartDate
     )
   }
 
-  val unauthenticated = Features(None, adFree = false, adblockMessage = true, None, None)
+  val unauthenticated = Features(None, adFree = false, adblockMessage = true, None, None, None)
 }
 
-case class Features(userId: Option[String], adFree: Boolean, adblockMessage: Boolean, cardHasExpired: Option[Boolean], cardExpires: Option[LocalDate])
+case class Features(
+  userId: Option[String],
+  adFree: Boolean,
+  adblockMessage: Boolean,
+  cardHasExpired: Option[Boolean],
+  cardExpires: Option[LocalDate],
+  startDate: Option[LocalDate]
+)

--- a/membership-attribute-service/app/models/Fixtures.scala
+++ b/membership-attribute-service/app/models/Fixtures.scala
@@ -1,9 +1,0 @@
-package models
-
-object Fixtures {
-  val membershipAttributes = Attributes(
-    UserId = "123",
-    Tier = "Patron",
-    MembershipNumber = Some("456")
-  )
-}

--- a/membership-attribute-service/app/parsers/Salesforce.scala
+++ b/membership-attribute-service/app/parsers/Salesforce.scala
@@ -62,7 +62,7 @@ object Salesforce {
         // If Salesforce Contact object has no Tier, we assume the user has expired/cancelled and mark them for deletion
         case None => MembershipDeletion(id)
         // If the Salesforce Contact has a Tier, we mark them for an update
-        case Some(tier) => MembershipUpdate(id, Some(tier), num)
+        case Some(tier) => MembershipUpdate(id, tier, num)
       }
     }
 

--- a/membership-attribute-service/app/repositories/MembershipAttributesSerializer.scala
+++ b/membership-attribute-service/app/repositories/MembershipAttributesSerializer.scala
@@ -9,7 +9,7 @@ object MembershipAttributesSerializer {
     val userId = "UserId"
     val membershipNumber = "MembershipNumber"
     val tier = "Tier"
-    val startDate = "StartDate"
+    val membershipJoinDate = "MembershipJoinDate"
   }
 }
 
@@ -27,7 +27,7 @@ case class MembershipAttributesSerializer(tableName: String)
       AttributeNames.userId -> membershipAttributes.UserId,
       AttributeNames.membershipNumber -> membershipAttributes.MembershipNumber.getOrElse(""),
       AttributeNames.tier -> membershipAttributes.Tier,
-      AttributeNames.startDate -> membershipAttributes.StartDate.map(_.toString).getOrElse("")
+      AttributeNames.membershipJoinDate -> membershipAttributes.MembershipJoinDate.map(_.toString).getOrElse("")
     ).filter(_._2.nonEmpty).map(mkAttribute[String])
 
   override def fromAttributeMap(item: collection.mutable.Map[String, AttributeValue]) = {
@@ -35,7 +35,7 @@ case class MembershipAttributesSerializer(tableName: String)
       UserId = item(AttributeNames.userId),
       MembershipNumber = item.get(AttributeNames.membershipNumber).map(_.getS),
       Tier = item(AttributeNames.tier),
-      StartDate = item.get(AttributeNames.startDate).map(LocalDate.parse(_))
+      MembershipJoinDate = item.get(AttributeNames.membershipJoinDate).map(LocalDate.parse(_))
     )
   }
 }

--- a/membership-attribute-service/app/repositories/MembershipAttributesSerializer.scala
+++ b/membership-attribute-service/app/repositories/MembershipAttributesSerializer.scala
@@ -2,12 +2,14 @@ package repositories
 
 import com.github.dwhjames.awswrap.dynamodb._
 import models.Attributes
+import org.joda.time.LocalDate
 
 object MembershipAttributesSerializer {
   object AttributeNames {
     val userId = "UserId"
     val membershipNumber = "MembershipNumber"
     val tier = "Tier"
+    val startDate = "StartDate"
   }
 }
 
@@ -24,13 +26,16 @@ case class MembershipAttributesSerializer(tableName: String)
     Map(
       AttributeNames.userId -> membershipAttributes.UserId,
       AttributeNames.membershipNumber -> membershipAttributes.MembershipNumber.getOrElse(""),
-      AttributeNames.tier -> membershipAttributes.Tier
+      AttributeNames.tier -> membershipAttributes.Tier,
+      AttributeNames.startDate -> membershipAttributes.StartDate.map(_.toString).getOrElse("")
     ).filter(_._2.nonEmpty).map(mkAttribute[String])
 
-  override def fromAttributeMap(item: collection.mutable.Map[String, AttributeValue]) =
+  override def fromAttributeMap(item: collection.mutable.Map[String, AttributeValue]) = {
     Attributes(
       UserId = item(AttributeNames.userId),
       MembershipNumber = item.get(AttributeNames.membershipNumber).map(_.getS),
-      Tier = item(AttributeNames.tier)
+      Tier = item(AttributeNames.tier),
+      StartDate = item.get(AttributeNames.startDate).map(LocalDate.parse(_))
     )
+  }
 }

--- a/membership-attribute-service/app/services/ScanamoAttributeService.scala
+++ b/membership-attribute-service/app/services/ScanamoAttributeService.scala
@@ -52,7 +52,8 @@ class ScanamoAttributeService(client: AmazonDynamoDBAsyncClient, table: String)
       scanamoSetOpt('MembershipNumber -> attributes.MembershipNumber),
       scanamoSetOpt('ContributionFrequency -> attributes.ContributionFrequency),
       scanamoSetOpt('CardExpirationMonth -> attributes.CardExpirationMonth),
-      scanamoSetOpt('CardExpirationYear -> attributes.CardExpirationYear)
+      scanamoSetOpt('CardExpirationYear -> attributes.CardExpirationYear),
+      scanamoSetOpt('MembershipJoinDate -> attributes.MembershipJoinDate)
     ).flatten match {
       case first :: remaining =>
         run(

--- a/membership-attribute-service/app/sources/SalesforceCSVExport.scala
+++ b/membership-attribute-service/app/sources/SalesforceCSVExport.scala
@@ -17,7 +17,7 @@ object SalesforceCSVExport {
       .map {
         case re(id, num, tier, date) =>
           val numOpt = if (num.isEmpty) None else Some(num)
-          Some(Attributes(id, tier, numOpt, StartDate = None))
+          Some(Attributes(id, tier, numOpt, MembershipJoinDate = None))
         case str =>
           logger.error(s"Couldn't parse line\n$str\nas a valid members attribute")
           None

--- a/membership-attribute-service/app/sources/SalesforceCSVExport.scala
+++ b/membership-attribute-service/app/sources/SalesforceCSVExport.scala
@@ -17,7 +17,7 @@ object SalesforceCSVExport {
       .map {
         case re(id, num, tier, date) =>
           val numOpt = if (num.isEmpty) None else Some(num)
-          Some(Attributes(id, tier, numOpt))
+          Some(Attributes(id, tier, numOpt, StartDate = None))
         case str =>
           logger.error(s"Couldn't parse line\n$str\nas a valid members attribute")
           None

--- a/membership-attribute-service/app/sources/SalesforceCSVExport.scala
+++ b/membership-attribute-service/app/sources/SalesforceCSVExport.scala
@@ -17,7 +17,7 @@ object SalesforceCSVExport {
       .map {
         case re(id, num, tier, date) =>
           val numOpt = if (num.isEmpty) None else Some(num)
-          Some(Attributes(id, Some(tier), numOpt, MembershipJoinDate = None))
+          Some(Attributes(id, Some(tier), numOpt))
         case str =>
           logger.error(s"Couldn't parse line\n$str\nas a valid members attribute")
           None

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -3,7 +3,6 @@ GET        /healthcheck                                     controllers.HealthCh
 
 GET        /user-attributes/me/membership                   controllers.AttributeController.membership
 GET        /user-attributes/me/features                     controllers.AttributeController.features
-POST       /user-attributes/me/update                       controllers.AttributeController.update
 
 GET        /user-attributes/me/mma-digitalpack              controllers.AccountController.digitalPackDetails
 GET        /user-attributes/me/mma-membership               controllers.AccountController.membershipDetails

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -79,7 +79,7 @@ class AttributeControllerTest extends Specification with AfterAll {
         |   "cardExpirationMonth": 3,
         |   "cardExpirationYear": 2018,
         |   "adFree": false,
-        |   "startDate": "2017-06-13",
+        |   "membershipJoinDate": "2017-06-13",
         |   "contentAccess":{"member":true,"paidMember":true}
         | }
       """.stripMargin)

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -5,6 +5,7 @@ import akka.actor.ActorSystem
 import components.TouchpointComponents
 import configuration.Config
 import models.Attributes
+import org.joda.time.LocalDate
 import org.specs2.mutable.Specification
 import org.specs2.specification.AfterAll
 import play.api.libs.concurrent.Execution.Implicits._
@@ -22,7 +23,13 @@ class AttributeControllerTest extends Specification with AfterAll {
   private val validUserId = "123"
   private val invalidUserId = "456"
   private val attributes = Attributes(
-    UserId = validUserId, Tier = "patron", MembershipNumber = Some("abc"), AdFree = Some(false), CardExpirationMonth = Some(3), CardExpirationYear = Some(2018)
+    UserId = validUserId,
+    Tier = "patron",
+    MembershipNumber = Some("abc"),
+    AdFree = Some(false),
+    CardExpirationMonth = Some(3),
+    CardExpirationYear = Some(2018),
+    StartDate = Some(new LocalDate(2017, 6, 13))
   )
 
   private val validUserCookie = Cookie("validUser", "true")
@@ -72,6 +79,7 @@ class AttributeControllerTest extends Specification with AfterAll {
         |   "cardExpirationMonth": 3,
         |   "cardExpirationYear": 2018,
         |   "adFree": false,
+        |   "startDate": "2017-06-13",
         |   "contentAccess":{"member":true,"paidMember":true}
         | }
       """.stripMargin)

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -29,7 +29,7 @@ class AttributeControllerTest extends Specification with AfterAll {
     AdFree = Some(false),
     CardExpirationMonth = Some(3),
     CardExpirationYear = Some(2018),
-    StartDate = Some(new LocalDate(2017, 6, 13))
+    MembershipJoinDate = Some(new LocalDate(2017, 6, 13))
   )
 
   private val validUserCookie = Cookie("validUser", "true")

--- a/membership-attribute-service/test/models/AttributesTest.scala
+++ b/membership-attribute-service/test/models/AttributesTest.scala
@@ -5,7 +5,7 @@ import org.specs2.mutable.Specification
 class AttributesTest extends Specification {
 
   "AttributesTest" should {
-    val attrs = Attributes(UserId = "123", Tier = "tier", MembershipNumber = None, StartDate = None)
+    val attrs = Attributes(UserId = "123", Tier = "tier", MembershipNumber = None, MembershipJoinDate = None)
 
     "isPaidTier returns" should {
       "true if the user is not a Guardian Friend" in {

--- a/membership-attribute-service/test/models/AttributesTest.scala
+++ b/membership-attribute-service/test/models/AttributesTest.scala
@@ -1,12 +1,11 @@
 package models
 
-import com.gu.memsub.Benefit.Contributor
 import org.specs2.mutable.Specification
 
 class AttributesTest extends Specification {
 
   "AttributesTest" should {
-    val attrs = Attributes(UserId = "123", Tier = None, MembershipNumber = None, ContributionFrequency = None, MembershipJoinDate = None)
+    val attrs = Attributes(UserId = "123")
 
     "isPaidTier returns" should {
       "true if the user is not a Guardian Friend" in {

--- a/membership-attribute-service/test/models/AttributesTest.scala
+++ b/membership-attribute-service/test/models/AttributesTest.scala
@@ -5,7 +5,7 @@ import org.specs2.mutable.Specification
 class AttributesTest extends Specification {
 
   "AttributesTest" should {
-    val attrs = Attributes(UserId = "123", Tier = "tier", MembershipNumber = None)
+    val attrs = Attributes(UserId = "123", Tier = "tier", MembershipNumber = None, StartDate = None)
 
     "isPaidTier returns" should {
       "true if the user is not a Guardian Friend" in {

--- a/membership-attribute-service/test/parsers/SalesforceTest.scala
+++ b/membership-attribute-service/test/parsers/SalesforceTest.scala
@@ -32,7 +32,7 @@ class SalesforceTest extends Specification {
           </soapenv:Body>
         </soapenv:Envelope>
 
-      val updateActionSeq = Seq(MembershipUpdate("identity_id", Some("Supporter"), Some("membership_number")))
+      val updateActionSeq = Seq(MembershipUpdate("identity_id", "Supporter", Some("membership_number")))
       Salesforce.parseOutboundMessage(payload, orgId) shouldEqual updateActionSeq.right
     }
 
@@ -58,7 +58,7 @@ class SalesforceTest extends Specification {
           </soapenv:Body>
         </soapenv:Envelope>
 
-      val updateActionSeq = Seq(MembershipUpdate("identity_id", Some("Supporter"), None))
+      val updateActionSeq = Seq(MembershipUpdate("identity_id", "Supporter", None))
       Salesforce.parseOutboundMessage(payload, orgId) shouldEqual updateActionSeq.right
     }
 
@@ -94,7 +94,7 @@ class SalesforceTest extends Specification {
           </soapenv:Body>
         </soapenv:Envelope>
 
-      val updateActionSeq = Seq(MembershipUpdate("123", Some("Supporter"), Some("12345")), MembershipUpdate("321", Some("Supporter"), Some("54321")))
+      val updateActionSeq = Seq(MembershipUpdate("123", "Supporter", Some("12345")), MembershipUpdate("321", "Supporter", Some("54321")))
       Salesforce.parseOutboundMessage(payload, orgId) shouldEqual updateActionSeq.right
     }
 
@@ -161,9 +161,9 @@ class SalesforceTest extends Specification {
           </soapenv:Body>
         </soapenv:Envelope>
 
-      val sfNotifications = Seq(MembershipUpdate("identity_id1", Some("Supporter"), None),
+      val sfNotifications = Seq(MembershipUpdate("identity_id1", "Supporter", None),
                                 MembershipDeletion("identity_id2"),
-                                MembershipUpdate("identity_id3", Some("Partner"), Some("membership_number")))
+                                MembershipUpdate("identity_id3", "Partner", Some("membership_number")))
       Salesforce.parseOutboundMessage(payload, orgId) shouldEqual sfNotifications.right
     }
 

--- a/membership-attribute-service/test/parsers/SalesforceTest.scala
+++ b/membership-attribute-service/test/parsers/SalesforceTest.scala
@@ -32,7 +32,7 @@ class SalesforceTest extends Specification {
           </soapenv:Body>
         </soapenv:Envelope>
 
-      val updateActionSeq = Seq(MembershipUpdate(Attributes("identity_id", "Supporter", Some("membership_number"))))
+      val updateActionSeq = Seq(MembershipUpdate("identity_id", "Supporter", Some("membership_number")))
       Salesforce.parseOutboundMessage(payload, orgId) shouldEqual updateActionSeq.right
     }
 
@@ -58,7 +58,7 @@ class SalesforceTest extends Specification {
           </soapenv:Body>
         </soapenv:Envelope>
 
-      val updateActionSeq = Seq(MembershipUpdate(Attributes("identity_id", "Supporter", None)))
+      val updateActionSeq = Seq(MembershipUpdate("identity_id", "Supporter", None))
       Salesforce.parseOutboundMessage(payload, orgId) shouldEqual updateActionSeq.right
     }
 
@@ -94,7 +94,7 @@ class SalesforceTest extends Specification {
           </soapenv:Body>
         </soapenv:Envelope>
 
-      val updateActionSeq = Seq(MembershipUpdate(Attributes("123", "Supporter", Some("12345"))), MembershipUpdate(Attributes("321", "Supporter", Some("54321"))))
+      val updateActionSeq = Seq(MembershipUpdate("123", "Supporter", Some("12345")), MembershipUpdate("321", "Supporter", Some("54321")))
       Salesforce.parseOutboundMessage(payload, orgId) shouldEqual updateActionSeq.right
     }
 
@@ -161,9 +161,9 @@ class SalesforceTest extends Specification {
           </soapenv:Body>
         </soapenv:Envelope>
 
-      val sfNotifications = Seq(MembershipUpdate(Attributes("identity_id1", "Supporter", None)),
+      val sfNotifications = Seq(MembershipUpdate("identity_id1", "Supporter", None),
                                 MembershipDeletion("identity_id2"),
-                                MembershipUpdate(Attributes("identity_id3", "Partner", Some("membership_number"))))
+                                MembershipUpdate("identity_id3", "Partner", Some("membership_number")))
       Salesforce.parseOutboundMessage(payload, orgId) shouldEqual sfNotifications.right
     }
 

--- a/membership-attribute-service/test/repositories/DynamoAttributeServiceTest.scala
+++ b/membership-attribute-service/test/repositories/DynamoAttributeServiceTest.scala
@@ -49,7 +49,7 @@ class DynamoAttributeServiceTest extends Specification {
   "get" should {
     "retrieve attributes for given user" in {
       val userId = UUID.randomUUID().toString
-      val attributes = Attributes(userId, "patron", Some("abc"), StartDate = Some(new LocalDate(2017, 6, 13)))
+      val attributes = Attributes(userId, "patron", Some("abc"), MembershipJoinDate = Some(new LocalDate(2017, 6, 13)))
       val result = for {
         insertResult <- repo.set(attributes)
         retrieved <- repo.get(userId)
@@ -70,17 +70,17 @@ class DynamoAttributeServiceTest extends Specification {
   "getMany" should {
 
     val testUsers = Seq(
-      Attributes("1234", "Partner", None, StartDate = None),
-      Attributes("2345", "Partner", None, StartDate = Some(new LocalDate(2017, 6, 12))),
-      Attributes("3456", "Partner", None, StartDate = Some(new LocalDate(2017, 6, 11))),
-      Attributes("4567", "Partner", None, StartDate = Some(new LocalDate(2017, 6, 10)))
+      Attributes("1234", "Partner", None, MembershipJoinDate = None),
+      Attributes("2345", "Partner", None, MembershipJoinDate = Some(new LocalDate(2017, 6, 12))),
+      Attributes("3456", "Partner", None, MembershipJoinDate = Some(new LocalDate(2017, 6, 11))),
+      Attributes("4567", "Partner", None, MembershipJoinDate = Some(new LocalDate(2017, 6, 10)))
     )
 
     "Fetch many people by user id" in {
       Await.result(Future.sequence(testUsers.map(repo.set)), 5.seconds)
       Await.result(repo.getMany(List("1234", "3456", "abcd")), 5.seconds) mustEqual Seq(
-        Attributes("1234", "Partner", None, StartDate = None),
-        Attributes("3456", "Partner", None, StartDate = Some(new LocalDate(2017, 6, 11)))
+        Attributes("1234", "Partner", None, MembershipJoinDate = None),
+        Attributes("3456", "Partner", None, MembershipJoinDate = Some(new LocalDate(2017, 6, 11)))
       )
     }
   }

--- a/membership-attribute-service/test/repositories/DynamoAttributeServiceTest.scala
+++ b/membership-attribute-service/test/repositories/DynamoAttributeServiceTest.scala
@@ -5,19 +5,16 @@ import java.util.UUID
 import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
 import com.amazonaws.services.dynamodbv2.model.CreateTableRequest
-import com.github.dwhjames.awswrap.dynamodb.{AmazonDynamoDBScalaClient, AmazonDynamoDBScalaMapper, Schema}
+import com.github.dwhjames.awswrap.dynamodb.{AmazonDynamoDBScalaClient, Schema}
 import models.Attributes
 import org.joda.time.LocalDate
 import org.specs2.mutable.Specification
-import org.specs2.matcher._
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import repositories.MembershipAttributesSerializer.AttributeNames
 import services.ScanamoAttributeService
 
-import scala.concurrent.{Await, Future}
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
-
 import scala.concurrent.duration._
-import org.specs2.concurrent.ExecutionEnv
+import scala.concurrent.{Await, Future}
 
 /**
  * Depends upon DynamoDB Local to be running on the default port of 8000.
@@ -70,17 +67,17 @@ class DynamoAttributeServiceTest extends Specification {
   "getMany" should {
 
     val testUsers = Seq(
-      Attributes(UserId = "1234", Tier = Some("Partner"), MembershipNumber = None, MembershipJoinDate = None),
-      Attributes(UserId = "2345", Tier = Some("Partner"), MembershipNumber = None, MembershipJoinDate = Some(new LocalDate(2017, 6, 12))),
-      Attributes(UserId = "3456", Tier = Some("Partner"), MembershipNumber = None, MembershipJoinDate = Some(new LocalDate(2017, 6, 11))),
-      Attributes(UserId = "4567", Tier = Some("Partner"), MembershipNumber = None, MembershipJoinDate = Some(new LocalDate(2017, 6, 10)))
+      Attributes(UserId = "1234", Tier = Some("Partner")),
+      Attributes(UserId = "2345", Tier = Some("Partner"), MembershipJoinDate = Some(new LocalDate(2017, 6, 12))),
+      Attributes(UserId = "3456", Tier = Some("Partner"), MembershipJoinDate = Some(new LocalDate(2017, 6, 11))),
+      Attributes(UserId = "4567", Tier = Some("Partner"), MembershipJoinDate = Some(new LocalDate(2017, 6, 10)))
     )
 
     "Fetch many people by user id" in {
       Await.result(Future.sequence(testUsers.map(repo.set)), 5.seconds)
       Await.result(repo.getMany(List("1234", "3456", "abcd")), 5.seconds) mustEqual Seq(
-        Attributes(UserId = "1234", Tier = Some("Partner"), MembershipNumber = None, MembershipJoinDate = None),
-        Attributes(UserId = "3456", Tier = Some("Partner"), MembershipNumber = None, MembershipJoinDate = Some(new LocalDate(2017, 6, 11)))
+        Attributes(UserId = "1234", Tier = Some("Partner")),
+        Attributes(UserId = "3456", Tier = Some("Partner"), MembershipJoinDate = Some(new LocalDate(2017, 6, 11)))
       )
     }
   }

--- a/membership-attribute-service/test/repositories/DynamoAttributeServiceTest.scala
+++ b/membership-attribute-service/test/repositories/DynamoAttributeServiceTest.scala
@@ -7,6 +7,7 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
 import com.amazonaws.services.dynamodbv2.model.CreateTableRequest
 import com.github.dwhjames.awswrap.dynamodb.{AmazonDynamoDBScalaClient, AmazonDynamoDBScalaMapper, Schema}
 import models.Attributes
+import org.joda.time.LocalDate
 import org.specs2.mutable.Specification
 import org.specs2.matcher._
 import repositories.MembershipAttributesSerializer.AttributeNames
@@ -14,6 +15,7 @@ import services.ScanamoAttributeService
 
 import scala.concurrent.{Await, Future}
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
+
 import scala.concurrent.duration._
 import org.specs2.concurrent.ExecutionEnv
 
@@ -47,7 +49,7 @@ class DynamoAttributeServiceTest extends Specification {
   "get" should {
     "retrieve attributes for given user" in {
       val userId = UUID.randomUUID().toString
-      val attributes = Attributes(userId, "patron", Some("abc"))
+      val attributes = Attributes(userId, "patron", Some("abc"), StartDate = Some(new LocalDate(2017, 6, 13)))
       val result = for {
         insertResult <- repo.set(attributes)
         retrieved <- repo.get(userId)
@@ -68,17 +70,17 @@ class DynamoAttributeServiceTest extends Specification {
   "getMany" should {
 
     val testUsers = Seq(
-      Attributes("1234", "Partner", None),
-      Attributes("2345", "Partner", None),
-      Attributes("3456", "Partner", None),
-      Attributes("4567", "Partner", None)
+      Attributes("1234", "Partner", None, StartDate = None),
+      Attributes("2345", "Partner", None, StartDate = Some(new LocalDate(2017, 6, 12))),
+      Attributes("3456", "Partner", None, StartDate = Some(new LocalDate(2017, 6, 11))),
+      Attributes("4567", "Partner", None, StartDate = Some(new LocalDate(2017, 6, 10)))
     )
 
     "Fetch many people by user id" in {
       Await.result(Future.sequence(testUsers.map(repo.set)), 5.seconds)
       Await.result(repo.getMany(List("1234", "3456", "abcd")), 5.seconds) mustEqual Seq(
-        Attributes("1234", "Partner", None),
-        Attributes("3456", "Partner", None)
+        Attributes("1234", "Partner", None, StartDate = None),
+        Attributes("3456", "Partner", None, StartDate = Some(new LocalDate(2017, 6, 11)))
       )
     }
   }

--- a/membership-attribute-service/test/sources/SalesforceCSVExportSpec.scala
+++ b/membership-attribute-service/test/sources/SalesforceCSVExportSpec.scala
@@ -16,9 +16,9 @@ class SalesforceCSVExportSpec extends Specification {
         val attributes = SalesforceCSVExport.membersAttributes(file).toList
 
         attributes shouldEqual List(
-          Attributes("323479263", "Partner", Some("292451"), StartDate = None),
-          Attributes("323479267", "Patron", Some("292454"), StartDate = None),
-          Attributes("323479268", "Friend", None, StartDate = None)
+          Attributes("323479263", "Partner", Some("292451"), MembershipJoinDate = None),
+          Attributes("323479267", "Patron", Some("292454"), MembershipJoinDate = None),
+          Attributes("323479268", "Friend", None, MembershipJoinDate = None)
         )
       }
     }

--- a/membership-attribute-service/test/sources/SalesforceCSVExportSpec.scala
+++ b/membership-attribute-service/test/sources/SalesforceCSVExportSpec.scala
@@ -16,9 +16,9 @@ class SalesforceCSVExportSpec extends Specification {
         val attributes = SalesforceCSVExport.membersAttributes(file).toList
 
         attributes shouldEqual List(
-          Attributes("323479263", "Partner", Some("292451")),
-          Attributes("323479267", "Patron", Some("292454")),
-          Attributes("323479268", "Friend", None)
+          Attributes("323479263", "Partner", Some("292451"), StartDate = None),
+          Attributes("323479267", "Patron", Some("292454"), StartDate = None),
+          Attributes("323479268", "Friend", None, StartDate = None)
         )
       }
     }

--- a/membership-attribute-service/test/sources/SalesforceCSVExportSpec.scala
+++ b/membership-attribute-service/test/sources/SalesforceCSVExportSpec.scala
@@ -16,9 +16,9 @@ class SalesforceCSVExportSpec extends Specification {
         val attributes = SalesforceCSVExport.membersAttributes(file).toList
 
         attributes shouldEqual List(
-          Attributes("323479263", Some("Partner"), Some("292451"), MembershipJoinDate = None),
-          Attributes("323479267", Some("Patron"), Some("292454"), MembershipJoinDate = None),
-          Attributes("323479268", Some("Friend"), None, MembershipJoinDate = None)
+          Attributes("323479263", Some("Partner"), Some("292451")),
+          Attributes("323479267", Some("Patron"), Some("292454")),
+          Attributes("323479268", Some("Friend"))
         )
       }
     }


### PR DESCRIPTION
This is to let us target messages on the client side to people who joined at certain times.  This lets us serve appropriate messages on anniversaries to make people feel more valued as a member based on what motivated joiners at that time.

Note: you can try viewing this with [?w=1](https://github.com/guardian/members-data-api/pull/192/files?w=1) to ignore all the indentation changes, but then it's a lot harder to comment...

The technical side is when we get the message from salesforce that someone has joined, we mirror the [contractEffectiveDate](https://github.com/guardian/membership-common/blob/919ed929b8f07bc4b399caf64d3e42be43aabe9b/src/main/scala/com/gu/memsub/subsv2/reads/SubJsonReads.scala#L110) which is called startDate for some reason (someone should fix that)
Then when someone hits the features endpoint, we return the extra field `startDate`
```json
{"userId":"30000594","adFree":false,"adblockMessage":false,"cardHasExpired":false,"cardExpires":"2022-02-28","startDate":"2017-06-19"}
```
This also works for existing users who don't have a record with the start/join date by just omitting the field completely.

I'm not sure about naming, since this is specifically the memberhip start date I'm not sure whether to call it joinDate.  I wonder how this would interact with contributions, as we might want to know when they started too.  We can add another contributionStartDate for that if we need it?

In due course we need to back populate the existing users, this would be by doing a query on zuora, and I found a batch loader in the codebase which may be old, but this is an essential step to actually being able to target existing members.

I will have a quick look after lunch and try to work out which bits could do with tests.

Into the mix I did a few small bits of tidy up, deleting an unused endpoint for update (no one called it through fastly as I grepped the logs) and also removed one layer from the MembershipUpdate object.

@lmath @jacobwinch @svillafe @pvighi would be great to get a bit of a review on this then I can fix things up this afternoon and potentially merge @svillafe 's [PR](https://github.com/guardian/members-data-api/pull/191) into it once he's merged.
