### PR TITLE
Allow Members Data API to authenticate and authorise iPad Daily Edition content

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -80,17 +80,17 @@ class AttributeController extends Controller with LoggingWithLogstashFields {
                 "X-Gu-Membership-Tier" -> tier,
                 "X-Gu-Membership-Is-Paid-Tier" -> attrs.isPaidTier.toString
               )
-            case Some(attrs @ Attributes(_, _, _, _, _, _, _, Some(date))) =>
-              log.info(s"$identityId is a digital subscriber expiring $date - $endpointDescription - found via $fromWhere")
-              onSuccessSupporter(attrs)
-            case Some(attrs @ Attributes(_, _, _, _, _, Some(paymentPlan), _, _)) =>
-              log.info(s"$identityId is a regular $paymentPlan contributor - $endpointDescription - found via $fromWhere")
-              onSuccessSupporter(attrs)
-            case Some(attrs @ Attributes(_, _, _, Some(true), _, _, _, _)) =>
-              log.info(s"$identityId is an ad-free reader - $endpointDescription - found via $fromWhere")
-              onSuccessSupporter(attrs)
             case Some(attrs) =>
-              log.info(s"$identityId is some unknown kind of supporter - $endpointDescription - $attrs found via $fromWhere")
+              attrs.DigitalSubscriptionExpiryDate.foreach { date =>
+                log.info(s"$identityId is a digital subscriber expiring $date")
+              }
+              attrs.RecurringContributionPaymentPlan.foreach { paymentPlan =>
+                log.info(s"$identityId is a regular $paymentPlan contributor")
+              }
+              attrs.AdFree.foreach { _ =>
+                log.info(s"$identityId is an ad-free reader")
+              }
+              log.info(s"$identityId supports the guardian - $attrs - found via $fromWhere")
               onSuccessSupporter(attrs)
             case _ =>
               onNotFound

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -57,7 +57,7 @@ class AttributeController extends Controller with LoggingWithLogstashFields {
   lazy val authenticationService: AuthenticationService = IdentityAuthService
   lazy val metrics = Metrics("AttributesController")
 
-  private def lookup(endpointDescription: String, onSuccessMember: Attributes => Result, onSuccessMemberAndOrContributor: Attributes => Result, onNotFound: Result, endpointEligibleForTest: Boolean) =
+  private def lookup(endpointDescription: String, onSuccessMember: Attributes => Result, onSuccessSupporter: Attributes => Result, onNotFound: Result, endpointEligibleForTest: Boolean) =
   {
     def pickAttributes(identityId: String) (implicit request: BackendRequest[AnyContent]): (String, Future[Option[Attributes]]) = {
       if(endpointEligibleForTest){
@@ -74,15 +74,24 @@ class AttributeController extends Controller with LoggingWithLogstashFields {
         case Some(identityId) =>
           val (fromWhere, attributes) = pickAttributes(identityId)
           attributes.map {
-            case Some(attrs @ Attributes(_, Some(tier), _, _, _, _, _)) =>
-              log.info(s"$identityId is a member - $endpointDescription - $attrs found via $fromWhere")
+            case Some(attrs @ Attributes(_, Some(tier), _, _, _, _, _, _)) =>
+              log.info(s"$identityId is a $tier member - $endpointDescription - $attrs found via $fromWhere")
               onSuccessMember(attrs).withHeaders(
                 "X-Gu-Membership-Tier" -> tier,
                 "X-Gu-Membership-Is-Paid-Tier" -> attrs.isPaidTier.toString
               )
+            case Some(attrs @ Attributes(_, _, _, _, _, _, _, Some(date))) =>
+              log.info(s"$identityId is a digital subscriber expiring $date - $endpointDescription - found via $fromWhere")
+              onSuccessSupporter(attrs)
+            case Some(attrs @ Attributes(_, _, _, _, _, Some(paymentPlan), _, _)) =>
+              log.info(s"$identityId is a regular $paymentPlan contributor - $endpointDescription - found via $fromWhere")
+              onSuccessSupporter(attrs)
+            case Some(attrs @ Attributes(_, _, _, Some(true), _, _, _, _)) =>
+              log.info(s"$identityId is an ad-free reader - $endpointDescription - found via $fromWhere")
+              onSuccessSupporter(attrs)
             case Some(attrs) =>
-              log.info(s"$identityId is a contributor - $endpointDescription - $attrs found via $fromWhere")
-              onSuccessMemberAndOrContributor(attrs)
+              log.info(s"$identityId is some unknown kind of supporter - $endpointDescription - $attrs found via $fromWhere")
+              onSuccessSupporter(attrs)
             case _ =>
               onNotFound
           }
@@ -220,9 +229,9 @@ class AttributeController extends Controller with LoggingWithLogstashFields {
        .getOrElse(notFound)
   }
 
-  def membership = lookup("membership", onSuccessMember = membershipAttributesFromAttributes, onSuccessMemberAndOrContributor = _ => notAMember, onNotFound = notFound, endpointEligibleForTest = true)
-  def attributes = lookup("attributes", onSuccessMember = identity[Attributes], onSuccessMemberAndOrContributor = identity[Attributes], onNotFound = notFound, endpointEligibleForTest = true)
-  def features = lookup("features", onSuccessMember = Features.fromAttributes, onSuccessMemberAndOrContributor = Features.notAMember, onNotFound = Features.unauthenticated, endpointEligibleForTest = true)
+  def membership = lookup("membership", onSuccessMember = membershipAttributesFromAttributes, onSuccessSupporter = _ => notAMember, onNotFound = notFound, endpointEligibleForTest = true)
+  def attributes = lookup("attributes", onSuccessMember = identity[Attributes], onSuccessSupporter = identity[Attributes], onNotFound = notFound, endpointEligibleForTest = true)
+  def features = lookup("features", onSuccessMember = Features.fromAttributes, onSuccessSupporter = Features.notAMember, onNotFound = Features.unauthenticated, endpointEligibleForTest = true)
   def zuoraMe = zuoraLookup("zuoraLookup")
 
   def updateAttributes(identityId : String): Action[AnyContent] = backendForSyncWithZuora.async { implicit request =>

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -159,7 +159,9 @@ class AttributeController extends Controller with LoggingWithLogstashFields {
               zuoraAttributes.copy(
                 AdFree = dynamoAttributes.AdFree, //fetched from Dynamo in the Zuora lookup anyway (dynamo is the source of truth)
                 Wallet = dynamoAttributes.Wallet, //can't be found based on Zuora lookups, and not currently used
-                MembershipNumber = dynamoAttributes.MembershipNumber //I don't think membership number is needed and it comes from Salesforce
+                MembershipNumber = dynamoAttributes.MembershipNumber, //I don't think membership number is needed and it comes from Salesforce
+                MembershipJoinDate = dynamoAttributes.MembershipJoinDate.flatMap(_ => zuoraAttributes.MembershipJoinDate), //only compare if dynamo has value
+                DigitalSubscriptionExpiryDate = None
               )
             }
           }

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -61,9 +61,9 @@ case class Attributes(
   lazy val isPaidTier = isSupporterTier || isPartnerTier || isPatronTier || isStaffTier
   lazy val isAdFree = AdFree.exists(identity)
   lazy val isContributor = RecurringContributionPaymentPlan.isDefined
-  lazy val isDigitalSubscriber = DigitalSubscriptionExpiryDate.isDefined
+  lazy val digitalSubscriberHasActivePlan = DigitalSubscriptionExpiryDate.exists(_.isAfter(now))
 
-  lazy val contentAccess = ContentAccess(member = isPaidTier || isFriendTier, paidMember = isPaidTier, recurringContributor = isContributor, digitalPack = DigitalSubscriptionExpiryDate.exists(_.isAfter(now))) // we want to include staff!
+  lazy val contentAccess = ContentAccess(member = isPaidTier || isFriendTier, paidMember = isPaidTier, recurringContributor = isContributor, digitalPack = digitalSubscriberHasActivePlan || isStaffTier)
 }
 
 object Attributes {

--- a/membership-attribute-service/app/services/AttributesMaker.scala
+++ b/membership-attribute-service/app/services/AttributesMaker.scala
@@ -1,12 +1,14 @@
 package services
 
-import com.github.nscala_time.time.OrderingImplicits.LocalDateOrdering
+import com.github.nscala_time.time.OrderingImplicits._
 import com.gu.memsub.subsv2.SubscriptionPlan.AnyPlan
 import com.gu.memsub.subsv2.{GetCurrentPlans, Subscription}
 import com.gu.memsub.{Benefit, Product}
 import com.typesafe.scalalogging.LazyLogging
 import models.Attributes
 import org.joda.time.LocalDate
+
+import scalaz.syntax.std.boolean._
 
 class AttributesMaker extends LazyLogging {
 
@@ -16,10 +18,10 @@ class AttributesMaker extends LazyLogging {
       GetCurrentPlans(subscription, forDate).map(_.list).toList.flatten  // it's expected that users may not have any current plans
     }
     def getTopProduct(subscription: Subscription[AnyPlan]): Option[Product] = {
-      getCurrentPlans(subscription).map(_.product).headOption
+      getCurrentPlans(subscription).headOption.map(_.product)
     }
     def getTopPlanName(subscription: Subscription[AnyPlan]): Option[String] = {
-      getCurrentPlans(subscription).map(_.name).headOption
+      getCurrentPlans(subscription).headOption.map(_.name)
     }
     def getAllBenefits(subscription: Subscription[AnyPlan]): Set[Benefit] = {
       getCurrentPlans(subscription).flatMap(_.charges.benefits.list).toSet
@@ -31,22 +33,20 @@ class AttributesMaker extends LazyLogging {
     val contributionSub = groupedSubs.getOrElse(Some(Product.Contribution), Nil).headOption     // Assumes only 1 regular contribution per Identity customer
     val subsWhichIncludeDigitalPack = subs.filter(getAllBenefits(_).contains(Benefit.Digipack))
 
-    if (membershipSub.nonEmpty || contributionSub.nonEmpty || subsWhichIncludeDigitalPack.nonEmpty) {
+    val hasAttributableProduct = membershipSub.nonEmpty || contributionSub.nonEmpty || subsWhichIncludeDigitalPack.nonEmpty
+
+    hasAttributableProduct.option {
       val tier: Option[String] = membershipSub.flatMap(getCurrentPlans(_).headOption.map(_.charges.benefits.head.id))
       val recurringContributionPaymentPlan: Option[String] = contributionSub.flatMap(getTopPlanName)
       val membershipJoinDate: Option[LocalDate] = membershipSub.map(_.startDate)
-      val latestDigitalPackExpiryDate: Option[LocalDate] = subsWhichIncludeDigitalPack.map(_.termEndDate).sorted.reverse.headOption
-
-      Some(Attributes(
+      val latestDigitalPackExpiryDate: Option[LocalDate] = Some(subsWhichIncludeDigitalPack.map(_.termEndDate)).filter(_.nonEmpty).map(_.max)
+      Attributes(
         UserId = identityId,
         Tier = tier,
         RecurringContributionPaymentPlan = recurringContributionPaymentPlan,
         MembershipJoinDate = membershipJoinDate,
         DigitalSubscriptionExpiryDate = latestDigitalPackExpiryDate
       )
-      )
-    } else {
-      None
     }
   }
 

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -33,7 +33,8 @@ class AttributeControllerTest extends Specification with AfterAll {
       membershipCard = Some(CardDetails("1234", 5, 2017, "membership"))
     )),
     MembershipJoinDate = Some(new LocalDate(2017, 5, 13)),
-    RecurringContributionPaymentPlan = Some("Monthly Contribution")
+    RecurringContributionPaymentPlan = Some("Monthly Contribution"),
+    DigitalSubscriptionExpiryDate = Some(new LocalDate(2100, 1, 1))
   )
 
   private val validUserCookie = Cookie("validUser", "true")
@@ -144,10 +145,12 @@ class AttributeControllerTest extends Specification with AfterAll {
                    |   "adFree": false,
                    |   "membershipJoinDate": "2017-05-13",
                    |   "recurringContributionPaymentPlan":"Monthly Contribution",
+                   |   "digitalSubscriptionExpiryDate":"2100-01-01",
                    |   "contentAccess": {
                    |     "member": true,
                    |     "paidMember": true,
-                   |     "recurringContributor": true
+                   |     "recurringContributor": true,
+                   |     "digitalPack": true
                    |   }
                    | }
                  """.stripMargin)


### PR DESCRIPTION
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->

The iPad Daily Edition app is changing to use Identity as its authentication, and as a result it can switch to use Members Data API rather than CAS to authorise that the app can download today's daily edition.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
- Added support for digital subscriptions in the /user-attributes/me endpoint.
- The JSON now returns the latest expiry date of whatever digital plans the user is signed up to, and a boolean in the contentAccess JSON as to whether they should be able to access digital content (Daily Edition / Premium Tier).
- I've done some D.R.Y refactoring of AttributesMaker after adding the third search/filter concern.
- Added some more detailed logging in AttributesController as to what principal subscription type has been identified.

Example response to `https://members-data-api.theguardian.com/user-attributes/me`:

```
{
  "userId": "123456",
  "digitalSubscriptionExpiryDate":"2100-01-01",
  "contentAccess": {
    "member": false,
    "paidMember": false,
    "recurringContributor": false,
    "digitalPack": true
  }
}
```

### trello card/screenshot/json/related PRs etc
https://trello.com/c/PyjUgof8/266-members-data-api-me-endpoint-to-show-whether-the-identity-user-has-a-digital-subscription

cc @johnduffell @pvighi @lmath @AWare @aodhol 