### PR TITLE
Dont' log warnings if a user has identity but not membership

### DIFF
--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -70,7 +70,7 @@ class AccountController extends LazyLogging {
         Ok(Json.obj())
       case -\/(message) =>
         logger.warn(s"Unable to retrieve payment details result for identity user $maybeUserId due to $message")
-        Ok(Json.obj())
+        InternalServerError("Failed to retrieve payment details due to an internal error")
     }
   }
 

--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -38,7 +38,7 @@ class AccountController extends LazyLogging {
 
     (for {
       user <- EitherT(Future.successful(authenticationService.userId \/> "no identity cookie for user"))
-      sfUser <- EitherT(tp.contactRepo.get(user).map(_ \/> s"couldn't read contact from SF for $user (TODO check the separate ERROR to find out why)"))
+      sfUser <- EitherT(tp.contactRepo.get(user).map(_.flatMap(_ \/> s"no SF user $user")))
       subscription <- EitherT(tp.subService.current[P](sfUser).map(_.headOption).map (_ \/> s"no current subscriptions for the sfUser $sfUser"))
       stripeCardToken <- EitherT(Future.successful(updateForm.bindFromRequest().value \/> "no card token submitted with request"))
       updateResult <- EitherT(tp.paymentService.setPaymentCardWithStripeToken(subscription.accountId, stripeCardToken).map(_ \/> "something missing when try to zuora payment card"))
@@ -57,19 +57,20 @@ class AccountController extends LazyLogging {
     val maybeUserId = authenticationService.userId
     logger.info(s"Attempting to retrieve payment details for identity user: $maybeUserId")
     (for {
-      user <- EitherT(Future.successful(maybeUserId \/> "no identity cookie for user"))
-      contact <- EitherT(request.touchpoint.contactRepo.get(user).map(_ \/> s"couldn't read contact from SF for $user (TODO check the separate ERROR to find out why)"))
-      sub <- EitherT(request.touchpoint.subService.either[F, P](contact).map(_ \/> s"couldn't read sub from zuora for crmId ${contact.salesforceAccountId} (TODO check the separate WARN to find out why)"))
-      details <- EitherT(request.touchpoint.paymentService.paymentDetails(sub).map[\/[String, PaymentDetails]](\/.right))
-    } yield (contact, details).toResult).run.map {
-      case \/-(result) => {
+      user <- OptionEither.liftFutureOption(maybeUserId \/> "no identity cookie for user")
+      contact <- OptionEither(request.touchpoint.contactRepo.get(user))
+      sub <- OptionEither.liftOption(request.touchpoint.subService.either[F, P](contact).map(_ \/> s"couldn't read sub from zuora for crmId ${contact.salesforceAccountId} (TODO check the separate WARN to find out why)"))
+      details <- OptionEither.liftOption(request.touchpoint.paymentService.paymentDetails(sub).map[\/[String, PaymentDetails]](\/.right))
+    } yield (contact, details).toResult).run.run.map {
+      case \/-(Some(result)) =>
         logger.info(s"Successfully retrieved payment details result for identity user: $maybeUserId")
         result
-      }
-      case -\/(message) => {
+      case \/-(None) =>
+        logger.info(s"identity user doesn't exist in SF: $maybeUserId")
+        Ok(Json.obj())
+      case -\/(message) =>
         logger.warn(s"Unable to retrieve payment details result for identity user $maybeUserId due to $message")
         Ok(Json.obj())
-      }
     }
   }
 
@@ -79,4 +80,20 @@ class AccountController extends LazyLogging {
   def membershipDetails = paymentDetails[SubscriptionPlan.PaidMember, SubscriptionPlan.FreeMember]
   def monthlyContributionDetails = paymentDetails[SubscriptionPlan.Contributor, Nothing]
   def digitalPackDetails = paymentDetails[SubscriptionPlan.Digipack, Nothing]
+}
+
+// this is helping us stack future/either/option
+object OptionEither {
+
+  type FutureEither[X] = EitherT[Future, String, X]
+
+  def apply[A](m: Future[\/[String, Option[A]]]): OptionT[FutureEither, A] =
+    OptionT[FutureEither, A](EitherT[Future, String, Option[A]](m))
+
+  def liftOption[A](x: Future[\/[String, A]]): OptionT[FutureEither, A] =
+    apply(x.map(_.map[Option[A]](Some.apply)))
+
+  def liftFutureOption[A](x: \/[String, A]): OptionT[FutureEither, A] =
+    apply(Future.successful(x.map[Option[A]](Some.apply)))
+
 }

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -85,7 +85,7 @@ class AttributeController extends Controller with LazyLogging {
     val result: EitherT[Future, String, Attributes] =
       // TODO - add the Stripe lookups for the Contribution and Membership cards to this flow, then we can deprecate the Salesforce hook.
       for {
-        contact <- EitherT(tp.contactRepo.get(identityId).map(_ \/> s"No contact for $identityId"))
+        contact <- EitherT(tp.contactRepo.get(identityId).map(_.flatMap(_ \/> s"No contact for $identityId")))
         memSubF = EitherT[Future, String, Option[Subscription[SubscriptionPlan.Member]]](tp.subService.current[SubscriptionPlan.Member](contact).map(a => \/.right(a.headOption)))
         conSubF = EitherT[Future, String, Option[Subscription[SubscriptionPlan.Contributor]]](tp.subService.current[SubscriptionPlan.Contributor](contact).map(a => \/.right(a.headOption)))
         memSub <- memSubF

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSNS = "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.428-SNAPSHOT"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.432"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.0"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSNS = "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.420"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.428-SNAPSHOT"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.0"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
Further to https://github.com/guardian/members-data-api/pull/203 I found that we were logging a warning every time someone visited the profile page with an identity account but no membership.
This is a completely valid situation, and made the logs unclear due to logging a lot of warnings.  This doesn't really contribute to the goal of understanding what the problems are with the data as it was confusing matters more.
### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
This PR updates it so that it uses the error returned from salesforce `get...` if any, or if the lookup just didn't produce anything it just logs a simple info to that effect.
### trello card/screenshot/json/related PRs etc
depends on https://github.com/guardian/membership-common/pull/503

@lmath @paulbrown1982 @jacobwinch @michaelwmcnamara 