### PR TITLE
Better logging when getting subs from Zuora

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -32,6 +32,7 @@ import prodtest.Allocator._
 
 import scalaz.{-\/, Disjunction, DisjunctionT, EitherT, \/, \/-}
 import scalaz.syntax.std.either._
+import scalaz._, std.list._, syntax.traverse._
 
 
 class AttributeController extends Controller with LoggingWithLogstashFields {
@@ -101,7 +102,6 @@ class AttributeController extends Controller with LoggingWithLogstashFields {
         val customFields: List[LogField] = List("zuora_latency_millis" -> latency.toInt, "zuora_call" -> whichCall, "identityId" -> identityId)
         result match {
           case -\/(messageOrError) => {
-            log.error(s"Attempted $whichCall but then: ${messageOrError}")
             logWarnWithCustomFields(s"$whichCall failed with ${messageOrError}", customFields)
           }
           case \/-(_) => logInfoWithCustomFields(s"$whichCall took ${latency}ms", customFields)
@@ -115,13 +115,20 @@ class AttributeController extends Controller with LoggingWithLogstashFields {
     def queryToAccountIds(response: QueryResponse): List[AccountId] =  response.records.map(_.Id)
 
     def getSubscriptions(accountIds: List[AccountId]): Future[Disjunction[String, List[Subscription[AnyPlan]]]] = {
-      def sub(accountId: AccountId): Future[List[Subscription[AnyPlan]]] = {
+      def sub(accountId: AccountId): Future[Disjunction[String, List[Subscription[AnyPlan]]]] =
         subscriptionService.subscriptionsForAccountId[AnyPlan](accountId)(anyPlanReads)
-      }
-      val maybeSubs: Future[List[Subscription[AnyPlan]]] = Future.traverse(accountIds)(id => sub(id)).map(_.flatten)
 
-      maybeSubs map { subs =>
-        if (subs.isEmpty) \/.left(s"Error getting subscriptions for identityId $identityId") else \/.right(subs)
+      val maybeSubs: Future[Disjunction[String, List[Subscription[AnyPlan]]]] = accountIds.traverseU(id => sub(id)).map(_.sequenceU.map(_.flatten))
+
+      maybeSubs.map {
+        _.leftMap { errorMsg =>
+          log.logger.error(s"We tried getting a subscription for a user, but then ${errorMsg}")
+          errorMsg
+        } map { subs =>
+          if(subs.isEmpty)
+            log.logger.warn(s"We tried getting subs for user with identityId ${identityId} but there weren't any")
+          subs
+        }
       }
     }
 

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -126,7 +126,7 @@ class AttributeController extends Controller with LoggingWithLogstashFields {
           errorMsg
         } map { subs =>
           if(subs.isEmpty)
-            log.logger.warn(s"We tried getting subs for user with identityId ${identityId} but there weren't any")
+            log.logger.info(s"We tried getting subs for user with identityId ${identityId} but there weren't any")
           subs
         }
       }

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -122,11 +122,10 @@ class AttributeController extends Controller with LoggingWithLogstashFields {
 
       maybeSubs.map {
         _.leftMap { errorMsg =>
-          log.logger.error(s"We tried getting a subscription for a user, but then ${errorMsg}")
+          log.error(s"We tried getting a subscription for a user with identityId ${identityId}, but then ${errorMsg}")
           errorMsg
         } map { subs =>
-          if(subs.isEmpty)
-            log.logger.info(s"We tried getting subs for user with identityId ${identityId} but there weren't any")
+          log.info(s"We got subs for identityId ${identityId} from Zuora and there were ${subs.length}")
           subs
         }
       }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSNS = "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.432"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.433"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.0"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
[PR 205](https://github.com/guardian/members-data-api/pull/205) added code to do lookups via Zuora. However, when getting subscriptions both an error when calling Zuora and the user literally having no subscriptions resulted in an empty list. 

Now that we want to [actually send some traffic](https://github.com/guardian/members-data-api/pull/209) through this lookup, it has become apparent that I need to be able to identify when calls to Zuora are failing, and log an error (so that I know to reduce the traffic). Since a user may really not have any subs, then I should just log with info in this case. I initially mistakenly logged both cases as an error.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
* log an error when calls to get subscriptions from Zuora fail
* log info when a user has no subs

### trello card/screenshot/json/related PRs etc
[PR 205 - lookups via Zuora](https://github.com/guardian/members-data-api/pull/205)
[PR 507 requires the client to handle errors when getting subs from Zuora](https://github.com/guardian/membership-common/pull/507)
[PR 209 - send some traffic to zuora lookup](https://github.com/guardian/members-data-api/pull/209)