### PR TITLE
Add /me and /me/membership to the Zuora lookup test

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -196,8 +196,8 @@ class AttributeController extends Controller with LoggingWithLogstashFields {
        .getOrElse(notFound)
   }
 
-  def membership = lookup("membership", onSuccessMember = membershipAttributesFromAttributes, onSuccessMemberAndOrContributor = _ => notAMember, onNotFound = notFound, endpointEligibleForTest = false)
-  def attributes = lookup("attributes", onSuccessMember = identity[Attributes], onSuccessMemberAndOrContributor = identity[Attributes], onNotFound = notFound, endpointEligibleForTest = false)
+  def membership = lookup("membership", onSuccessMember = membershipAttributesFromAttributes, onSuccessMemberAndOrContributor = _ => notAMember, onNotFound = notFound, endpointEligibleForTest = true)
+  def attributes = lookup("attributes", onSuccessMember = identity[Attributes], onSuccessMemberAndOrContributor = identity[Attributes], onNotFound = notFound, endpointEligibleForTest = true)
   def features = lookup("features", onSuccessMember = Features.fromAttributes, onSuccessMemberAndOrContributor = _ => Features.unauthenticated, onNotFound = Features.unauthenticated, endpointEligibleForTest = true)
   def zuoraMe = zuoraLookup("zuoraLookup")
 


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
We are exploring moving away from maintaining subscription info in dynamo. So, we are running a test where we send an increasing percentage of traffic for lookups via Zuora (instead of dynamo).

We did this test for /me/features but this looks to make up only about a quarter of the requests. So we will dial up the traffic for all the lookups and not just /me/features

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->

- Adds /me and /me/membership to the Zuora lookup test (they will direct a percentage of traffic to lookup via zuora -- the same percentage for all the endpoints)

### trello card/screenshot/json/related PRs etc
[pr 205 - endpoint to lookup via zuora](https://github.com/guardian/members-data-api/pull/205)
[pr 209 - send some /features traffic to lookup via zuora](https://github.com/guardian/members-data-api/pull/209)
[on trello](https://trello.com/c/VjKkm0Lp/228-endpoint-to-lookup-attributes-by-identity-id-based-only-on-calls-to-zuora)
