### PR TITLE
Preserve the value of the adfree flag on calls to /features for contributors

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -57,7 +57,7 @@ class AttributeController extends Controller with LoggingWithLogstashFields {
   lazy val authenticationService: AuthenticationService = IdentityAuthService
   lazy val metrics = Metrics("AttributesController")
 
-  private def lookup(endpointDescription: String, onSuccessMember: Attributes => Result, onSuccessMemberAndOrContributor: Attributes => Result, onNotFound: Result, endpointEligibleForTest: Boolean) =
+  private def lookup(endpointDescription: String, onSuccessMember: Attributes => Result, onSuccessMemberAndOrContributor: Attributes => Result, onNotFound: Result, endpointEligibleForTest: Boolean): Action[AnyContent] =
   {
     def pickAttributes(identityId: String) (implicit request: BackendRequest[AnyContent]): (String, Future[Option[Attributes]]) = {
       if(endpointEligibleForTest){
@@ -199,7 +199,7 @@ class AttributeController extends Controller with LoggingWithLogstashFields {
 
   def membership = lookup("membership", onSuccessMember = membershipAttributesFromAttributes, onSuccessMemberAndOrContributor = _ => notAMember, onNotFound = notFound, endpointEligibleForTest = true)
   def attributes = lookup("attributes", onSuccessMember = identity[Attributes], onSuccessMemberAndOrContributor = identity[Attributes], onNotFound = notFound, endpointEligibleForTest = true)
-  def features = lookup("features", onSuccessMember = Features.fromAttributes, onSuccessMemberAndOrContributor = Features.fromAttributes, onNotFound = Features.unauthenticated, endpointEligibleForTest = true)
+  def features = lookup("features", onSuccessMember = Features.fromAttributes, onSuccessMemberAndOrContributor = Features.notAMember, onNotFound = Features.unauthenticated, endpointEligibleForTest = true)
   def zuoraMe = zuoraLookup("zuoraLookup")
 
   def updateAttributes(identityId : String): Action[AnyContent] = backendForSyncWithZuora.async { implicit request =>

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -199,7 +199,7 @@ class AttributeController extends Controller with LoggingWithLogstashFields {
 
   def membership = lookup("membership", onSuccessMember = membershipAttributesFromAttributes, onSuccessMemberAndOrContributor = _ => notAMember, onNotFound = notFound, endpointEligibleForTest = true)
   def attributes = lookup("attributes", onSuccessMember = identity[Attributes], onSuccessMemberAndOrContributor = identity[Attributes], onNotFound = notFound, endpointEligibleForTest = true)
-  def features = lookup("features", onSuccessMember = Features.fromAttributes, onSuccessMemberAndOrContributor = _ => Features.unauthenticated, onNotFound = Features.unauthenticated, endpointEligibleForTest = true)
+  def features = lookup("features", onSuccessMember = Features.fromAttributes, onSuccessMemberAndOrContributor = Features.fromAttributes, onNotFound = Features.unauthenticated, endpointEligibleForTest = true)
   def zuoraMe = zuoraLookup("zuoraLookup")
 
   def updateAttributes(identityId : String): Action[AnyContent] = backendForSyncWithZuora.async { implicit request =>

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -57,7 +57,7 @@ class AttributeController extends Controller with LoggingWithLogstashFields {
   lazy val authenticationService: AuthenticationService = IdentityAuthService
   lazy val metrics = Metrics("AttributesController")
 
-  private def lookup(endpointDescription: String, onSuccessMember: Attributes => Result, onSuccessMemberAndOrContributor: Attributes => Result, onNotFound: Result, endpointEligibleForTest: Boolean): Action[AnyContent] =
+  private def lookup(endpointDescription: String, onSuccessMember: Attributes => Result, onSuccessMemberAndOrContributor: Attributes => Result, onNotFound: Result, endpointEligibleForTest: Boolean) =
   {
     def pickAttributes(identityId: String) (implicit request: BackendRequest[AnyContent]): (String, Future[Option[Attributes]]) = {
       if(endpointEligibleForTest){

--- a/membership-attribute-service/app/models/Features.scala
+++ b/membership-attribute-service/app/models/Features.scala
@@ -33,6 +33,11 @@ object Features {
   }
 
   val unauthenticated = Features(None, adFree = false, adblockMessage = true, None, None, None)
+
+  def notAMember(attributes: Attributes) = {
+    val adFree = attributes.AdFree.getOrElse(false)
+    Features(None, adFree = adFree, adblockMessage = true, None, None, None)
+  }
 }
 
 case class Features(

--- a/membership-attribute-service/app/models/Features.scala
+++ b/membership-attribute-service/app/models/Features.scala
@@ -36,7 +36,7 @@ object Features {
 
   def notAMember(attributes: Attributes) = {
     val adFree = attributes.AdFree.getOrElse(false)
-    Features(None, adFree = adFree, adblockMessage = true, None, None, None)
+    unauthenticated.copy(adFree = adFree)
   }
 }
 


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
If a logged in user is a contributor, then for the moment, we should return the adFree flag we have 
stored for them in dynamo on calls to /features.

I initially suggested just populating the fields we have available, but since /features is deprecated, better to keep to its existing behaviour as much as possible.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
- Preserve value of the adfree flag on calls to /features even for contributors

### trello card/screenshot/json/related PRs etc
