### PR TITLE
Use a longer timeout for Zuora queries to get account ids

### DIFF
--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -16,11 +16,10 @@ import com.gu.stripe.StripeService
 import com.gu.touchpoint.TouchpointBackendConfig
 import com.gu.zuora.rest.SimpleClient
 import com.gu.zuora.soap.ClientWithFeatureSupplier
-import com.gu.zuora.{ZuoraRestService, ZuoraService, rest}
+import com.gu.zuora.{PatientZuoraRestService, ZuoraRestService, ZuoraService}
 import configuration.Config
 import loghandling.ZuoraRequestCounter
-import prodtest.{Allocator, FeatureToggleDataUpdatedOnSchedule}
-import org.joda.time.LocalDate
+import prodtest.FeatureToggleDataUpdatedOnSchedule
 import services.IdentityService.IdentityConfig
 import services._
 
@@ -70,7 +69,9 @@ class TouchpointComponents(stage: String)(implicit system: ActorSystem) {
   lazy val snsGiraffeService: SNSGiraffeService = SNSGiraffeService(giraffeSns)
   lazy val zuoraService = new ZuoraService(soapClient)
   implicit lazy val simpleClient = new SimpleClient[Future](tpConfig.zuoraRest, ZuoraRequestCounter.withZuoraRequestCounter(RequestRunners.futureRunner))
+  lazy val patientSimpleClient = new SimpleClient[Future](tpConfig.zuoraRest, ZuoraRequestCounter.withZuoraRequestCounter(RequestRunners.configurableFutureRunner(30 seconds)))
   lazy val zuoraRestService = new ZuoraRestService[Future]()
+  lazy val patientZuoraRestService = new PatientZuoraRestService[Future](patientSimpleClient)
   lazy val catalogService = new CatalogService[Future](productIds, simpleClient, Await.result(_, 10.seconds), stage)
   lazy val futureCatalog: Future[CatalogMap] = catalogService.catalog.map(_.fold[CatalogMap](error => {println(s"error: ${error.list.mkString}"); Map()}, _.map))
 

--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -16,7 +16,7 @@ import com.gu.stripe.StripeService
 import com.gu.touchpoint.TouchpointBackendConfig
 import com.gu.zuora.rest.SimpleClient
 import com.gu.zuora.soap.ClientWithFeatureSupplier
-import com.gu.zuora.{PatientZuoraRestService, ZuoraRestService, ZuoraService}
+import com.gu.zuora.{ZuoraRestService, ZuoraService}
 import configuration.Config
 import loghandling.ZuoraRequestCounter
 import prodtest.FeatureToggleDataUpdatedOnSchedule
@@ -71,7 +71,7 @@ class TouchpointComponents(stage: String)(implicit system: ActorSystem) {
   implicit lazy val simpleClient = new SimpleClient[Future](tpConfig.zuoraRest, ZuoraRequestCounter.withZuoraRequestCounter(RequestRunners.futureRunner))
   lazy val patientSimpleClient = new SimpleClient[Future](tpConfig.zuoraRest, ZuoraRequestCounter.withZuoraRequestCounter(RequestRunners.configurableFutureRunner(30 seconds)))
   lazy val zuoraRestService = new ZuoraRestService[Future]()
-  lazy val patientZuoraRestService = new PatientZuoraRestService[Future](patientSimpleClient)
+  lazy val patientZuoraRestService = new ZuoraRestService[Future]()(implicitly, patientSimpleClient)
   lazy val catalogService = new CatalogService[Future](productIds, simpleClient, Await.result(_, 10.seconds), stage)
   lazy val futureCatalog: Future[CatalogMap] = catalogService.catalog.map(_.fold[CatalogMap](error => {println(s"error: ${error.list.mkString}"); Map()}, _.map))
 

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -7,7 +7,7 @@ import com.gu.memsub.subsv2.reads.SubPlanReads._
 import com.gu.memsub.subsv2.services.SubscriptionService
 import com.gu.memsub.subsv2.{Subscription, SubscriptionPlan}
 import com.gu.scanamo.error.DynamoReadError
-import com.gu.zuora.PatientZuoraRestService
+import com.gu.zuora.ZuoraRestService
 import com.gu.zuora.ZuoraRestService.QueryResponse
 import loghandling.ZuoraRequestCounter
 import configuration.Config
@@ -94,7 +94,7 @@ class AttributeController extends Controller with LoggingWithLogstashFields {
   }
 
 
-  private def attributesFromZuora(identityId: String, zuoraRestService: PatientZuoraRestService[Future], subscriptionService: SubscriptionService[Future], attributeService: AttributeService): Future[Option[Attributes]] = {
+  private def attributesFromZuora(identityId: String, patientZuoraRestService: ZuoraRestService[Future], subscriptionService: SubscriptionService[Future], attributeService: AttributeService): Future[Option[Attributes]] = {
 
     def withTimer[R](whichCall: String, futureResult: Future[Disjunction[String, R]]) = {
       import loghandling.StopWatch
@@ -134,7 +134,7 @@ class AttributeController extends Controller with LoggingWithLogstashFields {
       }
     }
 
-    def zuoraAccountsQuery(identityId: String): Future[Disjunction[String, QueryResponse]] = zuoraRestService.getAccounts(identityId).map {
+    def zuoraAccountsQuery(identityId: String): Future[Disjunction[String, QueryResponse]] = patientZuoraRestService.getAccounts(identityId).map {
       _.leftMap {error =>
         log.warn(s"Calling ZuoraAccountIdsFromIdentityId failed for identityId $identityId. with error: ${error}")
         s"Calling ZuoraAccountIdsFromIdentityId failed for identityId $identityId."

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSNS = "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.441-SNAPSHOT"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.440"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.0"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSNS = "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.437"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.441-SNAPSHOT"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.0"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
We're looking at moving away from maintaining membership attribute info in Dynamo and getting it from Zuora. But we might overload Zuora so we're dialing up a percentage of traffic that does lookups this way.

At 10% traffic we started seeing socket timeout exceptions during the daily Zuora bill run.

There is a call in particular that tends to timeout during the bill run, the identityId -> accountIds query. We are willing to wait longer so [pr 517 in membership common](https://github.com/guardian/membership-common/pull/517) moves this call into its own rest service that can have a longer timeout here in members-data-api.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
- When we do lookups via Zuora, we need to make a query to get accountIds from identityId. This change increases the timeout for that call to 30 seconds. 

### trello card/screenshot/json/related PRs etc
[pr 517 - move zuora calls that can have longer timeouts to a PatientZuoraRestService](https://github.com/guardian/membership-common/pull/517)
[pr221 members-data-api: Zuora lookup test for all the lookup endpoints](https://github.com/guardian/members-data-api/pull/221)
[on trello](https://trello.com/c/VjKkm0Lp/228-endpoint-to-lookup-attributes-by-identity-id-based-only-on-calls-to-zuora)