### PR TITLE
Fix staff tier giving digipack from dynamo

### DIFF
--- a/membership-attribute-service/app/json/package.scala
+++ b/membership-attribute-service/app/json/package.scala
@@ -8,6 +8,9 @@ package object json {
     def addField[T: Writes](fieldName: String, field: A => T): OWrites[A] =
       (writes ~ (__ \ fieldName).write[T])((a: A) => (a, field(a)))
 
+    def addNullableField[T: Writes](fieldName: String, field: A => Option[T]): OWrites[A] =
+      (writes ~ (__ \ fieldName).writeNullable[T])((a: A) => (a, field(a)))
+
     def removeField(fieldName: String): OWrites[A] = OWrites { a: A =>
       val transformer = (__ \ fieldName).json.prune
       Json.toJson(a)(writes).validate(transformer).get

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -2,15 +2,16 @@ package models
 
 
 import json._
+import com.github.nscala_time.time.OrderingImplicits._
 import org.joda.time.LocalDate
 import org.joda.time.LocalDate.now
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import play.api.mvc.Result
 import play.api.mvc.Results.Ok
-import scalaz.syntax.std.boolean._
 
 import scala.language.implicitConversions
+import scalaz.syntax.std.boolean._
 
 case class ContentAccess(member: Boolean, paidMember: Boolean, recurringContributor: Boolean, digitalPack: Boolean)
 
@@ -62,9 +63,9 @@ case class Attributes(
   lazy val isPaidTier = isSupporterTier || isPartnerTier || isPatronTier || isStaffTier
   lazy val isAdFree = AdFree.exists(identity)
   lazy val isContributor = RecurringContributionPaymentPlan.isDefined
-  lazy val staffExpiryDate: Option[LocalDate] = Tier.exists(_.equalsIgnoreCase("staff")).option(now.plusDays(1))
-  lazy val logicalDigitalSubscriptionExpiryDate =  Some(Set(staffExpiryDate, DigitalSubscriptionExpiryDate).flatten).filter(_.nonEmpty).map(_.max)
-  lazy val digitalSubscriberHasActivePlan = logicalDigitalSubscriptionExpiryDate.exists(_.isAfter(now))
+  lazy val staffDigitalSubscriptionExpiryDate: Option[LocalDate] = Tier.exists(_.equalsIgnoreCase("staff")).option(now.plusDays(1))
+  lazy val latestDigitalSubscriptionExpiryDate =  Some(Set(staffDigitalSubscriptionExpiryDate, DigitalSubscriptionExpiryDate).flatten).filter(_.nonEmpty).map(_.max)
+  lazy val digitalSubscriberHasActivePlan = latestDigitalSubscriptionExpiryDate.exists(_.isAfter(now))
 
   lazy val contentAccess = ContentAccess(member = isPaidTier || isFriendTier, paidMember = isPaidTier, recurringContributor = isContributor, digitalPack = digitalSubscriberHasActivePlan)
 }
@@ -80,7 +81,7 @@ object Attributes {
     (__ \ "recurringContributionPaymentPlan").writeNullable[String] and
     (__ \ "membershipJoinDate").writeNullable[LocalDate] and
     (__ \ "digitalSubscriptionExpiryDate").writeNullable[LocalDate]
-    )(unlift(Attributes.unapply)).addField("digitalSubscriptionExpiryDate", _.logicalDigitalSubscriptionExpiryDate).addField("contentAccess", _.contentAccess)
+    )(unlift(Attributes.unapply)).addNullableField("digitalSubscriptionExpiryDate", _.latestDigitalSubscriptionExpiryDate).addField("contentAccess", _.contentAccess)
 
   implicit def toResult(attrs: Attributes): Result =
     Ok(Json.toJson(attrs))

--- a/membership-attribute-service/app/services/AttributesMaker.scala
+++ b/membership-attribute-service/app/services/AttributesMaker.scala
@@ -7,7 +7,6 @@ import com.gu.memsub.{Benefit, Product}
 import com.typesafe.scalalogging.LazyLogging
 import models.Attributes
 import org.joda.time.LocalDate
-import org.joda.time.LocalDate.now
 
 import scalaz.syntax.std.boolean._
 
@@ -41,13 +40,12 @@ class AttributesMaker extends LazyLogging {
       val recurringContributionPaymentPlan: Option[String] = contributionSub.flatMap(getTopPlanName)
       val membershipJoinDate: Option[LocalDate] = membershipSub.map(_.startDate)
       val latestDigitalPackExpiryDate: Option[LocalDate] = Some(subsWhichIncludeDigitalPack.map(_.termEndDate)).filter(_.nonEmpty).map(_.max)
-      val staffExpiryDate: Option[LocalDate] = tier.exists(_.equalsIgnoreCase("staff")).option(now.plusDays(1))
       Attributes(
         UserId = identityId,
         Tier = tier,
         RecurringContributionPaymentPlan = recurringContributionPaymentPlan,
         MembershipJoinDate = membershipJoinDate,
-        DigitalSubscriptionExpiryDate = latestDigitalPackExpiryDate orElse staffExpiryDate
+        DigitalSubscriptionExpiryDate = latestDigitalPackExpiryDate
       )
     }
   }


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
For the Daily Edition - allow staff access

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->

Moved the logic to override the DigitalSubscriptionExpiryDate to with… ……in the case class itself so that it works when the class is constructed from Zuora or from a serialised Staff membership or Digital Supporter representation.

cc @johnduffell @aodhol @lmath @pvighi 
