### PR TITLE
Remove SF and Zuora tier comparison

### DIFF
--- a/membership-attribute-service/app/controllers/SalesforceHookController.scala
+++ b/membership-attribute-service/app/controllers/SalesforceHookController.scala
@@ -85,10 +85,8 @@ def createAttributes = BackendFromSalesforceAction.async(parse.xml) { request =>
       membershipSubscription <- OptionT(touchpoint.subService.current[SubscriptionPlan.Member](sfId).map(_.headOption))
     } yield {
 
-      // If the tier info does not match, we trust the info we get from Zuora, instead of the tier sent to us in the outbound message from Salesforce
+      // Zuora is the master for product info, so we use the tier from Zuora regardless of what Salesforce sends
       val tierFromZuora = membershipSubscription.plan.charges.benefit.id
-      val tierFromSalesforce = salesforceAttributes.Tier
-      if (tierFromZuora != tierFromSalesforce) logger.error(s"Differing tier info for $sfId : sf=$tierFromSalesforce zuora=$tierFromZuora")
 
       // If we have the card expiry date in Stripe, add them to Dynamo too.
       // TODO - refactor to use touchpoint.paymentService - requires membership-common model tweak first.


### PR DESCRIPTION
cc @svillafe 

Making tier optional in https://github.com/guardian/members-data-api/pull/191 means that this comparison always fails, hence the spike seen here:
https://sentry.io/the-guardian/members-data-api/issues/168652230/events/5806858122/

I'm not convinced this error is providing any value, so I'm going to remove this logging (rather than fixing the comparison).

I think we are in agreement that Salesforce is not a reliable source of truth for product information, so ultimately we want to get away from it having any involvement in the Dynamo sync.