### PR TITLE
Run sbt dependency vulnerability check on teamcity builds

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,8 +64,6 @@ val buildDebSettings = Seq(
   )
 )
 
-dependencyCheckFailBuildOnCVSS := 10 // we have a 9.3, decrese this when possible
-
 def lib(name: String) = Project(name, file(name))
   .enablePlugins(PlayScala, BuildInfoPlugin, RiffRaffArtifact, JDebPackaging).settings(commonSettings)
 
@@ -80,7 +78,7 @@ val api = app("membership-attribute-service")
   .settings(
     addCommandAlias("devrun", "run 9400"),
     addCommandAlias("batch-load", "runMain BatchLoader"),
-    addCommandAlias("play-artifact", ";dependencyCheck;riffRaffNotifyTeamcity")
+    addCommandAlias("play-artifact", "riffRaffNotifyTeamcity")
   )
 
 val root = project.in(file(".")).aggregate(api)

--- a/build.sbt
+++ b/build.sbt
@@ -64,12 +64,15 @@ val buildDebSettings = Seq(
   )
 )
 
+dependencyCheckFailBuildOnCVSS := 10 // we have a 9.3, decrese this when possible
+
 def lib(name: String) = Project(name, file(name))
   .enablePlugins(PlayScala, BuildInfoPlugin, RiffRaffArtifact, JDebPackaging).settings(commonSettings)
 
 def app(name: String) = lib(name)
   .settings(dynamoDBLocalSettings)
   .settings(buildDebSettings)
+  .settings(riffRaffArtifactResources += (file(s"${name}/target/scala-2.11/dependency-check-report.html"), s"${name}-dependency-check-report.html"))
 
 val api = app("membership-attribute-service")
   .settings(libraryDependencies ++= apiDependencies)
@@ -77,7 +80,7 @@ val api = app("membership-attribute-service")
   .settings(
     addCommandAlias("devrun", "run 9400"),
     addCommandAlias("batch-load", "runMain BatchLoader"),
-    addCommandAlias("play-artifact", "riffRaffNotifyTeamcity")
+    addCommandAlias("play-artifact", ";dependencyCheck;riffRaffNotifyTeamcity")
   )
 
 val root = project.in(file(".")).aggregate(api)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,3 +14,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.6")
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.7")
 
 libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts (Artifact("jdeb", "jar", "jar"))
+
+addSbtPlugin("net.vonbuchholtz" % "sbt-dependency-check" % "0.1.10")


### PR DESCRIPTION
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
We are very good at keeping our AMIs up to date for known problems/vulnerabilities there (amigo/amiable).   However libraries that we use in prod also may have vulnerabilities, that could be targeted more specifically.  This becomes more dangerous the more backend systems that system has access to, and that danger could apply until the next time credentials are rotated.

There is a [common list of vulnerabilities](https://cve.mitre.org/data/downloads/index.html) known in various libraries, which could be used by attackers and developers alike.  Ideally we want to be ahead of the attackers so should use it to prompt us to keep things up to date.

The downside is this just tells you when libraries are vulnerable, but doesn't prove that any of the affected functions are actually exposed in such a way to cause a risk in our case.

The plugin produces a nice [html report](https://teamcity-aws.gutools.co.uk/repository/download/memsub_membership_membersdataapi/77023:id/membership-attribute-service-dependency-check-report.html) but you can also fail the build on severity.  Unfortunately we have a 9.3 so we can't fail the build yet as that's the highest rating.

The first time I ran this it took 2 minutes as it was downloading the vulnerability files.  I reran it and it took under 20 seconds.  there maybe a way to run it in parallel.


### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
Basically add the plugin to SBT and tell it to copy the files into the build output.

### trello card/screenshot/json/related PRs etc
https://github.com/guardian/janus/pull/796

In the end, it's only useful to have this if we're going to keep things clean (i.e. keep deps up to date).  And ideally run it on all our projects. Any thoughts? @paulbrown1982 @adamnfish  @guardian/membership-and-subscriptions 