### PR TITLE
log much more detail when things fail in mma

### DIFF
--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -1,26 +1,28 @@
 package controllers
+import actions._
 import play.api.libs.concurrent.Execution.Implicits._
 import services.{AuthenticationService, IdentityAuthService}
 import com.gu.memsub._
-import json.PaymentCardUpdateResultWriters._
+import com.gu.memsub.subsv2.{Subscription, SubscriptionPlan}
+import com.gu.memsub.subsv2.reads.ChargeListReads._
+import com.gu.memsub.subsv2.reads.SubPlanReads
+import com.gu.memsub.subsv2.reads.SubPlanReads._
 import com.gu.services.model.PaymentDetails
+import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
+import json.PaymentCardUpdateResultWriters._
+import models.AccountDetails._
 import models.ApiErrors._
 import play.api.data.Form
 import play.api.data.Forms._
 import play.api.libs.json.Json
 import play.api.mvc.Results._
 import play.filters.cors.CORSActionBuilder
-import com.gu.memsub.subsv2.reads.SubPlanReads._
-import com.gu.memsub.subsv2.reads.ChargeListReads._
-import com.gu.memsub.subsv2.SubscriptionPlan
-import scalaz.std.scalaFuture._
+
 import scala.concurrent.Future
-import models.AccountDetails._
-import scalaz.OptionT
-import actions._
-import com.gu.memsub.subsv2.reads.SubPlanReads
-import com.typesafe.scalalogging.LazyLogging
+import scalaz.{-\/, EitherT, OptionT, \/, \/-}
+import scalaz.std.scalaFuture._
+import scalaz.syntax.std.option._
 
 class AccountController extends LazyLogging {
 
@@ -35,34 +37,38 @@ class AccountController extends LazyLogging {
     val tp = request.touchpoint
 
     (for {
-      user <- OptionT(Future.successful(authenticationService.userId))
-      sfUser <- OptionT(tp.contactRepo.get(user))
-      subscription <- OptionT(tp.subService.current[P](sfUser).map(_.headOption))
-      stripeCardToken <- OptionT(Future.successful(updateForm.bindFromRequest().value))
-      updateResult <- OptionT(tp.paymentService.setPaymentCardWithStripeToken(subscription.accountId, stripeCardToken))
+      user <- EitherT(Future.successful(authenticationService.userId \/> "no identity cookie for user"))
+      sfUser <- EitherT(tp.contactRepo.get(user).map(_ \/> s"couldn't read contact from SF for $user (TODO check the separate ERROR to find out why)"))
+      subscription <- EitherT(tp.subService.current[P](sfUser).map(_.headOption).map (_ \/> s"no current subscriptions for the sfUser $sfUser"))
+      stripeCardToken <- EitherT(Future.successful(updateForm.bindFromRequest().value \/> "no card token submitted with request"))
+      updateResult <- EitherT(tp.paymentService.setPaymentCardWithStripeToken(subscription.accountId, stripeCardToken).map(_ \/> "something missing when try to zuora payment card"))
     } yield updateResult match {
       case success: CardUpdateSuccess => Ok(Json.toJson(success))
       case failure: CardUpdateFailure => Forbidden(Json.toJson(failure))
-    }).run.map(_.getOrElse(notFound))
+    }).run.map {
+      case -\/(message) =>
+        logger.warn(s"didn't update card, $message")
+        notFound
+      case \/-(result) => result
+    }
   }
 
   def paymentDetails[P <: SubscriptionPlan.Paid : SubPlanReads, F <: SubscriptionPlan.Free : SubPlanReads] = mmaAction.async { implicit request =>
     val maybeUserId = authenticationService.userId
     logger.info(s"Attempting to retrieve payment details for identity user: $maybeUserId")
     (for {
-      user <- OptionT(Future.successful(maybeUserId))
-      contact <- OptionT(request.touchpoint.contactRepo.get(user))
-      sub <- OptionT(request.touchpoint.subService.either[F, P](contact))
-      details <- OptionT(request.touchpoint.paymentService.paymentDetails(sub).map[Option[PaymentDetails]](Some(_)))
-    } yield (contact, details).toResult).run.map { maybeResult => maybeResult match {
-        case Some(result) => {
-          logger.info(s"Successfully retrieved payment details result for identity user: $maybeUserId")
-          result
-        }
-        case None => {
-          logger.info(s"Unable to retrieve payment details result for identity user $maybeUserId")
-          Ok(Json.obj())
-        }
+      user <- EitherT(Future.successful(maybeUserId \/> "no identity cookie for user"))
+      contact <- EitherT(request.touchpoint.contactRepo.get(user).map(_ \/> s"couldn't read contact from SF for $user (TODO check the separate ERROR to find out why)"))
+      sub <- EitherT(request.touchpoint.subService.either[F, P](contact).map(_ \/> s"couldn't read sub from zuora for crmId ${contact.salesforceAccountId} (TODO check the separate WARN to find out why)"))
+      details <- EitherT(request.touchpoint.paymentService.paymentDetails(sub).map[\/[String, PaymentDetails]](\/.right))
+    } yield (contact, details).toResult).run.map {
+      case \/-(result) => {
+        logger.info(s"Successfully retrieved payment details result for identity user: $maybeUserId")
+        result
+      }
+      case -\/(message) => {
+        logger.warn(s"Unable to retrieve payment details result for identity user $maybeUserId due to $message")
+        Ok(Json.obj())
       }
     }
   }


### PR DESCRIPTION
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
At present, when users complain that the profile tab doesn't work, we can only find out from the logs that they made a request at a certain time, and whether it worked or not.  We can't find the detail of what went wrong in any case other than payment details wrong (credit card didn't validate etc).  There are a couple of places where it would spit out a separate message saying things failed.
This means we have to poke around in zuora etc to find some wrong looking data when we get a report.
This PR changes it so that any line in the for comprehension will return a proper message if it fails, so we know where things went wrong.

### trello card/screenshot/json/related PRs etc
I introduced an artificial failure on a test user and this appeared in the logs
`WARN: Unable to retrieve payment details result for identity user Some(30000594) due to couldn't read sub from zuora for crmId 001g000001h0T50AAE (TODO check the separate WARN to find out why)`


@jacobwinch @paulbrown1982 @pvighi @lmath @michaelwmcnamara @AWare 