### PR TITLE
Setting back the old response of `/me/membership`

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -90,7 +90,7 @@ class AttributeController extends Controller with LazyLogging {
   val notFound = ApiError("Not found", "Could not find user in the database", 404)
   val notAMember = ApiError("Not found", "User was found but they are not a member", 404)
 
-  def membership = lookup("membership", onSuccessMember = identity[Attributes], onSuccessMemberAndOrContributor = _ => notAMember, onNotFound = notFound)
+  def membership = lookup("membership", onSuccessMember = MembershipAttributes.fromAttributes, onSuccessMemberAndOrContributor = _ => notAMember, onNotFound = notFound)
   def attributes = lookup("attributes", onSuccessMember = identity[Attributes], onSuccessMemberAndOrContributor = identity[Attributes], onNotFound = notFound)
   def features = lookup("features", onSuccessMember = Features.fromAttributes, onSuccessMemberAndOrContributor = _ => Features.unauthenticated, onNotFound = Features.unauthenticated)
 

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -89,7 +89,7 @@ class AttributeController extends Controller with LazyLogging {
           UserId = identityId,
           Tier = memSub.map(_.plan.charges.benefit.id),
           MembershipNumber = contact.regNumber,
-          ContributionFrequency = conSub.map(_.plan.name),
+          ContributionPaymentPlan = conSub.map(_.plan.name),
           MembershipJoinDate = memSub.map(_.startDate)
         )
         res <- EitherT(tp.attrService.update(attributes).map(\/.right))
@@ -101,7 +101,7 @@ class AttributeController extends Controller with LazyLogging {
         ApiErrors.badRequest(error)
       },
       { attributes =>
-        logger.info(s"${attributes.UserId} -> ${attributes.Tier} || ${attributes.ContributionFrequency}")
+        logger.info(s"${attributes.UserId} -> ${attributes.Tier} || ${attributes.ContributionPaymentPlan}")
         Ok(Json.obj("updated" -> true))
       }
     )

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -68,7 +68,13 @@ class AttributeController extends Controller with LazyLogging {
   val notFound = ApiError("Not found", "Could not find user in the database", 404)
   val notAMember = ApiError("Not found", "User was found but they are not a member", 404)
 
-  def membership = lookup("membership", onSuccessMember = MembershipAttributes.fromAttributes, onSuccessMemberAndOrContributor = _ => notAMember, onNotFound = notFound)
+  private def membershipAttributesFromAttributes(attributes: Attributes): Result = {
+     MembershipAttributes.fromAttributes(attributes)
+       .map(member => Ok(Json.toJson(member)))
+       .getOrElse(notFound)
+  }
+
+  def membership = lookup("membership", onSuccessMember = membershipAttributesFromAttributes, onSuccessMemberAndOrContributor = _ => notAMember, onNotFound = notFound)
   def attributes = lookup("attributes", onSuccessMember = identity[Attributes], onSuccessMemberAndOrContributor = identity[Attributes], onNotFound = notFound)
   def features = lookup("features", onSuccessMember = Features.fromAttributes, onSuccessMemberAndOrContributor = _ => Features.unauthenticated, onNotFound = Features.unauthenticated)
 

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -73,36 +73,37 @@ object Attributes {
 
 
 case class MembershipAttributes(
-                       UserId: String,
-                       Tier: Option[String] = None,
-                       MembershipNumber: Option[String],
-                       AdFree: Option[Boolean] = None,
-                       ContentAccess : MembershipContentAccess)
+  UserId: String,
+  Tier: String,
+  MembershipNumber: Option[String],
+  AdFree: Option[Boolean] = None,
+  ContentAccess : MembershipContentAccess
+)
 
 object MembershipAttributes {
 
   implicit val jsWrite: OWrites[MembershipAttributes] = (
     (__ \ "userId").write[String] and
-    (__ \ "tier").writeNullable[String] and
+    (__ \ "tier").write[String] and
     (__ \ "membershipNumber").writeNullable[String] and
     (__ \ "adFree").writeNullable[Boolean] and
     (__ \ "contentAccess").write[MembershipContentAccess](MembershipContentAccess.jsWrite)
    )(unlift(MembershipAttributes.unapply))
 
-  implicit def toResult(attrs: MembershipAttributes): Result =
-    Ok(Json.toJson(attrs))
-
-  def fromAttributes( attr:Attributes) =
+  def fromAttributes(attr: Attributes): Option[MembershipAttributes] = for {
+    tier <- attr.Tier
+  } yield {
     MembershipAttributes(
       UserId = attr.UserId,
-      Tier = attr.Tier,
+      Tier = tier,
       MembershipNumber = attr.MembershipNumber,
       AdFree = attr.AdFree,
-      ContentAccess =  MembershipContentAccess(
+      ContentAccess = MembershipContentAccess(
         member = attr.contentAccess.member,
         paidMember = attr.contentAccess.paidMember
       )
     )
+  }
 
 }
 

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -1,5 +1,6 @@
 package models
 
+import com.gu.memsub.Benefit.PaidMemberTier
 import com.gu.memsub.subsv2.CatalogPlan.Contributor
 import json._
 import org.joda.time.LocalDate
@@ -59,6 +60,51 @@ object Attributes {
     (__ \ "contributionFrequency").writeNullable[String]
   )(unlift(Attributes.unapply)).addField("contentAccess", _.contentAccess)
 
+
+
   implicit def toResult(attrs: Attributes): Result =
     Ok(Json.toJson(attrs))
+}
+
+
+
+case class MembershipAttributes(
+                       UserId: String,
+                       Tier: Option[String] = None,
+                       MembershipNumber: Option[String],
+                       AdFree: Option[Boolean] = None,
+                       ContentAccess : MembershipContentAccess)
+
+object MembershipAttributes {
+
+  implicit val jsWrite: OWrites[MembershipAttributes] = (
+    (__ \ "userId").write[String] and
+    (__ \ "tier").writeNullable[String] and
+    (__ \ "membershipNumber").writeNullable[String] and
+    (__ \ "adFree").writeNullable[Boolean] and
+    (__ \ "contentAccess").write[MembershipContentAccess](MembershipContentAccess.jsWrite)
+   )(unlift(MembershipAttributes.unapply))
+
+  implicit def toResult(attrs: MembershipAttributes): Result =
+    Ok(Json.toJson(attrs))
+
+  def fromAttributes( attr:Attributes) =
+    MembershipAttributes(
+      UserId = attr.UserId,
+      Tier = attr.Tier,
+      MembershipNumber = attr.MembershipNumber,
+      AdFree = attr.AdFree,
+      ContentAccess =  MembershipContentAccess(
+        member = attr.contentAccess.member,
+        paidMember = attr.contentAccess.paidMember
+      )
+    )
+
+}
+
+
+case class MembershipContentAccess(member: Boolean, paidMember: Boolean)
+
+object MembershipContentAccess {
+  implicit val jsWrite = Json.writes[MembershipContentAccess]
 }

--- a/membership-attribute-service/app/services/ScanamoAttributeService.scala
+++ b/membership-attribute-service/app/services/ScanamoAttributeService.scala
@@ -50,7 +50,7 @@ class ScanamoAttributeService(client: AmazonDynamoDBAsyncClient, table: String)
     List(
       scanamoSetOpt('Tier, attributes.Tier),
       scanamoSetOpt('MembershipNumber -> attributes.MembershipNumber),
-      scanamoSetOpt('ContributionFrequency -> attributes.ContributionFrequency),
+      scanamoSetOpt('ContributionPaymentPlan -> attributes.ContributionPaymentPlan),
       scanamoSetOpt('CardExpirationMonth -> attributes.CardExpirationMonth),
       scanamoSetOpt('CardExpirationYear -> attributes.CardExpirationYear),
       scanamoSetOpt('MembershipJoinDate -> attributes.MembershipJoinDate)

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -78,11 +78,8 @@ class AttributeControllerTest extends Specification with AfterAll {
         |   "tier": "patron",
         |   "membershipNumber": "abc",
         |   "userId": "123",
-        |   "cardExpirationMonth": 3,
-        |   "cardExpirationYear": 2018,
         |   "adFree": false,
-        |   "membershipJoinDate": "2017-06-13",
-        |   "contentAccess":{"member":true,"paidMember":true, "contributor":false}
+        |   "contentAccess":{"member":true,"paidMember":true}
         | }
       """.stripMargin)
   }

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -84,6 +84,24 @@ class AttributeControllerTest extends Specification with AfterAll {
       """.stripMargin)
   }
 
+  def verifyFullSuccessfullResult(result: Future[Result]) = {
+    status(result) shouldEqual OK
+    val jsonBody = contentAsJson(result)
+    jsonBody shouldEqual
+      Json.parse("""
+                   | {
+                   |   "tier": "patron",
+                   |   "membershipNumber": "abc",
+                   |   "userId": "123",
+                   |   "cardExpirationMonth": 3,
+                   |   "cardExpirationYear": 2018,
+                   |   "adFree": false,
+                   |   "membershipJoinDate": "2017-06-13",
+                   |   "contentAccess":{"member":true,"paidMember":true, "recurringContributor":false}
+                   | }
+                 """.stripMargin)
+  }
+
   "getMyAttributes" should {
     "return unauthorised when cookies not provided" in {
       val req = FakeRequest()
@@ -99,12 +117,20 @@ class AttributeControllerTest extends Specification with AfterAll {
       status(result) shouldEqual NOT_FOUND
     }
 
-    "retrieve attributes for user in cookie" in {
+    "retrieve membership attributes for user in cookie" in {
       val req = FakeRequest().withCookies(validUserCookie)
       val result: Future[Result] = controller.membership(req)
 
       verifySuccessfulResult(result)
     }
+
+    "retrieve all the attributes for user in cookie" in {
+      val req = FakeRequest().withCookies(validUserCookie)
+      val result: Future[Result] = controller.attributes(req)
+
+      verifyFullSuccessfullResult(result)
+    }
+
   }
 
   override def afterAll() = as.shutdown()

--- a/membership-attribute-service/test/models/AttributesTest.scala
+++ b/membership-attribute-service/test/models/AttributesTest.scala
@@ -19,21 +19,21 @@ class AttributesTest extends Specification {
       }
 
       "false if the user is a Contributor but not a member" in {
-        attrs.copy(Tier = None, ContributionFrequency = Some("Monthly Contributor")).isPaidTier shouldEqual false
+        attrs.copy(Tier = None, ContributionPaymentPlan = Some("Monthly Contributor")).isPaidTier shouldEqual false
       }
     }
 
     "isContributor returns" should {
       "true if the user is a contributor" in {
-        attrs.copy(ContributionFrequency = Some("Monthly Contribution")).isContributor shouldEqual true
+        attrs.copy(ContributionPaymentPlan = Some("Monthly Contribution")).isContributor shouldEqual true
       }
 
       "true if the user is a contributor and a Member" in {
-        attrs.copy(Tier = Some("Friend"), ContributionFrequency = Some("Monthly Contribution")).isContributor shouldEqual true
+        attrs.copy(Tier = Some("Friend"), ContributionPaymentPlan = Some("Monthly Contribution")).isContributor shouldEqual true
       }
 
       "false if the user is not a Contributor but a member" in {
-        attrs.copy(Tier = Some("Friend"), ContributionFrequency = None).isContributor shouldEqual false
+        attrs.copy(Tier = Some("Friend"), ContributionPaymentPlan = None).isContributor shouldEqual false
       }
     }
 

--- a/membership-attribute-service/test/repositories/DynamoAttributeServiceTest.scala
+++ b/membership-attribute-service/test/repositories/DynamoAttributeServiceTest.scala
@@ -46,7 +46,13 @@ class DynamoAttributeServiceTest extends Specification {
   "get" should {
     "retrieve attributes for given user" in {
       val userId = UUID.randomUUID().toString
-      val attributes = Attributes(userId, Tier = Some("Patron"), MembershipNumber =  Some("abc"), ContributionFrequency = Some("Monthly Contribution"), MembershipJoinDate = Some(new LocalDate(2017, 6, 13)))
+      val attributes = Attributes(
+        userId,
+        Tier = Some("Patron"),
+        MembershipNumber =  Some("abc"),
+        ContributionPaymentPlan = Some("Monthly Contribution"),
+        MembershipJoinDate = Some(new LocalDate(2017, 6, 13)))
+
       val result = for {
         insertResult <- repo.set(attributes)
         retrieved <- repo.get(userId)


### PR DESCRIPTION
# Summary
In order to have backwards compatibility, this PR removes all the contributor information from the `/me/membership` endpoint and keeps it only in `/me`.
Additionally, the field `ContributionFrequency` has been renamed to `ContributionPaymentPlan` and the `contributor`  field inside content access object was change to recurringContributor.

This PR is a follow-up to https://github.com/guardian/members-data-api/pull/191

# Responses
Therefore the endpoints will return for a user who is a recurring contributor and a member:

## Only recurring contributor

### `/me/membership`

**Status Code:** `404`
```
{
    "message": "Not found",
    "details": "User was found but they are not a member",
    "statusCode": 404
}
```
### `/me`
**Status Code:** `200`
```
{
    "userId": "30000600",
    "contributionPaymentPlan": "Monthly Contribution",
    "contentAccess": {
        "member": false,
        "paidMember": false,
        "recurringContributor": true
    }
}
```
## Only a member

### `/me/membership`

```
{
    "userId": "30000602",
    "tier": "Supporter",
    "membershipNumber": "1234",
    "contentAccess": {
        "member": true,
        "paidMember": true
    }
}
```
### `/me`
```
{
    "userId": "30000602",
    "tier": "Supporter",
    "membershipNumber": "1234",
    "cardExpirationMonth": 12,
    "cardExpirationYear": 2042,
    "membershipJoinDate": "2017-06-20",
    "contentAccess": {
        "member": true,
        "paidMember": true,
        "recurringContributor": false
    }
}
```

## Member and contributor
### `/me/membership`
```
{
   "userId": "30000602",
   "tier": "Supporter",
   "membershipNumber": "324145",
   "contentAccess": {
      "member": true,
      "paidMember": true
   }
}
```
### `/me`
```
{
   "userId": "30000602",
   "tier": "Supporter",
   "membershipNumber": "324145",
   "cardExpirationMonth": 12,
   "cardExpirationYear": 2042,
   "contributionPaymentPlan": "Monthly Contribution",
   "membershipJoinDate": "2017-06-20",
   "contentAccess": {
      "member": true,
      "paidMember": true,
      "recurringContributor": true
   }
}
```