### PR TITLE
Fix logging for timed GetSubscriptions calls to Zuora

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -152,7 +152,7 @@ class AttributeController extends Controller with LoggingWithLogstashFields {
       _.leftMap { errorMsg =>
         log.info(s"Tried to get Attributes for ${identityId} but failed with $errorMsg")
         errorMsg
-      }.fold(_ => None, identity) //.getOrElse(None)
+      }.fold(_ => None, identity)
     }
   }
 

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -150,9 +150,9 @@ class AttributeController extends Controller with LoggingWithLogstashFields {
 
     attributes.run.map {
       _.leftMap { errorMsg =>
-        log.error(s"Tried to get Attributes for ${identityId} but failed with $errorMsg")
+        log.info(s"Tried to get Attributes for ${identityId} but failed with $errorMsg")
         errorMsg
-      }.getOrElse(None)
+      }.fold(_ => None, identity) //.getOrElse(None)
     }
   }
 

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -131,7 +131,10 @@ class AttributeController extends Controller with LoggingWithLogstashFields {
     }
 
     def zuoraAccountsQuery(identityId: String): Future[Disjunction[String, QueryResponse]] = zuoraRestService.getAccounts(identityId).map {
-      _.leftMap (error => s"Calling ZuoraAccountIdsFromIdentityId failed for identityId $identityId. Error: $error")
+      _.leftMap {error =>
+        log.warn(s"Calling ZuoraAccountIdsFromIdentityId failed for identityId $identityId. with error: ${error}")
+        s"Calling ZuoraAccountIdsFromIdentityId failed for identityId $identityId."
+      }
     }
 
     val attributes = for {

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -148,7 +148,12 @@ class AttributeController extends Controller with LoggingWithLogstashFields {
       AttributesMaker.attributes(identityId, subscriptions, LocalDate.now())
     }
 
-    attributes.run.map(_.toOption).map(_.getOrElse(None))
+    attributes.run.map {
+      _.leftMap { errorMsg =>
+        log.error(s"Tried to get Attributes for ${identityId} but failed with $errorMsg")
+        errorMsg
+      }.getOrElse(None)
+    }
   }
 
   private def zuoraLookup(endpointDescription: String) =


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
![image](https://user-images.githubusercontent.com/3072877/28976185-d3f6e608-7934-11e7-8f53-99748c8af42f.png)
To stop logging that a call to zuora takes 0ms when that call did not in fact happen
### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
- Remove responsibility for error logs from 'withTimer' as we only want to error log if the call to Zuora has failed. Error log right after a call to Zuora if the call returns a left instead. 
- If getSubscriptions gets an empty list of accounts, return a left (this ensures that the for comprehension will not log timed subscriptions calls to Zuora that don't happen)

### trello card/screenshot/json/related PRs etc
[PR 207 - log latency on calls to Zuora](https://github.com/guardian/members-data-api/pull/207)
[PR 209 - send some /features traffic to lookup via zuora](https://github.com/guardian/members-data-api/pull/209)
[on trello](https://trello.com/c/VjKkm0Lp/228-endpoint-to-lookup-attributes-by-identity-id-based-only-on-calls-to-zuora)