### PR TITLE
Support for storing card expiry dates for both membership and recurring contributions

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -95,7 +95,7 @@ class AttributeController extends Controller with LazyLogging {
           UserId = identityId,
           Tier = memSub.map(_.plan.charges.benefit.id),
           MembershipNumber = contact.regNumber,
-          ContributionPaymentPlan = conSub.map(_.plan.name),
+          RecurringContributionPaymentPlan = conSub.map(_.plan.name),
           MembershipJoinDate = memSub.map(_.startDate)
         )
         res <- EitherT(tp.attrService.update(attributes).map(\/.right))
@@ -107,7 +107,7 @@ class AttributeController extends Controller with LazyLogging {
         ApiErrors.badRequest(error)
       },
       { attributes =>
-        logger.info(s"${attributes.UserId} -> ${attributes.Tier} || ${attributes.ContributionPaymentPlan}")
+        logger.info(s"${attributes.UserId} -> ${attributes.Tier} || ${attributes.RecurringContributionPaymentPlan}")
         Ok(Json.obj("updated" -> true))
       }
     )

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -46,7 +46,7 @@ case class Attributes(
   MembershipNumber: Option[String] = None,
   AdFree: Option[Boolean] = None,
   Wallet: Option[Wallet] = None,
-  ContributionPaymentPlan: Option[String] = None,
+  RecurringContributionPaymentPlan: Option[String] = None,
   MembershipJoinDate: Option[LocalDate] = None
 ) {
 
@@ -59,7 +59,7 @@ case class Attributes(
   lazy val isStaffTier = Tier.exists(_.equalsIgnoreCase("staff"))
   lazy val isPaidTier = isSupporterTier || isPartnerTier || isPatronTier || isStaffTier
   lazy val isAdFree = AdFree.exists(identity)
-  lazy val isContributor = ContributionPaymentPlan.isDefined
+  lazy val isContributor = RecurringContributionPaymentPlan.isDefined
 
   lazy val contentAccess = ContentAccess(member = isPaidTier || isFriendTier, paidMember = isPaidTier, recurringContributor = isContributor) // we want to include staff!
 }
@@ -72,7 +72,7 @@ object Attributes {
     (__ \ "membershipNumber").writeNullable[String] and
     (__ \ "adFree").writeNullable[Boolean] and
     (__ \ "wallet").writeNullable[Wallet](Wallet.jsWrite) and
-    (__ \ "contributionPaymentPlan").writeNullable[String] and
+    (__ \ "recurringContributionPaymentPlan").writeNullable[String] and
     (__ \ "membershipJoinDate").writeNullable[LocalDate]
   )(unlift(Attributes.unapply)).addField("contentAccess", _.contentAccess)
 

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -18,7 +18,7 @@ object ContentAccess {
 }
 
 case class CardDetails(last4: String, expirationMonth: Int, expirationYear: Int, forProduct: String) {
-  val asLocalDate = new LocalDate(expirationYear, expirationMonth, 1).plusMonths(1).minusDays(1)
+  def asLocalDate: LocalDate = new LocalDate(expirationYear, expirationMonth, 1).plusMonths(1).minusDays(1)
 }
 
 object CardDetails {

--- a/membership-attribute-service/app/models/Features.scala
+++ b/membership-attribute-service/app/models/Features.scala
@@ -17,12 +17,17 @@ object Features {
     )
 
   def fromAttributes(attributes: Attributes) = {
+    // TODO - confirm which notification we're doing first: 'your card is expiring soon' or 'your card has expired'
+
+    // It's too confusing to tell the customer about multiple card expirations, so just take the first
+    val maybeExpiredCard = attributes.Wallet.flatMap(_.expiredCards.headOption)
+
     Features(
       userId = Some(attributes.UserId),
       adFree = attributes.isAdFree,
       adblockMessage = !attributes.isPaidTier,
-      cardHasExpired = attributes.maybeCardHasExpired,
-      cardExpires = attributes.cardExpires,
+      cardHasExpiredForProduct = maybeExpiredCard.map(_.forProduct),
+      cardExpiredOn = maybeExpiredCard.map(_.asLocalDate),
       membershipJoinDate = attributes.MembershipJoinDate
     )
   }
@@ -34,7 +39,7 @@ case class Features(
   userId: Option[String],
   adFree: Boolean,
   adblockMessage: Boolean,
-  cardHasExpired: Option[Boolean],
-  cardExpires: Option[LocalDate],
+  cardHasExpiredForProduct: Option[String],
+  cardExpiredOn: Option[LocalDate],
   membershipJoinDate: Option[LocalDate]
 )

--- a/membership-attribute-service/app/services/ScanamoAttributeService.scala
+++ b/membership-attribute-service/app/services/ScanamoAttributeService.scala
@@ -48,7 +48,7 @@ class ScanamoAttributeService(client: AmazonDynamoDBAsyncClient, table: String)
     List(
       scanamoSetOpt('Tier, attributes.Tier),
       scanamoSetOpt('MembershipNumber -> attributes.MembershipNumber),
-      scanamoSetOpt('ContributionPaymentPlan -> attributes.ContributionPaymentPlan),
+      scanamoSetOpt('RecurringContributionPaymentPlan -> attributes.RecurringContributionPaymentPlan),
       scanamoSetOpt('Wallet -> attributes.Wallet),
       scanamoSetOpt('MembershipJoinDate -> attributes.MembershipJoinDate)
     ).flatten match {

--- a/membership-attribute-service/app/services/ScanamoAttributeService.scala
+++ b/membership-attribute-service/app/services/ScanamoAttributeService.scala
@@ -1,19 +1,17 @@
 package services
 
-import models.Attributes
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
-import com.amazonaws.services.dynamodbv2.model.{DeleteItemResult, PutItemResult, UpdateItemResult}
-import com.gu.memsub.Benefit.Contributor
+import com.amazonaws.services.dynamodbv2.model.{DeleteItemResult, PutItemResult}
+import com.gu.scanamo._
+import com.gu.scanamo.error.{DynamoReadError, MissingProperty}
+import com.gu.scanamo.syntax.{set => scanamoSet, _}
+import com.gu.scanamo.update.UpdateExpression
+import com.typesafe.scalalogging.LazyLogging
+import models.Attributes
+import org.joda.time.LocalDate
 import play.api.libs.concurrent.Execution.Implicits._
 
 import scala.concurrent.Future
-import com.gu.scanamo.syntax._
-import com.gu.scanamo._
-import com.gu.scanamo.error.{DynamoReadError, MissingProperty}
-import com.gu.scanamo.syntax.{set => scanamoSet}
-import com.gu.scanamo.update.UpdateExpression
-import com.typesafe.scalalogging.LazyLogging
-import org.joda.time.LocalDate
 
 class ScanamoAttributeService(client: AmazonDynamoDBAsyncClient, table: String)
     extends AttributeService with LazyLogging {
@@ -51,8 +49,7 @@ class ScanamoAttributeService(client: AmazonDynamoDBAsyncClient, table: String)
       scanamoSetOpt('Tier, attributes.Tier),
       scanamoSetOpt('MembershipNumber -> attributes.MembershipNumber),
       scanamoSetOpt('ContributionPaymentPlan -> attributes.ContributionPaymentPlan),
-      scanamoSetOpt('CardExpirationMonth -> attributes.CardExpirationMonth),
-      scanamoSetOpt('CardExpirationYear -> attributes.CardExpirationYear),
+      scanamoSetOpt('Wallet -> attributes.Wallet),
       scanamoSetOpt('MembershipJoinDate -> attributes.MembershipJoinDate)
     ).flatten match {
       case first :: remaining =>

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -33,7 +33,7 @@ class AttributeControllerTest extends Specification with AfterAll {
       membershipCard = Some(CardDetails("1234", 5, 2017, "membership"))
     )),
     MembershipJoinDate = Some(new LocalDate(2017, 5, 13)),
-    ContributionPaymentPlan = Some("Monthly Contribution")
+    RecurringContributionPaymentPlan = Some("Monthly Contribution")
   )
 
   private val validUserCookie = Cookie("validUser", "true")

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -143,7 +143,7 @@ class AttributeControllerTest extends Specification with AfterAll {
                    |   },
                    |   "adFree": false,
                    |   "membershipJoinDate": "2017-05-13",
-                   |   "contributionPaymentPlan":"Monthly Contribution",
+                   |   "recurringContributionPaymentPlan":"Monthly Contribution",
                    |   "contentAccess": {
                    |     "member": true,
                    |     "paidMember": true,

--- a/membership-attribute-service/test/models/AttributesTest.scala
+++ b/membership-attribute-service/test/models/AttributesTest.scala
@@ -37,12 +37,14 @@ class AttributesTest extends Specification {
       }
     }
 
-    "maybeCardHasExpired returns" should {
-      "true if the card expiry is in the past" in {
-        attrs.copy(CardExpirationMonth = Some(1), CardExpirationYear = Some(2017)).maybeCardHasExpired shouldEqual Some(true)
+    "expiredCards returns" should {
+      "all expired cards in the wallet" in {
+        val bothCards = Seq(CardDetails("1234", 1, 2017, "foo"), CardDetails("1234", 2, 2017, "foo"))
+        Wallet(membershipCard = bothCards.headOption, recurringContributionCard = bothCards.tail.headOption).expiredCards shouldEqual bothCards
       }
-      "false if the card expiry is in the past" in {
-        attrs.copy(CardExpirationMonth = Some(1), CardExpirationYear = Some(3000)).maybeCardHasExpired shouldEqual Some(false)
+      "only the expired card in the wallet" in {
+        val bothCards = Seq(CardDetails("1234", 1, 2017, "foo"), CardDetails("1234", 2, 3000, "foo"))
+        Wallet(membershipCard = bothCards.headOption, recurringContributionCard = bothCards.tail.headOption).expiredCards shouldEqual bothCards.headOption.toSeq
       }
     }
   }

--- a/membership-attribute-service/test/models/AttributesTest.scala
+++ b/membership-attribute-service/test/models/AttributesTest.scala
@@ -19,21 +19,21 @@ class AttributesTest extends Specification {
       }
 
       "false if the user is a Contributor but not a member" in {
-        attrs.copy(Tier = None, ContributionPaymentPlan = Some("Monthly Contributor")).isPaidTier shouldEqual false
+        attrs.copy(Tier = None, RecurringContributionPaymentPlan = Some("Monthly Contributor")).isPaidTier shouldEqual false
       }
     }
 
     "isContributor returns" should {
       "true if the user is a contributor" in {
-        attrs.copy(ContributionPaymentPlan = Some("Monthly Contribution")).isContributor shouldEqual true
+        attrs.copy(RecurringContributionPaymentPlan = Some("Monthly Contribution")).isContributor shouldEqual true
       }
 
       "true if the user is a contributor and a Member" in {
-        attrs.copy(Tier = Some("Friend"), ContributionPaymentPlan = Some("Monthly Contribution")).isContributor shouldEqual true
+        attrs.copy(Tier = Some("Friend"), RecurringContributionPaymentPlan = Some("Monthly Contribution")).isContributor shouldEqual true
       }
 
       "false if the user is not a Contributor but a member" in {
-        attrs.copy(Tier = Some("Friend"), ContributionPaymentPlan = None).isContributor shouldEqual false
+        attrs.copy(Tier = Some("Friend"), RecurringContributionPaymentPlan = None).isContributor shouldEqual false
       }
     }
 

--- a/membership-attribute-service/test/repositories/DynamoAttributeServiceTest.scala
+++ b/membership-attribute-service/test/repositories/DynamoAttributeServiceTest.scala
@@ -50,7 +50,7 @@ class DynamoAttributeServiceTest extends Specification {
         userId,
         Tier = Some("Patron"),
         MembershipNumber =  Some("abc"),
-        ContributionPaymentPlan = Some("Monthly Contribution"),
+        RecurringContributionPaymentPlan = Some("Monthly Contribution"),
         MembershipJoinDate = Some(new LocalDate(2017, 6, 13)))
 
       val result = for {


### PR DESCRIPTION
Updated the Attributes and Features models to contain a grouping of cards rather than just one, as an Attributes record now relates to multiple Zuora subscriptions/billing accounts.

I've also used this opportunity to tweak the /features endpoint to list which product has an expired card and what the expiry date was. This means we no longer output non-expired card expiry dates via that endpoint (a tiny bit safer).

There are a few TODOs dotted around which explain how we'll merge the Salesforce hook with the /update-attributes endpoint, so that there's only one code path updating Dynamo.

cc @svillafe @pvighi @lmath @johnduffell @rupertbates @rtyley 