### PR TITLE
Add a how many concurrent calls to zuora counter + logging this value

### DIFF
--- a/membership-attribute-service/app/loghandling/RequestRunnerEmbellisher.scala
+++ b/membership-attribute-service/app/loghandling/RequestRunnerEmbellisher.scala
@@ -1,0 +1,15 @@
+package loghandling
+
+import okhttp3.{Request, Response}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+object RequestRunnerEmbellisher {
+
+  def withZuoraRequestCounter(runner: (Request) => Future[Response])(implicit ec: ExecutionContext): (Request) => Future[Response] = request => {
+    ZuoraRequestCounter.increment
+    val response = runner(request)
+    response.onComplete(_ => ZuoraRequestCounter.decrement)
+    response
+  }
+}

--- a/membership-attribute-service/app/loghandling/ZuoraRequestCounter.scala
+++ b/membership-attribute-service/app/loghandling/ZuoraRequestCounter.scala
@@ -1,0 +1,15 @@
+package loghandling
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import com.typesafe.scalalogging.LazyLogging
+
+object ZuoraRequestCounter extends LazyLogging{
+  private val counter = new AtomicInteger()
+
+  def increment: Int = counter.incrementAndGet()
+
+  def decrement: Int = counter.decrementAndGet()
+
+  def get = counter.get()
+}


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
[PR 209 in members-data-api ](https://github.com/guardian/members-data-api/pull/209) sends some traffic through /features to do a lookup via calls to Zuora. Once we switch the percentage higher, it should be useful to know some information about how many concurrent calls we are making to Zuora.

Originally, I wanted to add this in membership-common (see: [PR 512- add a how many current calls to Zuora counter)](https://github.com/guardian/membership-common/pull/512) but if during a call to Zuora a future failed, the counter may be incremented and then never decremented. 

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
- Adds a counter for how many calls we have made to Zuora that decrements on response or failed future

### trello card/screenshot/json/related PRs etc
[PR 209 - send some /features traffic to lookup via Zuora](https://github.com/guardian/members-data-api/pull/209)
[On trello](https://trello.com/c/VjKkm0Lp/228-endpoint-to-lookup-attributes-by-identity-id-based-only-on-calls-to-zuora)