### PR TITLE
Fix MMA to work even if you have another product.

### DIFF
--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -66,7 +66,7 @@ class AccountController extends LazyLogging {
     (for {
       user <- OptionEither.liftFutureEither(maybeUserId)
       contact <- OptionEither(request.touchpoint.contactRepo.get(user))
-      sub <- OptionEither.liftOption(request.touchpoint.subService.either[F, P](contact).map(_ \/> s"couldn't read sub from zuora for crmId ${contact.salesforceAccountId} (TODO check the separate WARN to find out why)"))
+      sub <- OptionEither(request.touchpoint.subService.either[F, P](contact).map(_.leftMap(message => s"couldn't read sub from zuora for crmId ${contact.salesforceAccountId} due to $message")))
       details <- OptionEither.liftOption(request.touchpoint.paymentService.paymentDetails(sub).map[\/[String, PaymentDetails]](\/.right))
     } yield (contact, details).toResult).run.run.map {
       case \/-(Some(result)) =>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSNS = "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.433"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.435-SNAPSHOT"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.0"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSNS = "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.435-SNAPSHOT"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.437"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.0"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"


### PR DESCRIPTION
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
This is a health PR to fix a problem where mma endpoint for digipack returned an error if the user had a membership etc.  And vice versa.  The call is indeed failing, but fail to read a sub should just be treated as it is the wrong type.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
Use the new type which can report error or optionality.
### trello card/screenshot/json/related PRs etc
https://github.com/guardian/membership-common/pull/509

@paulbrown1982 @lmath @pvighi @jacobwinch 