### PR TITLE
Use dynamo client builder instead of deprecated constructor in touchpoint backend

### DIFF
--- a/membership-attribute-service/app/services/ScanamoAttributeService.scala
+++ b/membership-attribute-service/app/services/ScanamoAttributeService.scala
@@ -1,6 +1,6 @@
 package services
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
 import com.amazonaws.services.dynamodbv2.model.{DeleteItemResult, PutItemResult}
 import com.gu.scanamo._
 import com.gu.scanamo.error.{DynamoReadError, MissingProperty}
@@ -13,7 +13,7 @@ import play.api.libs.concurrent.Execution.Implicits._
 
 import scala.concurrent.Future
 
-class ScanamoAttributeService(client: AmazonDynamoDBAsyncClient, table: String)
+class ScanamoAttributeService(client: AmazonDynamoDBAsync, table: String)
     extends AttributeService with LazyLogging {
 
   implicit val jodaStringFormat = DynamoFormat.coercedXmap[LocalDate, String, IllegalArgumentException](

--- a/membership-attribute-service/app/services/ScanamoBehaviourService.scala
+++ b/membership-attribute-service/app/services/ScanamoBehaviourService.scala
@@ -1,6 +1,6 @@
 package services
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
 import com.amazonaws.services.dynamodbv2.model.{DeleteItemResult, PutItemResult}
 import com.gu.scanamo.syntax._
 import com.gu.scanamo.{ScanamoAsync, Table}
@@ -9,7 +9,7 @@ import models.Behaviour
 import play.api.libs.concurrent.Execution.Implicits._
 import scala.concurrent.Future
 
-class ScanamoBehaviourService(client: AmazonDynamoDBAsyncClient, table: String) extends BehaviourService with LazyLogging {
+class ScanamoBehaviourService(client: AmazonDynamoDBAsync, table: String) extends BehaviourService with LazyLogging {
 
   val scanamo = Table[Behaviour](table)
   def run[T] = ScanamoAsync.exec[T](client) _

--- a/membership-attribute-service/app/services/ScanamoFeatureToggleService.scala
+++ b/membership-attribute-service/app/services/ScanamoFeatureToggleService.scala
@@ -1,6 +1,6 @@
 package services
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
 import com.gu.scanamo._
 import com.gu.scanamo.error.DynamoReadError
 import com.gu.scanamo.syntax.{set => scanamoSet, _}
@@ -13,7 +13,7 @@ import scalaz.\/
 import scalaz.syntax.std.either._
 import scalaz.syntax.std.option._
 
-class ScanamoFeatureToggleService(client: AmazonDynamoDBAsyncClient, table: String) extends LazyLogging {
+class ScanamoFeatureToggleService(client: AmazonDynamoDBAsync, table: String) extends LazyLogging {
 
   private val scanamo = Table[FeatureToggle](table)
   def run[T] = ScanamoAsync.exec[T](client) _


### PR DESCRIPTION
I just looked at that deprecation warning enough times to crack.
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
Moving away from deprecated constructors must be a good thing. 

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
- In the TouchpointBackend, create a dynamo db client using the builder instead of the constructor, which is deprecated

### trello card/screenshot/json/related PRs etc
