### PR TITLE
Return an "empty" set of attributes if membership data not found

### DIFF
--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -168,13 +168,31 @@ class AttributeControllerTest extends Specification with AfterAll {
       status(result3) shouldEqual UNAUTHORIZED
     }
 
-    "return not found for unknown users in membership and attributes" in {
+    "return not found for unknown users in membership" in {
       val req = FakeRequest().withCookies(invalidUserCookie)
-      val result1 = controller.membership(req)
-      val result2 = controller.attributes(req)
+      val result = controller.membership(req)
 
-      status(result1) shouldEqual NOT_FOUND
-      status(result2) shouldEqual NOT_FOUND
+      status(result) shouldEqual NOT_FOUND
+    }
+
+    "return all false attributes for unknown users" in {
+      val req = FakeRequest().withCookies(invalidUserCookie)
+      val result = controller.attributes(req)
+
+      status(result) shouldEqual OK
+      val jsonBody = contentAsJson(result)
+      jsonBody shouldEqual
+        Json.parse("""
+                     |{
+                     |  "userId": "456",
+                     |  "adFree": false,
+                     |  "contentAccess": {
+                     |    "member": false,
+                     |    "paidMember": false,
+                     |    "recurringContributor": false,
+                     |    "digitalPack": false
+                     |  }
+                     |}""".stripMargin)
     }
 
     "retrieve default features for unknown users" in {


### PR DESCRIPTION
### Why do we need this?
We need to be able to identify recurring contributors as paying users to suppress funding asks in frontend.

This change also simplifies the code in apps to manage user status.

See [this trello card](https://trello.com/c/o0yYpe8Q/753-update-dotcom-to-hide-messaging-based-on-recurring-contributor-field-in-members-data-api-response)

There will also be related PRs opened in frontend and support-frontend.

### The changes
Return a set of negative data as a 200 response instead of a 404 if the user is known by identity but not the members database.

### Screenshots
Before (a user with an identity ID but no membership data):
<img width="644" alt="screen shot 2017-09-08 at 15 40 07" src="https://user-images.githubusercontent.com/690395/30216811-1df80c86-94ac-11e7-962d-891727042cc7.png">

After (with a faked user id for illustrative purposes only):
![screen shot 2017-09-07 at 18 22 50](https://user-images.githubusercontent.com/690395/30176347-fe9d1078-93f9-11e7-9f5f-e226e0425133.png)

And for someone with no identity ID either (this behaviour is unchanged):
![screen shot 2017-09-07 at 18 23 13](https://user-images.githubusercontent.com/690395/30176334-f8178cf6-93f9-11e7-803d-c30e06eeddde.png)

cc @Ap0c 