### PR TITLE
Endpoint to lookup attributes based on calls to Zuora

### DIFF
--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -16,7 +16,7 @@ import com.gu.stripe.StripeService
 import com.gu.touchpoint.TouchpointBackendConfig
 import com.gu.zuora.rest.SimpleClient
 import com.gu.zuora.soap.ClientWithFeatureSupplier
-import com.gu.zuora.{ZuoraService, rest}
+import com.gu.zuora.{ZuoraRestService, ZuoraService, rest}
 import configuration.Config
 import org.joda.time.LocalDate
 import services.IdentityService.IdentityConfig
@@ -65,7 +65,8 @@ class TouchpointComponents(stage: String)(implicit system: ActorSystem) {
   lazy val behaviourService: BehaviourService = new ScanamoBehaviourService(new AmazonDynamoDBAsyncClient(com.gu.aws.CredentialsProvider).withRegion(Regions.EU_WEST_1), dynamoBehaviourTable)
   lazy val snsGiraffeService: SNSGiraffeService = SNSGiraffeService(giraffeSns)
   lazy val zuoraService = new ZuoraService(soapClient)
-  lazy val simpleClient = new SimpleClient[Future](tpConfig.zuoraRest, RequestRunners.futureRunner)
+  implicit lazy val simpleClient = new SimpleClient[Future](tpConfig.zuoraRest, RequestRunners.futureRunner)
+  lazy val zuoraRestService = new ZuoraRestService[Future]()
   lazy val catalogService = new CatalogService[Future](productIds, simpleClient, Await.result(_, 10.seconds), stage)
 
   lazy val futureCatalog: Future[CatalogMap] = catalogService.catalog.map(_.fold[CatalogMap](error => {println(s"error: ${error.list.mkString}"); Map()}, _.map))

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -96,7 +96,7 @@ class AttributeController extends Controller with LazyLogging {
         case Some(id) =>
           attributesFromZuora(id, request.touchpoint.zuoraRestService, request.touchpoint.subService).map {
             case Some(attrs) =>
-              logger.info(s"$id is a contributor - $endpointDescription - $attrs")
+              logger.info(s"Successfully retrieved attributes from Zuora for user $id: $attrs")
               attrs
             case _ => notFound
           }

--- a/membership-attribute-service/app/services/AttributesMaker.scala
+++ b/membership-attribute-service/app/services/AttributesMaker.scala
@@ -1,0 +1,48 @@
+package services
+
+import com.gu.zuora.ZuoraRestService.RestSubscriptions
+import com.typesafe.scalalogging.LazyLogging
+import models.Attributes
+import org.joda.time.LocalDate
+
+class AttributesMaker extends LazyLogging {
+
+  private case class BasicSubscriptionInfo(productName: String, ratePlanName: String, contractEffectiveDate: String)
+
+  def attributes(userId: String, subs: List[RestSubscriptions]): Option[Attributes] = {
+    logger.info(s"SUBS SUBS SUBS: $subs")
+
+    val filteredSubs = subscriptionInfo(subs)
+    val membershipSub = filteredSubs.filter(sub => isMember(sub.productName))
+    val contributionSub = filteredSubs.filter(sub => isContributor(sub.productName))
+
+    val tier = if(membershipSub.nonEmpty) Some(membershipSub.head.productName) else None
+    val membershipJoinDate = if(membershipSub.nonEmpty) Some(new LocalDate(membershipSub.head.contractEffectiveDate)) else None
+    val recurringContributionPaymentPlan = if(contributionSub.nonEmpty) Some(contributionSub.head.ratePlanName) else None
+
+    if(filteredSubs.nonEmpty)
+      Some(Attributes(
+        UserId = userId,
+        Tier = tier,
+        RecurringContributionPaymentPlan = recurringContributionPaymentPlan,
+        MembershipJoinDate = membershipJoinDate
+        )
+      )
+    else None
+  }
+
+  private def isMember(productName: String): Boolean = List("Supporter", "Partner", "Patron").contains(productName)
+  private def isContributor(productName: String): Boolean = "Contributor" == productName
+  private def isMemberOrContributor(productName: String) = isContributor(productName) || isMember(productName)
+
+  private def subscriptionInfo(subs: List[RestSubscriptions]): Seq[BasicSubscriptionInfo] = {
+
+    val flatSubs: Seq[(String, String, String)] = subs.flatMap { sub => sub.subscriptions}
+      .map { restSub => (restSub.ratePlans.head.productName, restSub.ratePlans.head.ratePlanName, restSub.contractEffectiveDate)}
+
+    //todo surely this is convoluted
+    flatSubs.map(s => BasicSubscriptionInfo(s._1, s._2, s._3)).filter(subInfo => isMemberOrContributor(subInfo.productName))
+  }
+}
+
+object AttributesMaker extends AttributesMaker

--- a/membership-attribute-service/app/services/AttributesMaker.scala
+++ b/membership-attribute-service/app/services/AttributesMaker.scala
@@ -9,7 +9,7 @@ import org.joda.time.LocalDate
 
 class AttributesMaker extends LazyLogging {
 
-  def attributes(userId: String, subs: List[Subscription[AnyPlan]], forDate: LocalDate): Option[Attributes] = {
+  def attributes(identityId: String, subs: List[Subscription[AnyPlan]], forDate: LocalDate): Option[Attributes] = {
 
     val groupedSubs: Map[Option[Product], List[Subscription[AnyPlan]]] = subs.groupBy(subscription => GetCurrentPlans(subscription, forDate).toOption.map(_.head.product))
     val membershipSub = groupedSubs.getOrElse(Some(Product.Membership), Nil)
@@ -21,7 +21,7 @@ class AttributesMaker extends LazyLogging {
 
     if(!membershipSub.isEmpty || !contributionSub.isEmpty)
       Some(Attributes(
-        UserId = userId,
+        UserId = identityId,
         Tier = tier,
         RecurringContributionPaymentPlan = recurringContributionPaymentPlan,
         MembershipJoinDate = membershipJoinDate

--- a/membership-attribute-service/app/services/AttributesMaker.scala
+++ b/membership-attribute-service/app/services/AttributesMaker.scala
@@ -1,6 +1,6 @@
 package services
 
-import com.gu.zuora.ZuoraRestService.RestSubscriptions
+import com.gu.zuora.ZuoraRestService.{RestSubscription, RestSubscriptions}
 import com.typesafe.scalalogging.LazyLogging
 import models.Attributes
 import org.joda.time.LocalDate
@@ -9,7 +9,7 @@ class AttributesMaker extends LazyLogging {
 
   private case class BasicSubscriptionInfo(productName: String, ratePlanName: String, contractEffectiveDate: String)
 
-  def attributes(userId: String, subs: List[RestSubscriptions]): Option[Attributes] = {
+  def attributes(userId: String, subs: List[RestSubscription]): Option[Attributes] = {
     logger.info(s"SUBS SUBS SUBS: $subs")
 
     val filteredSubs = subscriptionInfo(subs)
@@ -31,13 +31,13 @@ class AttributesMaker extends LazyLogging {
     else None
   }
 
-  private def isMember(productName: String): Boolean = List("Supporter", "Partner", "Patron").contains(productName)
+  private def isMember(productName: String): Boolean = List("Supporter", "Partner", "Patron", "Friend").contains(productName)
   private def isContributor(productName: String): Boolean = "Contributor" == productName
   private def isMemberOrContributor(productName: String) = isContributor(productName) || isMember(productName)
 
-  private def subscriptionInfo(subs: List[RestSubscriptions]): Seq[BasicSubscriptionInfo] = {
+  private def subscriptionInfo(subs: List[RestSubscription]): Seq[BasicSubscriptionInfo] = {
 
-    val flatSubs: Seq[(String, String, String)] = subs.flatMap { sub => sub.subscriptions}
+    val flatSubs: Seq[(String, String, String)] = subs
       .map { restSub => (restSub.ratePlans.head.productName, restSub.ratePlans.head.ratePlanName, restSub.contractEffectiveDate)}
 
     //todo surely this is convoluted

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -26,4 +26,5 @@ POST       /stripe-hook-sns                                 controllers.StripeHo
 POST       /user-attributes/:identityId                     controllers.AttributeController.updateAttributes(identityId : String)
 #The endpoint below will replace /user-attributes/me/membership in the long term
 GET        /user-attributes/me                              controllers.AttributeController.attributes
+GET        /user-attributes/zuora-lookup                    controllers.AttributeController.zuoraMe
 

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -2,10 +2,7 @@ package controllers
 
 import actions.BackendRequest
 import akka.actor.ActorSystem
-import com.gu.memsub.Subscription.AccountId
 import com.gu.scanamo.error.DynamoReadError
-import com.gu.zuora.ZuoraRestService
-import com.gu.zuora.ZuoraRestService.{AccountSummary, QueryResponse}
 import components.TouchpointComponents
 import configuration.Config
 import models.{Attributes, CardDetails, Wallet}
@@ -20,7 +17,6 @@ import play.api.test.Helpers._
 import services.{AttributeService, AuthenticationService}
 
 import scala.concurrent.Future
-import scalaz.\/
 
 class AttributeControllerTest extends Specification with AfterAll {
   implicit val as: ActorSystem = ActorSystem("test")
@@ -38,11 +34,6 @@ class AttributeControllerTest extends Specification with AfterAll {
     )),
     MembershipJoinDate = Some(new LocalDate(2017, 5, 13)),
     RecurringContributionPaymentPlan = Some("Monthly Contribution")
-  )
-
-  private val accountsQueryResponse = ZuoraRestService.QueryResponse(
-    records = List(ZuoraRestService.Record(Id = "2c92c0f85cee08f3015cf32fa5df14a1"), ZuoraRestService.Record(Id = "2c92c0f85cee08f3015cf32fa5df14a1")),
-    size = 2
   )
 
   private val validUserCookie = Cookie("validUser", "true")
@@ -68,13 +59,6 @@ class AttributeControllerTest extends Specification with AfterAll {
         override def update(attributes: Attributes) : Future[Either[DynamoReadError, Attributes]] = ???
       }
 
-//      val fakeZuoraRestService = new ZuoraRestService[Future]{
-//        override def getAccount(accountId: AccountId): Future[\/[String, AccountSummary]] = ???
-//        override def getAccounts(identityId: String): Future[\/[String, QueryResponse]] =
-//          Future.successful(if (identityId == validUserId) \/.right(accountsQueryResponse) else \/.left("error! D:"))
-//        override def addEmail(accountId: AccountId, email: String): Future[\/[String, Unit]] = ???
-//      }
-
       object components extends TouchpointComponents(Config.defaultTouchpointBackendStage) {
         override lazy val attrService = a
       }
@@ -82,7 +66,6 @@ class AttributeControllerTest extends Specification with AfterAll {
       Future(Right(new BackendRequest[A](components, request)))
     }
   }
-
 
   private val controller = new AttributeController {
     override lazy val authenticationService = fakeAuthService

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -2,7 +2,10 @@ package controllers
 
 import actions.BackendRequest
 import akka.actor.ActorSystem
+import com.gu.memsub.Subscription.AccountId
 import com.gu.scanamo.error.DynamoReadError
+import com.gu.zuora.ZuoraRestService
+import com.gu.zuora.ZuoraRestService.{AccountSummary, QueryResponse}
 import components.TouchpointComponents
 import configuration.Config
 import models.{Attributes, CardDetails, Wallet}
@@ -17,6 +20,7 @@ import play.api.test.Helpers._
 import services.{AttributeService, AuthenticationService}
 
 import scala.concurrent.Future
+import scalaz.\/
 
 class AttributeControllerTest extends Specification with AfterAll {
   implicit val as: ActorSystem = ActorSystem("test")
@@ -34,6 +38,11 @@ class AttributeControllerTest extends Specification with AfterAll {
     )),
     MembershipJoinDate = Some(new LocalDate(2017, 5, 13)),
     RecurringContributionPaymentPlan = Some("Monthly Contribution")
+  )
+
+  private val accountsQueryResponse = ZuoraRestService.QueryResponse(
+    records = List(ZuoraRestService.Record(Id = "2c92c0f85cee08f3015cf32fa5df14a1"), ZuoraRestService.Record(Id = "2c92c0f85cee08f3015cf32fa5df14a1")),
+    size = 2
   )
 
   private val validUserCookie = Cookie("validUser", "true")
@@ -59,6 +68,13 @@ class AttributeControllerTest extends Specification with AfterAll {
         override def update(attributes: Attributes) : Future[Either[DynamoReadError, Attributes]] = ???
       }
 
+      val fakeZuoraRestService = new ZuoraRestService[Future]{
+        override def getAccount(accountId: AccountId): Future[\/[String, AccountSummary]] = ???
+        override def getAccounts(identityId: String): Future[\/[String, QueryResponse]] =
+          Future.successful(if (identityId == validUserId) \/.right(accountsQueryResponse) else \/.left("error! D:"))
+        override def addEmail(accountId: AccountId, email: String): Future[\/[String, Unit]] = ???
+      }
+
       object components extends TouchpointComponents(Config.defaultTouchpointBackendStage) {
         override lazy val attrService = a
       }
@@ -66,6 +82,7 @@ class AttributeControllerTest extends Specification with AfterAll {
       Future(Right(new BackendRequest[A](components, request)))
     }
   }
+
 
   private val controller = new AttributeController {
     override lazy val authenticationService = fakeAuthService

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -68,12 +68,12 @@ class AttributeControllerTest extends Specification with AfterAll {
         override def update(attributes: Attributes) : Future[Either[DynamoReadError, Attributes]] = ???
       }
 
-      val fakeZuoraRestService = new ZuoraRestService[Future]{
-        override def getAccount(accountId: AccountId): Future[\/[String, AccountSummary]] = ???
-        override def getAccounts(identityId: String): Future[\/[String, QueryResponse]] =
-          Future.successful(if (identityId == validUserId) \/.right(accountsQueryResponse) else \/.left("error! D:"))
-        override def addEmail(accountId: AccountId, email: String): Future[\/[String, Unit]] = ???
-      }
+//      val fakeZuoraRestService = new ZuoraRestService[Future]{
+//        override def getAccount(accountId: AccountId): Future[\/[String, AccountSummary]] = ???
+//        override def getAccounts(identityId: String): Future[\/[String, QueryResponse]] =
+//          Future.successful(if (identityId == validUserId) \/.right(accountsQueryResponse) else \/.left("error! D:"))
+//        override def addEmail(accountId: AccountId, email: String): Future[\/[String, Unit]] = ???
+//      }
 
       object components extends TouchpointComponents(Config.defaultTouchpointBackendStage) {
         override lazy val attrService = a

--- a/membership-attribute-service/test/services/AttributesMakerTest.scala
+++ b/membership-attribute-service/test/services/AttributesMakerTest.scala
@@ -9,32 +9,30 @@ class AttributesMakerTest extends Specification {
 
   "attributes" should {
     val testId = "123"
-    val member = RestSubscriptions(
-      subscriptions = List(RestSubscription(
+    val member = RestSubscription(
         ratePlans = List(RestRatePlan("Supporter","Non Founder Supporter - annual")),
-        contractEffectiveDate = "2017-06-29")
-      )
+        contractEffectiveDate = "2017-06-29"
     )
 
-    val contributor = RestSubscriptions(
-      subscriptions = List(RestSubscription(
+    val friend = RestSubscription(
+        ratePlans = List(RestRatePlan("Friend","Non Founder Friend")),
+        contractEffectiveDate = "2017-06-20"
+      )
+
+
+    val contributor = RestSubscription(
         ratePlans = List(RestRatePlan("Contributor","Monthly Contribution")),
-        contractEffectiveDate = "2017-06-30")
-      )
+        contractEffectiveDate = "2017-06-30"
     )
 
-//    "return none when no subs" in {
-//        //needed??
-//    }
 
 
     "return none when only sub is digipack" in { //for now!
-      val digipack = RestSubscriptions(
-        subscriptions = List(RestSubscription(
+      val digipack = RestSubscription(
           ratePlans = List(RestRatePlan("Digital Pack","Digital Pack Monthly")),
-          contractEffectiveDate = "2017-07-04")
-        )
+          contractEffectiveDate = "2017-07-04"
       )
+
 
       AttributesMaker.attributes(testId, List(digipack)) === None
     }
@@ -81,6 +79,20 @@ class AttributesMakerTest extends Specification {
       )
       )
       AttributesMaker.attributes(testId, List(contributor, member)) === expected
+    }
+
+    "return attributes when the membership is a friend tier" in {
+      val expected = Some(Attributes(
+        UserId = testId,
+        Tier = Some("Friend"),
+        MembershipNumber = None,
+        AdFree = None,
+        Wallet = None,
+        RecurringContributionPaymentPlan = None,
+        MembershipJoinDate = Some(new LocalDate("2017-06-20"))
+      )
+      )
+      AttributesMaker.attributes(testId, List(friend)) === expected
     }
   }
 }

--- a/membership-attribute-service/test/services/AttributesMakerTest.scala
+++ b/membership-attribute-service/test/services/AttributesMakerTest.scala
@@ -1,0 +1,87 @@
+package services
+
+import com.gu.zuora.ZuoraRestService.{RestRatePlan, RestSubscription, RestSubscriptions}
+import models.Attributes
+import org.joda.time.LocalDate
+import org.specs2.mutable.Specification
+
+class AttributesMakerTest extends Specification {
+
+  "attributes" should {
+    val testId = "123"
+    val member = RestSubscriptions(
+      subscriptions = List(RestSubscription(
+        ratePlans = List(RestRatePlan("Supporter","Non Founder Supporter - annual")),
+        contractEffectiveDate = "2017-06-29")
+      )
+    )
+
+    val contributor = RestSubscriptions(
+      subscriptions = List(RestSubscription(
+        ratePlans = List(RestRatePlan("Contributor","Monthly Contribution")),
+        contractEffectiveDate = "2017-06-30")
+      )
+    )
+
+//    "return none when no subs" in {
+//        //needed??
+//    }
+
+
+    "return none when only sub is digipack" in { //for now!
+      val digipack = RestSubscriptions(
+        subscriptions = List(RestSubscription(
+          ratePlans = List(RestRatePlan("Digital Pack","Digital Pack Monthly")),
+          contractEffectiveDate = "2017-07-04")
+        )
+      )
+
+      AttributesMaker.attributes(testId, List(digipack)) === None
+    }
+
+    "return attributes when one sub is a membership" in {
+      val expected = Some(Attributes(
+          UserId = testId,
+          Tier = Some("Supporter"),
+          MembershipNumber = None,
+          AdFree = None,
+          Wallet = None,
+          RecurringContributionPaymentPlan = None,
+          MembershipJoinDate = Some(new LocalDate("2017-06-29"))
+        )
+      )
+      AttributesMaker.attributes(testId, List(member)) === expected
+
+    }
+
+    "return attributes when one sub is a recurring contribution" in {
+
+      val expected = Some(Attributes(
+          UserId = testId,
+          Tier = None,
+          MembershipNumber = None,
+          AdFree = None,
+          Wallet = None,
+          RecurringContributionPaymentPlan = Some("Monthly Contribution"),
+          MembershipJoinDate = None
+        )
+      )
+      AttributesMaker.attributes(testId, List(contributor)) === expected
+    }
+
+    "return attributes relevant to both when one sub is a contribution and the other a membership" in {
+      val expected = Some(Attributes(
+        UserId = testId,
+        Tier = Some("Supporter"),
+        MembershipNumber = None,
+        AdFree = None,
+        Wallet = None,
+        RecurringContributionPaymentPlan = Some("Monthly Contribution"),
+        MembershipJoinDate = Some(new LocalDate("2017-06-29"))
+      )
+      )
+      AttributesMaker.attributes(testId, List(contributor, member)) === expected
+    }
+  }
+}
+

--- a/membership-attribute-service/test/services/AttributesMakerTest.scala
+++ b/membership-attribute-service/test/services/AttributesMakerTest.scala
@@ -1,70 +1,112 @@
 package services
 
-import com.gu.zuora.ZuoraRestService.{RestRatePlan, RestSubscription, RestSubscriptions}
+import com.gu.i18n.Currency.GBP
+import com.gu.memsub.Benefit._
+import com.gu.memsub.Subscription.{ProductRatePlanChargeId, ProductRatePlanId, RatePlanId}
+import com.github.nscala_time.time.Implicits._
+import com.gu.memsub.{Product, Benefit, BillingPeriod, PricingSummary, Price}
+import com.gu.memsub.Subscription._
+import com.gu.memsub.subsv2._
 import models.Attributes
 import org.joda.time.LocalDate
 import org.specs2.mutable.Specification
 
+import scalaz.NonEmptyList
+
 class AttributesMakerTest extends Specification {
 
   "attributes" should {
-    val testId = "123"
-    val member = RestSubscription(
-        ratePlans = List(RestRatePlan("Supporter","Non Founder Supporter - annual")),
-        contractEffectiveDate = "2017-06-29"
+    val referenceDate = new LocalDate(2016, 10, 26)
+
+    val friendPlan = FreeSubscriptionPlan[Product.Membership, FreeCharge[Benefit.Friend.type]](
+      RatePlanId("idFriend"), ProductRatePlanId("prpi"), "Friend", "desc", "Friend", Product.Membership,FreeCharge(Friend, Set(GBP)), referenceDate
+    )
+    def supporterPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan.Supporter = PaidSubscriptionPlan[Product.Membership, PaidCharge[Benefit.Supporter.type, BillingPeriod]](
+      RatePlanId("idSupporter"), ProductRatePlanId("prpi"), "Supporter", "desc", "Supporter", Product.Membership, List.empty, PaidCharge(Supporter, BillingPeriod.Year, PricingSummary(Map(GBP -> Price(49.0f, GBP))), ProductRatePlanChargeId("bar")), None, startDate, endDate
+    )
+    def digipackPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan.Digipack = PaidSubscriptionPlan[Product.ZDigipack, PaidCharge[Benefit.Digipack.type, BillingPeriod]](
+      RatePlanId("idDigipack"), ProductRatePlanId("prpi"), "Digipack", "desc", "Digital Pack", Product.Digipack, List.empty, PaidCharge(Digipack, BillingPeriod.Year, PricingSummary(Map(GBP -> Price(119.90f, GBP))), ProductRatePlanChargeId("baz")), None, startDate, endDate
     )
 
-    val friend = RestSubscription(
-        ratePlans = List(RestRatePlan("Friend","Non Founder Friend")),
-        contractEffectiveDate = "2017-06-20"
-      )
-
-
-    val contributor = RestSubscription(
-        ratePlans = List(RestRatePlan("Contributor","Monthly Contribution")),
-        contractEffectiveDate = "2017-06-30"
+    def contributorPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan.Contributor = PaidSubscriptionPlan[Product.Contribution, PaidCharge[Benefit.Contributor.type, BillingPeriod]](
+      RatePlanId("idContributor"), ProductRatePlanId("prpi"), "Monthly Contribution", "desc", "Monthly Contribution", Product.Contribution, List.empty, PaidCharge(Contributor, BillingPeriod.Month, PricingSummary(Map(GBP -> Price(5.0f, GBP))), ProductRatePlanChargeId("bar")), None, startDate, endDate
     )
 
-
-
-    "return none when only sub is digipack" in { //for now!
-      val digipack = RestSubscription(
-          ratePlans = List(RestRatePlan("Digital Pack","Digital Pack Monthly")),
-          contractEffectiveDate = "2017-07-04"
+    def toSubscription[P <: SubscriptionPlan.AnyPlan](isCancelled: Boolean)(plans: NonEmptyList[P]): Subscription[P] = {
+      Subscription(
+        id = Id(plans.head.id.get),
+        name = Name("AS-123123"),
+        accountId = AccountId("accountId"),
+        startDate = plans.head.start,
+        acceptanceDate = plans.head.start,
+        termStartDate = plans.head.start,
+        termEndDate = plans.head.start + 1.year,
+        casActivationDate = None,
+        promoCode = None,
+        isCancelled = isCancelled,
+        hasPendingFreePlan = false,
+        plans = plans,
+        readerType = ReaderType.Direct,
+        autoRenew = true
       )
-
-
-      AttributesMaker.attributes(testId, List(digipack)) === None
     }
 
-    "return attributes when one sub is a membership" in {
-      val expected = Some(Attributes(
-          UserId = testId,
-          Tier = Some("Supporter"),
-          MembershipNumber = None,
-          AdFree = None,
-          Wallet = None,
-          RecurringContributionPaymentPlan = None,
-          MembershipJoinDate = Some(new LocalDate("2017-06-29"))
-        )
-      )
-      AttributesMaker.attributes(testId, List(member)) === expected
+    val testId = "123"
+    val digipack = toSubscription(false)(NonEmptyList(digipackPlan(referenceDate, referenceDate + 1.year)))
+    val membership = toSubscription(false)(NonEmptyList(supporterPlan(referenceDate, referenceDate + 1.year)))
+    val expiredMembership = toSubscription(false)(NonEmptyList(supporterPlan(referenceDate - 2.year, referenceDate - 1.year)))
+    val friend = toSubscription(false)(NonEmptyList(friendPlan))
+    val contributor = toSubscription(false)(NonEmptyList(contributorPlan(referenceDate, referenceDate + 1.month)))
 
+    "return none when only sub is digipack" in { //for now!
+      AttributesMaker.attributes(testId, List(digipack), referenceDate) === None
+    }
+
+    "return none when only sub is expired" in {
+      AttributesMaker.attributes(testId, List(expiredMembership), referenceDate) === None
+    }
+
+    "return attributes when there is one membership sub" in {
+      val expected = Some(Attributes(
+        UserId = testId,
+        Tier = Some("Supporter"),
+        MembershipNumber = None,
+        AdFree = None,
+        Wallet = None,
+        RecurringContributionPaymentPlan = None,
+        MembershipJoinDate = Some(referenceDate)
+      )
+      )
+      AttributesMaker.attributes(testId, List(membership), referenceDate) === expected
+    }
+
+    "return attributes when one sub is expired and one is not" in {
+      val expected = Some(Attributes(
+        UserId = testId,
+        Tier = None,
+        MembershipNumber = None,
+        AdFree = None,
+        Wallet = None,
+        RecurringContributionPaymentPlan = Some("Monthly Contribution"),
+        MembershipJoinDate = None
+      )
+      )
+
+      AttributesMaker.attributes(testId, List(expiredMembership, contributor), referenceDate) === expected
     }
 
     "return attributes when one sub is a recurring contribution" in {
-
       val expected = Some(Attributes(
-          UserId = testId,
-          Tier = None,
-          MembershipNumber = None,
-          AdFree = None,
-          Wallet = None,
-          RecurringContributionPaymentPlan = Some("Monthly Contribution"),
-          MembershipJoinDate = None
-        )
+        UserId = testId,
+        Tier = None,
+        MembershipNumber = None,
+        AdFree = None,
+        Wallet = None,
+        RecurringContributionPaymentPlan = Some("Monthly Contribution"),
+        MembershipJoinDate = None
       )
-      AttributesMaker.attributes(testId, List(contributor)) === expected
+      )
+      AttributesMaker.attributes(testId, List(contributor), referenceDate) === expected
     }
 
     "return attributes relevant to both when one sub is a contribution and the other a membership" in {
@@ -75,10 +117,10 @@ class AttributesMakerTest extends Specification {
         AdFree = None,
         Wallet = None,
         RecurringContributionPaymentPlan = Some("Monthly Contribution"),
-        MembershipJoinDate = Some(new LocalDate("2017-06-29"))
+        MembershipJoinDate = Some(referenceDate)
       )
       )
-      AttributesMaker.attributes(testId, List(contributor, member)) === expected
+      AttributesMaker.attributes(testId, List(contributor, membership), referenceDate) === expected
     }
 
     "return attributes when the membership is a friend tier" in {
@@ -89,10 +131,10 @@ class AttributesMakerTest extends Specification {
         AdFree = None,
         Wallet = None,
         RecurringContributionPaymentPlan = None,
-        MembershipJoinDate = Some(new LocalDate("2017-06-20"))
+        MembershipJoinDate = Some(referenceDate)
       )
       )
-      AttributesMaker.attributes(testId, List(friend)) === expected
+      AttributesMaker.attributes(testId, List(friend), referenceDate) === expected
     }
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSNS = "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.420"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.427-SNAPSHOT"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.0"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSNS = "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.430-SNAPSHOT"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.431"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.0"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSNS = "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.427-SNAPSHOT"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.430-SNAPSHOT"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.0"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
We'd like to explore the viability of doing lookups via Zuora (without accessing the Membership Attributes dynamo table). I prefer to split this into two PRs: this one to introduce the endpoint and another to establish how it will be used to test the viability of doing lookups via zuora at all (i.e. calling the endpoint, and being able to control/modify how much it gets called). 

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
- `GET /user-attributes/zuora-lookup` should match the response of `/user-attributes/me` except minus the membership number (this comes from salesforce)
- This is done by querying zuora to get accountids, then looking up subscriptions for each account id returned. With that information, we can build up the attributes. 

### trello card/screenshot/json/related PRs etc
[On trello](https://trello.com/c/VjKkm0Lp/228-endpoint-to-lookup-attributes-by-identity-id-based-only-on-calls-to-zuora)
Relies on [this PR in membership common](https://github.com/guardian/membership-common/pull/505/)