### PR TITLE
Fixed how staff memberships enable the Digital Pack subscription

### DIFF
--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -63,7 +63,7 @@ case class Attributes(
   lazy val isContributor = RecurringContributionPaymentPlan.isDefined
   lazy val digitalSubscriberHasActivePlan = DigitalSubscriptionExpiryDate.exists(_.isAfter(now))
 
-  lazy val contentAccess = ContentAccess(member = isPaidTier || isFriendTier, paidMember = isPaidTier, recurringContributor = isContributor, digitalPack = digitalSubscriberHasActivePlan || isStaffTier)
+  lazy val contentAccess = ContentAccess(member = isPaidTier || isFriendTier, paidMember = isPaidTier, recurringContributor = isContributor, digitalPack = digitalSubscriberHasActivePlan)
 }
 
 object Attributes {

--- a/membership-attribute-service/app/services/AttributesMaker.scala
+++ b/membership-attribute-service/app/services/AttributesMaker.scala
@@ -7,6 +7,7 @@ import com.gu.memsub.{Benefit, Product}
 import com.typesafe.scalalogging.LazyLogging
 import models.Attributes
 import org.joda.time.LocalDate
+import org.joda.time.LocalDate.now
 
 import scalaz.syntax.std.boolean._
 
@@ -40,12 +41,13 @@ class AttributesMaker extends LazyLogging {
       val recurringContributionPaymentPlan: Option[String] = contributionSub.flatMap(getTopPlanName)
       val membershipJoinDate: Option[LocalDate] = membershipSub.map(_.startDate)
       val latestDigitalPackExpiryDate: Option[LocalDate] = Some(subsWhichIncludeDigitalPack.map(_.termEndDate)).filter(_.nonEmpty).map(_.max)
+      val staffExpiryDate: Option[LocalDate] = tier.exists(_.equalsIgnoreCase("staff")).option(now.plusDays(1))
       Attributes(
         UserId = identityId,
         Tier = tier,
         RecurringContributionPaymentPlan = recurringContributionPaymentPlan,
         MembershipJoinDate = membershipJoinDate,
-        DigitalSubscriptionExpiryDate = latestDigitalPackExpiryDate
+        DigitalSubscriptionExpiryDate = latestDigitalPackExpiryDate orElse staffExpiryDate
       )
     }
   }


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
Fixed how staff memberships enable the Digital Pack subscription. 

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
It's now impossible for contentAccess.digitalPack to be true if the digitalSubscriptionExpiryDate is absent. This was leading to a confusing ambiguity, see: https://github.com/guardian/members-data-api/pull/230#issuecomment-328131062

### trello card/screenshot/json/related PRs etc

cc @aodhol @JustinPinner @johnduffell @pvighi @lmath @AWare 