### PR TITLE
Added a new error type in the APIErros Object.

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -31,7 +31,7 @@ class AttributeController extends Controller with LazyLogging {
     def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) = {
       request.headers.get("Authorization") match {
         case Some(header) if keys.contains(header) => block(request)
-        case _ => Future.successful(Forbidden("Invalid API key"))
+        case _ => Future.successful(ApiErrors.forbidden)
       }
     }
   }

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -31,7 +31,7 @@ class AttributeController extends Controller with LazyLogging {
     def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) = {
       request.headers.get("Authorization") match {
         case Some(header) if keys.contains(header) => block(request)
-        case _ => Future.successful(ApiErrors.forbidden)
+        case _ => Future.successful(ApiErrors.invalidApiKey)
       }
     }
   }

--- a/membership-attribute-service/app/models/ApiErrors.scala
+++ b/membership-attribute-service/app/models/ApiErrors.scala
@@ -34,4 +34,10 @@ object ApiErrors {
     details = "Failed to authenticate",
     statusCode = 401
   )
+
+  val forbidden = ApiError(
+    message = "Forbidden",
+    details = "Invalid API key",
+    statusCode = 403
+  )
 }

--- a/membership-attribute-service/app/models/ApiErrors.scala
+++ b/membership-attribute-service/app/models/ApiErrors.scala
@@ -35,7 +35,7 @@ object ApiErrors {
     statusCode = 401
   )
 
-  val forbidden = ApiError(
+  val invalidApiKey = ApiError(
     message = "Forbidden",
     details = "Invalid API key",
     statusCode = 403


### PR DESCRIPTION
## Why do we need this? 
Currently in the case of an invalid API key for the sync attributes endpoint, we are returning a plain text saying `Invalid API key`. This PR change that by returning a JSON. We keep returning `HTTP Status code 403`.

### Old response:
**HTTP Status Code**  403
``` 
Invalid API key
```


### New response
**HTTP Status Code**  403

``` JSON
{
    "message": "Forbidden",
    "details": "Invalid API key",
    "statusCode": 403
}
```

## The changes 
* New API Error
* Changed the returning error for `/user-attributes/:user_id`

## Related PRs:
https://github.com/guardian/members-data-api/pull/191
https://github.com/guardian/members-data-api/pull/200


