### PR TITLE
Yet more logging: did attributes come from zuora or dynamo? + what stage for feature toggle logging

### DIFF
--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -77,6 +77,6 @@ class TouchpointComponents(stage: String)(implicit system: ActorSystem) {
 
   lazy val subService = new SubscriptionService[Future](productIds, futureCatalog, simpleClient, zuoraService.getAccountIds)
   lazy val paymentService = new PaymentService(stripeService, zuoraService, catalogService.unsafeCatalog.productMap)
-  lazy val featureToggleData = new FeatureToggleDataUpdatedOnSchedule(featureToggleService)
+  lazy val featureToggleData = new FeatureToggleDataUpdatedOnSchedule(featureToggleService, stage)
 
 }

--- a/membership-attribute-service/app/prodtest/FeatureToggleDataUpdatedOnSchedule.scala
+++ b/membership-attribute-service/app/prodtest/FeatureToggleDataUpdatedOnSchedule.scala
@@ -9,7 +9,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.DurationInt
 import scalaz.{-\/, \/-}
 
-class FeatureToggleDataUpdatedOnSchedule(featureToggleService: ScanamoFeatureToggleService)(implicit ec: ExecutionContext, system: ActorSystem) extends LazyLogging {
+class FeatureToggleDataUpdatedOnSchedule(featureToggleService: ScanamoFeatureToggleService, stage: String)(implicit ec: ExecutionContext, system: ActorSystem) extends LazyLogging {
 
   private val updateZuoraTrafficPercentageTask: ScheduledTask[Int] = {
     val featureName = "UpdateAttributesFromZuoraLookupPercentage"
@@ -18,11 +18,11 @@ class FeatureToggleDataUpdatedOnSchedule(featureToggleService: ScanamoFeatureTog
         result match {
           case \/-(feature) =>
             val percentage = feature.TrafficPercentage.getOrElse(0)
-            logger.info(s"$featureName scheduled task set percentage to $percentage")
+            logger.info(s"$featureName scheduled task set percentage to $percentage in $stage")
             percentage
           case -\/(e) =>
             logger.warn(s"Tried to update the percentage of traffic for $featureName, but that feature was not " +
-              s"found in the table. Setting traffic to 0%. Error: $e")
+              s"found in the table. Setting traffic to 0% in $stage. Error: $e")
             0
         }
       }


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
We're testing out sending lookup (/me, /me/features, /me/membership) to get attributes information from Zuora. As I was increasing the traffic looking up via Zuora, I noticed that if I looked at a particular instance then the percentage of traffic seemed to be toggling between what I set it to and 0. This is probably just the percentage for UAT, but to be sure, more logging is required!

This also seemed like a sensible time to add a log on each lookup call for if the information came via Zuora or via Dynamo.
 
### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->

- When the percentage for the test is updated, log which stage that update is for
- On {/me, /me/features, /me/membership} calls, log if the attributes came from Zuora or Dynamo
 
### trello card/screenshot/json/related PRs etc
[PR 209 - send some /features traffic to lookup via Zuora](https://github.com/guardian/members-data-api/pull/209)
[on trello](https://trello.com/c/VjKkm0Lp/228-endpoint-to-lookup-attributes-by-identity-id-based-only-on-calls-to-zuora)