### PR TITLE
Make SSL certificate an environment variable. 

### DIFF
--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -66,6 +66,9 @@ Parameters:
   LoggingPolicy:
     Description: Policy needed to access the kinesis stream
     Type: String
+  ELBSSLCertificate:
+    Description: ELB SSL Certificate ARN
+    Type: String
 Mappings:
   StageVariables:
     PROD:
@@ -78,7 +81,6 @@ Mappings:
       DynamoDBFeatureToggleTable: arn:aws:dynamodb:*:*:table/MembershipFeatureToggles-PROD
       DynamoDBFeatureToggleTableTestUsers: arn:aws:dynamodb:*:*:table/MembershipFeatureToggles-UAT
       GiraffeTopic: giraffe
-      SSLCertificate: arn:aws:iam::865473395570:server-certificate/members-data-api.theguardian.com
 
     CODE:
       NotificationAlarmPeriod: 1200
@@ -90,7 +92,6 @@ Mappings:
       DynamoDBFeatureToggleTable: arn:aws:dynamodb:*:*:table/MembershipFeatureToggles-DEV
       DynamoDBFeatureToggleTableTestUsers: arn:aws:dynamodb:*:*:table/MembershipFeatureToggles-UAT
       GiraffeTopic: giraffe-code
-      SSLCertificate: arn:aws:iam::865473395570:server-certificate/members-data-api.theguardian.com
 
 Resources:
   MembershipRole:
@@ -205,8 +206,7 @@ Resources:
       - LoadBalancerPort: '443'
         InstancePort: '9000'
         Protocol: HTTPS
-        SSLCertificateId:
-          Fn::FindInMap: [ StageVariables, { Ref: Stage }, SSLCertificate ]
+        SSLCertificateId: !Ref ELBSSLCertificate
       ConnectionDrainingPolicy:
         Enabled: 'true'
         Timeout: '60'


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
This change will make it easy to switch the IAM certificate out for an ACM certificate. A Fastly configuration change will also be needed.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
Make SSL certificate an environment variable. 

### trello card/screenshot/json/related PRs etc
https://trello.com/c/R6vnLl1R/265-expires-16th-sep-make-members-data-api-elb-use-an-acm-cert-and-make-sure-fastly-is-happy

cc @jacobwinch 
