### PR TITLE
Move Zuora lookup code out of the controller

### DIFF
--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -64,6 +64,7 @@ class TouchpointComponents(stage: String)(implicit system: ActorSystem) {
   )
   lazy val contactRepo = new SimpleContactRepository(tpConfig.salesforce, system.scheduler, Config.applicationName)
   lazy val attrService: AttributeService = new ScanamoAttributeService(new AmazonDynamoDBAsyncClient(com.gu.aws.CredentialsProvider).withRegion(Regions.EU_WEST_1), dynamoAttributesTable)
+  lazy val zuoraAttrService: ZuoraAttributeService = new ZuoraAttributeService(zuoraRestService, subService, attrService)
   lazy val behaviourService: BehaviourService = new ScanamoBehaviourService(new AmazonDynamoDBAsyncClient(com.gu.aws.CredentialsProvider).withRegion(Regions.EU_WEST_1), dynamoBehaviourTable)
   lazy val featureToggleService: ScanamoFeatureToggleService = new ScanamoFeatureToggleService(new AmazonDynamoDBAsyncClient(com.gu.aws.CredentialsProvider).withRegion(Regions.EU_WEST_1), dynamoFeatureToggleTable)
   lazy val snsGiraffeService: SNSGiraffeService = SNSGiraffeService(giraffeSns)

--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -7,6 +7,7 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
 import scalaz.std.scalaFuture._
 import com.gu.config
 import com.gu.memsub.services.PaymentService
+import com.gu.memsub.subsv2.SubscriptionPlan.AnyPlan
 import com.gu.memsub.subsv2.services.SubscriptionService.CatalogMap
 import com.gu.memsub.subsv2.services._
 import com.gu.monitoring.ServiceMetrics
@@ -64,7 +65,7 @@ class TouchpointComponents(stage: String)(implicit system: ActorSystem) {
   )
   lazy val contactRepo = new SimpleContactRepository(tpConfig.salesforce, system.scheduler, Config.applicationName)
   lazy val attrService: AttributeService = new ScanamoAttributeService(new AmazonDynamoDBAsyncClient(com.gu.aws.CredentialsProvider).withRegion(Regions.EU_WEST_1), dynamoAttributesTable)
-  lazy val zuoraAttrService: ZuoraAttributeService = new ZuoraAttributeService(zuoraRestService, subService, attrService)
+  lazy val zuoraAttrService: ZuoraAttributeService = new ZuoraAttributeService(accountId => zuoraRestService.getAccounts(accountId), accountId => reads => subService.subscriptionsForAccountId[AnyPlan](accountId)(reads), attrService)
   lazy val behaviourService: BehaviourService = new ScanamoBehaviourService(new AmazonDynamoDBAsyncClient(com.gu.aws.CredentialsProvider).withRegion(Regions.EU_WEST_1), dynamoBehaviourTable)
   lazy val featureToggleService: ScanamoFeatureToggleService = new ScanamoFeatureToggleService(new AmazonDynamoDBAsyncClient(com.gu.aws.CredentialsProvider).withRegion(Regions.EU_WEST_1), dynamoFeatureToggleTable)
   lazy val snsGiraffeService: SNSGiraffeService = SNSGiraffeService(giraffeSns)

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -1,15 +1,9 @@
 package controllers
 import actions._
-import com.gu.memsub.Subscription.AccountId
-import com.gu.memsub.subsv2.SubscriptionPlan.AnyPlan
 import com.gu.memsub.subsv2.reads.ChargeListReads._
 import com.gu.memsub.subsv2.reads.SubPlanReads._
-import com.gu.memsub.subsv2.services.SubscriptionService
 import com.gu.memsub.subsv2.{Subscription, SubscriptionPlan}
 import com.gu.scanamo.error.DynamoReadError
-import com.gu.zuora.ZuoraRestService
-import com.gu.zuora.ZuoraRestService.QueryResponse
-import loghandling.ZuoraRequestCounter
 import configuration.Config
 import configuration.Config.authentication
 import loghandling.LoggingField.{LogField, LogFieldString}
@@ -19,23 +13,18 @@ import models.ApiErrors._
 import models.Features._
 import models._
 import monitoring.Metrics
-import org.joda.time.LocalDate
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.Json
 import play.api.mvc._
 import play.filters.cors.CORSActionBuilder
-import services.{AttributeService, AttributesMaker, AuthenticationService, IdentityAuthService}
+import prodtest.Allocator._
+import services.{AuthenticationService, IdentityAuthService}
 
 import scala.concurrent.Future
 import scalaz.std.scalaFuture._
-import scalaz.syntax.std.option._
-import prodtest.Allocator._
-
-import scalaz.{-\/, Disjunction, EitherT, \/, \/-}
 import scalaz.syntax.std.either._
-import scalaz._
-import std.list._
-import syntax.traverse._
+import scalaz.syntax.std.option._
+import scalaz.{EitherT, \/}
 
 
 class AttributeController extends Controller with LoggingWithLogstashFields {
@@ -63,7 +52,7 @@ class AttributeController extends Controller with LoggingWithLogstashFields {
       if(endpointEligibleForTest){
         val percentageInTest = request.touchpoint.featureToggleData.getPercentageTrafficForZuoraLookupTask.get()
         isInTest(identityId, percentageInTest) match {
-          case true => ("Zuora", attributesFromZuora(identityId, request.touchpoint.patientZuoraRestService, request.touchpoint.subService, request.touchpoint.attrService))
+          case true => ("Zuora", request.touchpoint.zuoraAttrService.attributesFromZuora(identityId))
           case false => ("Dynamo", request.touchpoint.attrService.get(identityId))
         }
       } else ("Dynamo", request.touchpoint.attrService.get(identityId))
@@ -107,114 +96,11 @@ class AttributeController extends Controller with LoggingWithLogstashFields {
       }
   }
 
-
-  private def attributesFromZuora(identityId: String, patientZuoraRestService: ZuoraRestService[Future], subscriptionService: SubscriptionService[Future], attributeService: AttributeService): Future[Option[Attributes]] = {
-
-    def withTimer[R](whichCall: String, futureResult: Future[Disjunction[String, R]]) = {
-      import loghandling.StopWatch
-      val stopWatch = new StopWatch
-
-      futureResult.map { disjunction: Disjunction[String, R] =>
-        disjunction match {
-          case -\/(message) => log.warn(s"$whichCall failed with: $message")
-          case \/-(_) =>
-            val latency = stopWatch.elapsed
-            val zuoraConcurrencyCount = ZuoraRequestCounter.get
-            val customFields: List[LogField] = List("zuora_latency_millis" -> latency.toInt, "zuora_call" -> whichCall, "identityId" -> identityId, "zuora_concurrency_count" -> zuoraConcurrencyCount)
-            logInfoWithCustomFields(s"$whichCall took ${latency}ms.", customFields)
-        }
-      }.onFailure {
-        case e: Throwable => log.error(s"Future failed when attempting $whichCall.", e)
-      }
-      futureResult
-    }
-
-    def queryToAccountIds(response: QueryResponse): List[AccountId] =  response.records.map(_.Id)
-
-    def getSubscriptions(accountIds: List[AccountId]): Future[Disjunction[String, List[Subscription[AnyPlan]]]] = {
-
-      def sub(accountId: AccountId): Future[Disjunction[String, List[Subscription[AnyPlan]]]] =
-        subscriptionService.subscriptionsForAccountId[AnyPlan](accountId)(anyPlanReads)
-
-      val maybeSubs: Future[Disjunction[String, List[Subscription[AnyPlan]]]] = accountIds.traverseU(id => sub(id)).map(_.sequenceU.map(_.flatten))
-      maybeSubs.map {
-        _.leftMap { errorMsg =>
-          log.warn(s"We tried getting subscription for a user with identityId $identityId, but then $errorMsg")
-          s"We called Zuora to get subscriptions for a user with identityId $identityId but the call failed"
-        } map { subs =>
-          log.info(s"We got subs for identityId $identityId from Zuora and there were ${subs.length}")
-          subs
-        }
-      }
-    }
-
-    def zuoraAccountsQuery(identityId: String): Future[Disjunction[String, QueryResponse]] = patientZuoraRestService.getAccounts(identityId).map {
-      _.leftMap {error =>
-        log.warn(s"Calling ZuoraAccountIdsFromIdentityId failed for identityId $identityId. with error: ${error}")
-        s"Calling ZuoraAccountIdsFromIdentityId failed for identityId $identityId."
-      }
-    }
-
-    def compareThenLogAttributes(attributesFromDynamo: Future[Option[Attributes]], attributesFromZuora: Future[Option[Attributes]]): Unit = {
-      attributesFromDynamo map { maybeDynamoAttributes =>
-        attributesFromZuora map { maybeZuoraAttributes =>
-          val zuoraAttributesWithIgnoredFields = maybeZuoraAttributes flatMap  { zuoraAttributes =>
-            maybeDynamoAttributes map { dynamoAttributes =>
-              zuoraAttributes.copy(
-                AdFree = dynamoAttributes.AdFree, //fetched from Dynamo in the Zuora lookup anyway (dynamo is the source of truth)
-                Wallet = dynamoAttributes.Wallet, //can't be found based on Zuora lookups, and not currently used
-                MembershipNumber = dynamoAttributes.MembershipNumber, //I don't think membership number is needed and it comes from Salesforce
-                MembershipJoinDate = dynamoAttributes.MembershipJoinDate.flatMap(_ => zuoraAttributes.MembershipJoinDate), //only compare if dynamo has value
-                DigitalSubscriptionExpiryDate = None
-              )
-            }
-          }
-          if (zuoraAttributesWithIgnoredFields != maybeDynamoAttributes)
-            log.info(s"We looked up attributes via Zuora for $identityId and Zuora and Dynamo disagreed." +
-              s" Zuora attributes: $maybeZuoraAttributes. Dynamo attributes: $maybeDynamoAttributes.")
-        }
-      }
-    }
-
-    val attributesDisjunction = for {
-      accounts <- EitherT[Future, String, QueryResponse](withTimer(s"ZuoraAccountIdsFromIdentityId", zuoraAccountsQuery(identityId)))
-      accountIds = queryToAccountIds(accounts)
-      subscriptions <- EitherT[Future, String, List[Subscription[AnyPlan]]](
-        if(accountIds.nonEmpty) withTimer(s"ZuoraGetSubscriptions", getSubscriptions(accountIds))
-        else Future.successful(\/.right {
-          log.info(s"User with identityId $identityId has no accountIds and thus no subscriptions.")
-          Nil
-        })
-      )
-    } yield {
-      AttributesMaker.attributes(identityId, subscriptions, LocalDate.now())
-    }
-
-    val attributes = attributesDisjunction.run.map {
-      _.leftMap { errorMsg =>
-        log.error(s"Tried to get Attributes for $identityId but failed with $errorMsg")
-        errorMsg
-      }.fold(_ => None, identity)
-    }
-
-    val attributesFromDynamo: Future[Option[Attributes]] = attributeService.get(identityId)
-
-    compareThenLogAttributes(attributesFromDynamo, attributes)
-
-    val adFreeFlagFromDynamo = attributesFromDynamo map (_.flatMap(_.AdFree))
-
-    attributes flatMap { maybeAttributes =>
-      adFreeFlagFromDynamo map { adFree =>
-        maybeAttributes map {_.copy(AdFree = adFree)}
-      }
-    }
-  }
-
   private def zuoraLookup(endpointDescription: String) =
     backendAction.async { implicit request =>
       authenticationService.userId(request) match {
         case Some(identityId) =>
-          attributesFromZuora(identityId, request.touchpoint.patientZuoraRestService, request.touchpoint.subService, request.touchpoint.attrService).map {
+          request.touchpoint.zuoraAttrService.attributesFromZuora(identityId).map {
             case Some(attrs) =>
               log.info(s"Successfully retrieved attributes from Zuora for user $identityId: $attrs")
               attrs

--- a/membership-attribute-service/app/services/ZuoraAttributeService.scala
+++ b/membership-attribute-service/app/services/ZuoraAttributeService.scala
@@ -1,0 +1,152 @@
+package services
+import com.gu.memsub.Subscription.AccountId
+import com.gu.memsub.subsv2.Subscription
+import com.gu.memsub.subsv2.SubscriptionPlan.AnyPlan
+import com.gu.memsub.subsv2.reads.SubPlanReads.anyPlanReads
+import com.gu.memsub.subsv2.services.SubscriptionService
+import com.gu.zuora.ZuoraRestService
+import com.gu.zuora.ZuoraRestService.QueryResponse
+import loghandling.LoggingField.LogField
+import loghandling.{LoggingWithLogstashFields, ZuoraRequestCounter}
+import models.Attributes
+import org.joda.time.LocalDate
+import play.api.libs.concurrent.Execution.Implicits._
+
+import scalaz.{-\/, Disjunction, EitherT, \/, \/-}
+import scala.concurrent.Future
+import scalaz.std.scalaFuture._
+import scalaz.syntax.std.option._
+
+import scalaz.syntax.std.either._
+import scalaz._
+import std.list._
+import syntax.traverse._
+
+
+class ZuoraAttributeService(patientZuoraRestService: ZuoraRestService[Future], subscriptionService: SubscriptionService[Future], scanamoAttributeService: AttributeService) extends LoggingWithLogstashFields {
+
+  def get(userId: String): Future[Option[Attributes]] = attributesFromZuora(userId)
+
+  def attributesFromZuora(identityId: String): Future[Option[Attributes]] = {
+
+    val attributesDisjunction = for {
+      accounts <- EitherT[Future, String, QueryResponse](withTimer(s"ZuoraAccountIdsFromIdentityId", zuoraAccountsQuery(identityId, patientZuoraRestService), identityId))
+      accountIds = queryToAccountIds(accounts)
+      subscriptions <- EitherT[Future, String, List[Subscription[AnyPlan]]](
+        if(accountIds.nonEmpty) withTimer(s"ZuoraGetSubscriptions", getSubscriptions(accountIds, identityId), identityId)
+        else Future.successful(\/.right {
+          log.info(s"User with identityId $identityId has no accountIds and thus no subscriptions.")
+          Nil
+        })
+      )
+    } yield {
+      AttributesMaker.attributes(identityId, subscriptions, LocalDate.now())
+    }
+
+    val attributes = attributesDisjunction.run.map {
+      _.leftMap { errorMsg =>
+        log.error(s"Tried to get Attributes for $identityId but failed with $errorMsg")
+        errorMsg
+      }.fold(_ => None, identity)
+    }
+
+    val attributesFromDynamo: Future[Option[Attributes]] = scanamoAttributeService.get(identityId)
+
+    dynamoAndZuoraAgree(attributesFromDynamo, attributes, identityId)
+
+    attributesWithFlagFromDynamo(attributes, attributesFromDynamo)
+  }
+
+
+  def attributesWithFlagFromDynamo(attributesFromZuora: Future[Option[Attributes]], attributesFromDynamo: Future[Option[Attributes]]) = {
+    val adFreeFlagFromDynamo = attributesFromDynamo map (_.flatMap(_.AdFree))
+
+    attributesFromZuora flatMap { maybeAttributes =>
+      adFreeFlagFromDynamo map { adFree =>
+        maybeAttributes map {_.copy(AdFree = adFree)}
+      }
+    }
+  }
+
+
+  def getSubscriptions(accountIds: List[AccountId], identityId: String): Future[Disjunction[String, List[Subscription[AnyPlan]]]] = {
+
+    def sub(accountId: AccountId): Future[Disjunction[String, List[Subscription[AnyPlan]]]] = {
+      val x = subscriptionService.subscriptionsForAccountId[AnyPlan](accountId)(anyPlanReads)
+      println("subscription?? "+x)
+      println("accountID?? "+accountId)
+      println(".... as a string "+accountId.get)
+      x
+    }
+
+    val maybeSubs: Future[Disjunction[String, List[Subscription[AnyPlan]]]] = accountIds.traverse[Future, Disjunction[String, List[Subscription[AnyPlan]]]](id => {
+      sub(id)
+    }).map(_.sequenceU.map(_.flatten))
+
+//    val maybeSubs: Future[Disjunction[String, List[Subscription[AnyPlan]]]] = accountIds.traverseU(id => sub(id)).map(_.sequenceU.map(_.flatten))
+
+    maybeSubs.map {
+      _.leftMap { errorMsg =>
+        log.warn(s"We tried getting subscription for a user with identityId $identityId, but then $errorMsg")
+        s"We called Zuora to get subscriptions for a user with identityId $identityId but the call failed"
+      } map { subs =>
+        log.info(s"We got subs for identityId $identityId from Zuora and there were ${subs.length}")
+        subs
+      }
+    }
+  }
+
+  private def withTimer[R](whichCall: String, futureResult: Future[Disjunction[String, R]], identityId: String) = {
+    import loghandling.StopWatch
+    val stopWatch = new StopWatch
+
+    futureResult.map { disjunction: Disjunction[String, R] =>
+      disjunction match {
+        case -\/(message) => log.warn(s"$whichCall failed with: $message")
+        case \/-(_) =>
+          val latency = stopWatch.elapsed
+          val zuoraConcurrencyCount = ZuoraRequestCounter.get
+          val customFields: List[LogField] = List("zuora_latency_millis" -> latency.toInt, "zuora_call" -> whichCall, "identityId" -> identityId, "zuora_concurrency_count" -> zuoraConcurrencyCount)
+          logInfoWithCustomFields(s"$whichCall took ${latency}ms.", customFields)
+      }
+    }.onFailure {
+      case e: Throwable => log.error(s"Future failed when attempting $whichCall.", e)
+    }
+    futureResult
+  }
+
+  def dynamoAndZuoraAgree(attributesFromDynamo: Future[Option[Attributes]], attributesFromZuora: Future[Option[Attributes]], identityId: String): Future[Boolean] = {
+    attributesFromDynamo flatMap { maybeDynamoAttributes =>
+      attributesFromZuora map { maybeZuoraAttributes =>
+        val zuoraAttributesWithIgnoredFields = maybeZuoraAttributes flatMap  { zuoraAttributes =>
+          maybeDynamoAttributes map { dynamoAttributes =>
+            zuoraAttributes.copy(
+              AdFree = dynamoAttributes.AdFree, //fetched from Dynamo in the Zuora lookup anyway (dynamo is the source of truth)
+              Wallet = dynamoAttributes.Wallet, //can't be found based on Zuora lookups, and not currently used
+              MembershipNumber = dynamoAttributes.MembershipNumber, //I don't think membership number is needed and it comes from Salesforce
+              MembershipJoinDate = dynamoAttributes.MembershipJoinDate.flatMap(_ => zuoraAttributes.MembershipJoinDate), //only compare if dynamo has value
+              DigitalSubscriptionExpiryDate = None
+            )
+          }
+        }
+        val dynamoAndZuoraAgree = zuoraAttributesWithIgnoredFields == maybeDynamoAttributes
+        if (!dynamoAndZuoraAgree)
+          log.info(s"We looked up attributes via Zuora for $identityId and Zuora and Dynamo disagreed." +
+            s" Zuora attributes: $maybeZuoraAttributes. Dynamo attributes: $maybeDynamoAttributes.")
+
+        dynamoAndZuoraAgree
+      }
+    }
+  }
+
+  def queryToAccountIds(response: QueryResponse): List[AccountId] =  response.records.map(_.Id)
+
+  def zuoraAccountsQuery(identityId: String, patientZuoraRestService: ZuoraRestService[Future]): Future[Disjunction[String, QueryResponse]] =
+    patientZuoraRestService.getAccounts(identityId).map {
+      _.leftMap { error =>
+        log.warn(s"Calling ZuoraAccountIdsFromIdentityId failed for identityId $identityId. with error: ${error}")
+        s"Calling ZuoraAccountIdsFromIdentityId failed for identityId $identityId."
+    }
+  }
+}
+

--- a/membership-attribute-service/app/services/ZuoraAttributeService.scala
+++ b/membership-attribute-service/app/services/ZuoraAttributeService.scala
@@ -35,9 +35,7 @@ class ZuoraAttributeService(identityIdToAccountIds: String => Future[String \/ Q
         })
       )
     } yield {
-      val whatami = AttributesMaker.attributes(identityId, subscriptions, LocalDate.now())
-      println(whatami)
-      whatami
+      AttributesMaker.attributes(identityId, subscriptions, LocalDate.now())
     }
 
     val attributes = attributesDisjunction.run.map {

--- a/membership-attribute-service/test/services/AttributesMakerTest.scala
+++ b/membership-attribute-service/test/services/AttributesMakerTest.scala
@@ -1,69 +1,15 @@
 package services
 
-import com.gu.i18n.Currency.GBP
-import com.gu.memsub.Benefit._
-import com.gu.memsub.Subscription.{ProductRatePlanChargeId, ProductRatePlanId, RatePlanId}
 import com.github.nscala_time.time.Implicits._
-import com.gu.memsub.{Product, Benefit, BillingPeriod, PricingSummary, Price}
-import com.gu.memsub.Subscription._
-import com.gu.memsub.subsv2._
 import models.Attributes
-import org.joda.time.LocalDate
 import org.specs2.mutable.Specification
 
-import scalaz.NonEmptyList
+import testdata.SubscriptionTestDataHelper._
 
 class AttributesMakerTest extends Specification {
 
   "attributes" should {
-    val referenceDate = new LocalDate(2016, 10, 26)
-
-    val friendPlan = FreeSubscriptionPlan[Product.Membership, FreeCharge[Benefit.Friend.type]](
-      RatePlanId("idFriend"), ProductRatePlanId("prpi"), "Friend", "desc", "Friend", Product.Membership,FreeCharge(Friend, Set(GBP)), referenceDate
-    )
-    def supporterPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan.Supporter = PaidSubscriptionPlan[Product.Membership, PaidCharge[Benefit.Supporter.type, BillingPeriod]](
-      RatePlanId("idSupporter"), ProductRatePlanId("prpi"), "Supporter", "desc", "Supporter", Product.Membership, List.empty, PaidCharge(Supporter, BillingPeriod.Year, PricingSummary(Map(GBP -> Price(49.0f, GBP))), ProductRatePlanChargeId("bar")), None, startDate, endDate
-    )
-    def digipackPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan.Digipack = PaidSubscriptionPlan[Product.ZDigipack, PaidCharge[Benefit.Digipack.type, BillingPeriod]](
-      RatePlanId("idDigipack"), ProductRatePlanId("prpi"), "Digipack", "desc", "Digital Pack", Product.Digipack, List.empty, PaidCharge(Digipack, BillingPeriod.Year, PricingSummary(Map(GBP -> Price(119.90f, GBP))), ProductRatePlanChargeId("baz")), None, startDate, endDate
-    )
-    def paperPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan.Delivery = PaidSubscriptionPlan[Product.Delivery, PaperCharges](
-      RatePlanId("idDigipack"), ProductRatePlanId("prpi"), "Sunday", "desc", "Sunday", Product.Delivery, List.empty, PaperCharges(Seq((SundayPaper, PricingSummary(Map(GBP -> Price(5.07f, GBP))))).toMap, None), None, startDate, endDate
-    )
-    def paperPlusPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan.Delivery = PaidSubscriptionPlan[Product.Delivery, PaperCharges](
-      RatePlanId("idDigipack"), ProductRatePlanId("prpi"), "Sunday+", "desc", "Sunday+", Product.Delivery, List.empty, PaperCharges(Seq((SundayPaper, PricingSummary(Map(GBP -> Price(5.07f, GBP))))).toMap, Some(PricingSummary(Map(GBP -> Price(119.90f, GBP))))), None, startDate, endDate
-    )
-    def contributorPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan.Contributor = PaidSubscriptionPlan[Product.Contribution, PaidCharge[Benefit.Contributor.type, BillingPeriod]](
-      RatePlanId("idContributor"), ProductRatePlanId("prpi"), "Monthly Contribution", "desc", "Monthly Contribution", Product.Contribution, List.empty, PaidCharge(Contributor, BillingPeriod.Month, PricingSummary(Map(GBP -> Price(5.0f, GBP))), ProductRatePlanChargeId("bar")), None, startDate, endDate
-    )
-
-    def toSubscription[P <: SubscriptionPlan.AnyPlan](isCancelled: Boolean)(plans: NonEmptyList[P]): Subscription[P] = {
-      Subscription(
-        id = Id(plans.head.id.get),
-        name = Name("AS-123123"),
-        accountId = AccountId("accountId"),
-        startDate = plans.head.start,
-        acceptanceDate = plans.head.start,
-        termStartDate = plans.head.start,
-        termEndDate = plans.head.start + 1.year,
-        casActivationDate = None,
-        promoCode = None,
-        isCancelled = isCancelled,
-        hasPendingFreePlan = false,
-        plans = plans,
-        readerType = ReaderType.Direct,
-        autoRenew = true
-      )
-    }
-
     val testId = "123"
-    val digipack = toSubscription(false)(NonEmptyList(digipackPlan(referenceDate, referenceDate + 1.year)))
-    val sunday = toSubscription(false)(NonEmptyList(paperPlan(referenceDate, referenceDate + 1.year)))
-    val sundayPlus = toSubscription(false)(NonEmptyList(paperPlusPlan(referenceDate, referenceDate + 1.year)))
-    val membership = toSubscription(false)(NonEmptyList(supporterPlan(referenceDate, referenceDate + 1.year)))
-    val expiredMembership = toSubscription(false)(NonEmptyList(supporterPlan(referenceDate - 2.year, referenceDate - 1.year)))
-    val friend = toSubscription(false)(NonEmptyList(friendPlan))
-    val contributor = toSubscription(false)(NonEmptyList(contributorPlan(referenceDate, referenceDate + 1.month)))
 
     "return attributes when digipack sub" in {
       val expected = Some(Attributes(

--- a/membership-attribute-service/test/services/AttributesMakerTest.scala
+++ b/membership-attribute-service/test/services/AttributesMakerTest.scala
@@ -2,11 +2,12 @@ package services
 
 import com.github.nscala_time.time.Implicits._
 import models.Attributes
+import org.joda.time.LocalDate
 import org.specs2.mutable.Specification
+import testdata.SubscriptionTestData
 
-import testdata.SubscriptionTestDataHelper._
-
-class AttributesMakerTest extends Specification {
+class AttributesMakerTest extends Specification with SubscriptionTestData {
+  override def referenceDate = new LocalDate(2016, 10, 26)
 
   "attributes" should {
     val testId = "123"

--- a/membership-attribute-service/test/services/ZuoraAttributeServiceTest.scala
+++ b/membership-attribute-service/test/services/ZuoraAttributeServiceTest.scala
@@ -1,0 +1,157 @@
+package services
+
+import com.gu.memsub.Subscription.AccountId
+import com.gu.memsub.subsv2.{ChargeList, Subscription, SubscriptionPlan}
+import com.gu.memsub.subsv2.SubscriptionPlan.{AnyPlan, Contributor}
+import com.gu.memsub.subsv2.reads.SubPlanReads
+import com.gu.memsub.subsv2.services.SubscriptionService
+import com.gu.zuora.ZuoraRestService
+import com.gu.zuora.ZuoraRestService.{AccountIdRecord, QueryResponse}
+import com.gu.zuora.rest.SimpleClient
+import models.Attributes
+import org.joda.time.LocalDate
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+
+import scala.concurrent.{Await, Future}
+import scalaz.{Disjunction, \/}
+import testdata.SubscriptionTestDataHelper._
+
+class ZuoraAttributeServiceTest(implicit ee: ExecutionEnv) extends Specification with Mockito {
+
+  val testId = "12345"
+//  val testAccountId = AccountId("AS-123123")
+  val testAccountId = AccountId("accountId")
+  val joinDate = new LocalDate(2017, 2, 26)
+  val oneAccountQueryResponse = QueryResponse(records = List(AccountIdRecord(testAccountId)), size = 1)
+  val contributorAttributes = Attributes(UserId = testId, None, None, None, None, RecurringContributionPaymentPlan = Some("Monthly Contributor"), None, None)
+  val friendAttributes = Attributes(UserId = testId, Some("Friend"), None, None, None, None, Some(joinDate), None)
+  val supporterAttributes = Attributes(UserId = testId, Some("Supporter"), None, None, None, None, Some(joinDate), None)
+
+  "ZuoraAttributeService" should {
+
+    "attributesFromZuora" should {
+      "return attributes for a user who has one subscription" in new happyContributorAttributes {
+        zuoraAttributeService.attributesFromZuora(testId)
+       ok
+      }
+
+      "return attributes for a user who has many subscriptions" in {
+        ok
+      }
+
+      "get the value of the adfree flag from the dynamo attributes" in {
+        ok
+      }
+
+      "return None and not make additional calls to get subscriptions if the user has no account ids" in {
+        ok
+      }
+    }
+
+    "getSubscriptions" should {
+      "get a contributor subscription for a user who is a contributor" in new happyContributorAttributes {
+        val subscriptions = zuoraAttributeService.getSubscriptions(List(testAccountId), testId)
+
+        subscriptions === contributor
+      }
+
+      "get all subscriptions if a user has multiple" in {
+        ok
+      }
+
+      "get an empty list of subscriptions for a user who doesn't have any " in {
+        ok
+      }
+
+      "return a left with error message if the subscription service returns a left" in {
+        ok
+      }
+    }
+
+    "queryToAccountIds" should {
+      "extract an AccountId from a query response" in new happyContributorAttributes {
+        val accountIds: List[AccountId] = zuoraAttributeService.queryToAccountIds(oneAccountQueryResponse)
+        accountIds === List(testAccountId)
+      }
+
+      "return an empty list when no account ids" in new happyContributorAttributes {
+        val emptyResponse = QueryResponse(records = Nil, size = 0)
+        val accountIds: List[AccountId] = zuoraAttributeService.queryToAccountIds(emptyResponse)
+        accountIds === Nil
+      }
+    }
+
+    "dynamoAndZuoraAgree" should {
+      "return true if the fields obtainable from zuora match " in new happyContributorAttributes {
+        val fromDynamo = Future.successful(Some(supporterAttributes))
+        val fromZuora = Future.successful(Some(supporterAttributes))
+
+        zuoraAttributeService.dynamoAndZuoraAgree(fromDynamo, fromZuora, testId) must be_==(true).await
+      }
+
+      "ignore the fields not obtainable from zuora" in new happyContributorAttributes {
+        val fromDynamo = Future.successful(Some(supporterAttributes.copy(AdFree = Some(true))))
+        val fromZuora = Future.successful(Some(supporterAttributes))
+
+        zuoraAttributeService.dynamoAndZuoraAgree(fromDynamo, fromZuora, testId) must be_==(true).await
+      }
+
+      "return false when dynamo is outdated and does not match zuora" in new happyContributorAttributes {
+        val fromDynamo = Future.successful(Some(supporterAttributes))
+        val fromZuora = Future.successful(Some(friendAttributes))
+
+        zuoraAttributeService.dynamoAndZuoraAgree(fromDynamo, fromZuora, testId) must be_==(false).await
+      }
+    }
+
+    "attributesWithFlagFromDynamo" should {
+      "update return attributes with only adFree status copied from the dynamo attributes" in new happyContributorAttributes {
+        val fromDynamo = Future.successful(Some(contributorAttributes.copy(AdFree = Some(true), Tier = Some("Partner"))))
+        val fromZuora = Future.successful(Some(contributorAttributes))
+
+        val expectedResult = Some(contributorAttributes.copy(AdFree = Some(true)))
+
+        zuoraAttributeService.attributesWithFlagFromDynamo(fromZuora, fromDynamo) must be_==(expectedResult).await
+      }
+
+      "not have an AdFree status either if there isn't one in dynamo" in new happyContributorAttributes {
+        val fromDynamo = Future.successful(Some(contributorAttributes.copy(Tier = Some("Partner"))))
+        val fromZuora = Future.successful(Some(contributorAttributes))
+
+        zuoraAttributeService.attributesWithFlagFromDynamo(fromZuora, fromDynamo) must be_==(Some(contributorAttributes)).await
+      }
+    }
+
+  }
+
+  trait happyContributorAttributes extends Scope {
+    //test Id has one subscription and it's a recurring contribution atm
+    implicit val mockSimpleClient = mock[SimpleClient[Future]]
+    val mockPatientZuoraRestService = mock[ZuoraRestService[Future]]
+    val mockSubscriptionService = mock[SubscriptionService[Future]]
+    val mockScanamoService = mock[AttributeService]
+
+    import ZuoraRestService._
+    import com.gu.memsub.subsv2.reads.SubPlanReads.anyPlanReads
+
+
+    def cannedResponse(identityId: String): Future[\/[String, QueryResponse]] = Future.successful(if(identityId == testId) \/.left(s"account ids not found for $testId") else \/.right(oneAccountQueryResponse))
+    mockSimpleClient.post[RestQuery, QueryResponse]("action/query", RestQuery(s"select Id from account where IdentityId__c = '$testId'")) returns cannedResponse(testId)
+    mockPatientZuoraRestService.getAccounts(testId) returns cannedResponse(testId)
+
+    def cannedSubsResponse(accountId: AccountId) = Future.successful(if(accountId != testAccountId) \/.left(s"subscriptions not found for $testId") else \/.right(List(contributor)))
+    implicit def anyPlanMatcher = any[SubPlanReads[AnyPlan]]
+    //    mockSubscriptionService.subscriptionsForAccountId[AnyPlan](testAccountId)(anyPlanReads) returns cannedSubsResponse(testAccountId)
+
+    mockSubscriptionService.subscriptionsForAccountId[AnyPlan](any[AccountId])(anyPlanMatcher) returns cannedSubsResponse(testAccountId)
+
+    mockScanamoService.get(testId) returns Future.successful(Some(contributorAttributes))
+
+    val zuoraAttributeService = new ZuoraAttributeService(mockPatientZuoraRestService, mockSubscriptionService, mockScanamoService)
+
+  }
+
+}

--- a/membership-attribute-service/test/services/ZuoraAttributeServiceTest.scala
+++ b/membership-attribute-service/test/services/ZuoraAttributeServiceTest.scala
@@ -1,83 +1,99 @@
 package services
 
 import com.gu.memsub.Subscription.AccountId
-import com.gu.memsub.subsv2.{ChargeList, Subscription, SubscriptionPlan}
-import com.gu.memsub.subsv2.SubscriptionPlan.{AnyPlan, Contributor}
+import com.gu.memsub.subsv2.SubscriptionPlan.AnyPlan
 import com.gu.memsub.subsv2.reads.SubPlanReads
-import com.gu.memsub.subsv2.services.SubscriptionService
-import com.gu.zuora.ZuoraRestService
 import com.gu.zuora.ZuoraRestService.{AccountIdRecord, QueryResponse}
-import com.gu.zuora.rest.SimpleClient
 import models.Attributes
 import org.joda.time.LocalDate
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
+import testdata.SubscriptionTestData
 
-import scala.concurrent.{Await, Future}
-import scalaz.{Disjunction, \/}
-import testdata.SubscriptionTestDataHelper._
+import scala.concurrent.Future
+import scalaz.\/
 
-class ZuoraAttributeServiceTest(implicit ee: ExecutionEnv) extends Specification with Mockito {
+
+class ZuoraAttributeServiceTest(implicit ee: ExecutionEnv) extends Specification with Mockito with SubscriptionTestData {
+
+  override def referenceDate = new LocalDate(2017, 9, 20)
 
   val testId = "12345"
-//  val testAccountId = AccountId("AS-123123")
   val testAccountId = AccountId("accountId")
-  val joinDate = new LocalDate(2017, 2, 26)
+  val anotherTestAccountId = AccountId("anotherTestAccountId")
+  val joinDate = referenceDate.plusWeeks(1)
+  val digitalPackExpirationDate = referenceDate.plusYears(1)
   val oneAccountQueryResponse = QueryResponse(records = List(AccountIdRecord(testAccountId)), size = 1)
-  val contributorAttributes = Attributes(UserId = testId, None, None, None, None, RecurringContributionPaymentPlan = Some("Monthly Contributor"), None, None)
+  val twoAccountsQueryResponse = QueryResponse(records = List(AccountIdRecord(testAccountId), AccountIdRecord(anotherTestAccountId)), size = 2)
+  val contributorAttributes = Attributes(UserId = testId, None, None, None, None, RecurringContributionPaymentPlan = Some("Monthly Contribution"), None, None)
+
   val friendAttributes = Attributes(UserId = testId, Some("Friend"), None, None, None, None, Some(joinDate), None)
   val supporterAttributes = Attributes(UserId = testId, Some("Supporter"), None, None, None, None, Some(joinDate), None)
 
   "ZuoraAttributeService" should {
 
     "attributesFromZuora" should {
-      "return attributes for a user who has one subscription" in new happyContributorAttributes {
-        zuoraAttributeService.attributesFromZuora(testId)
-       ok
+      "return attributes for a user who has one subscription" in new contributor {
+        val attributes: Future[Option[Attributes]] = zuoraAttributeService.attributesFromZuora(testId)
+        attributes must be_==(Some(contributorAttributes)).await
       }
 
-      "return attributes for a user who has many subscriptions" in {
-        ok
+      "return attributes for a user who has many subscriptions" in new contributorDigitalPack {
+        val attributes: Future[Option[Attributes]] = zuoraAttributeService.attributesFromZuora(testId)
+        attributes must be_==(Some(contributorDigitalPackAttributes)).await
       }
 
-      "get the value of the adfree flag from the dynamo attributes" in {
-        ok
+      "get the value of the adfree flag from the dynamo attributes" in new contributorDigitalPack {
+        val contributorDigitalPackAdfreeAttributes = contributorDigitalPackAttributes.copy(AdFree = Some(true))
+        val outdatedAttributesButWithAdFree = contributorDigitalPackAttributes.copy(DigitalSubscriptionExpiryDate = None, AdFree = Some(true))
+
+        mockScanamoService.get(testId) returns Future.successful(Some(outdatedAttributesButWithAdFree))
+
+        val attributes: Future[Option[Attributes]] = zuoraAttributeService.attributesFromZuora(testId)
+        attributes must be_==(Some(contributorDigitalPackAdfreeAttributes)).await
       }
 
-      "return None and not make additional calls to get subscriptions if the user has no account ids" in {
-        ok
+      "return None if the user has no account ids" in new noAccounts {
+        val attributes: Future[Option[Attributes]] = zuoraAttributeService.attributesFromZuora(testId)
+        attributes must be_==(None).await
       }
     }
 
     "getSubscriptions" should {
-      "get a contributor subscription for a user who is a contributor" in new happyContributorAttributes {
+      "get a contributor subscription for a user who is a contributor" in new contributor {
         val subscriptions = zuoraAttributeService.getSubscriptions(List(testAccountId), testId)
 
-        subscriptions === contributor
+        subscriptions must be_==(\/.right(List(contributor))).await
       }
 
-      "get all subscriptions if a user has multiple" in {
-        ok
+      "get all subscriptions if a user has multiple" in new contributorDigitalPack {
+        val subscriptions = zuoraAttributeService.getSubscriptions(List(testAccountId, anotherTestAccountId), testId)
+
+        subscriptions must be_==(\/.right(List(contributor, digipack))).await
       }
 
-      "get an empty list of subscriptions for a user who doesn't have any " in {
-        ok
+      "get an empty list of subscriptions for a user who doesn't have any " in new accountButNoSubscriptions {
+        val subscriptions = zuoraAttributeService.getSubscriptions(List(testAccountId), testId)
+
+        subscriptions must be_==(\/.right(Nil)).await
       }
 
-      "return a left with error message if the subscription service returns a left" in {
-        ok
+      "return a left with error message if the subscription service returns a left" in new errorWhenGettingSubs {
+        val subscriptions = zuoraAttributeService.getSubscriptions(List(testAccountId), testId)
+
+        subscriptions must be_==(\/.left(s"We called Zuora to get subscriptions for a user with identityId $testId but the call failed because $testErrorMessage")).await
       }
     }
 
     "queryToAccountIds" should {
-      "extract an AccountId from a query response" in new happyContributorAttributes {
+      "extract an AccountId from a query response" in new contributor {
         val accountIds: List[AccountId] = zuoraAttributeService.queryToAccountIds(oneAccountQueryResponse)
         accountIds === List(testAccountId)
       }
 
-      "return an empty list when no account ids" in new happyContributorAttributes {
+      "return an empty list when no account ids" in new contributor {
         val emptyResponse = QueryResponse(records = Nil, size = 0)
         val accountIds: List[AccountId] = zuoraAttributeService.queryToAccountIds(emptyResponse)
         accountIds === Nil
@@ -85,21 +101,21 @@ class ZuoraAttributeServiceTest(implicit ee: ExecutionEnv) extends Specification
     }
 
     "dynamoAndZuoraAgree" should {
-      "return true if the fields obtainable from zuora match " in new happyContributorAttributes {
+      "return true if the fields obtainable from zuora match " in new contributor {
         val fromDynamo = Future.successful(Some(supporterAttributes))
         val fromZuora = Future.successful(Some(supporterAttributes))
 
         zuoraAttributeService.dynamoAndZuoraAgree(fromDynamo, fromZuora, testId) must be_==(true).await
       }
 
-      "ignore the fields not obtainable from zuora" in new happyContributorAttributes {
+      "ignore the fields not obtainable from zuora" in new contributor {
         val fromDynamo = Future.successful(Some(supporterAttributes.copy(AdFree = Some(true))))
         val fromZuora = Future.successful(Some(supporterAttributes))
 
         zuoraAttributeService.dynamoAndZuoraAgree(fromDynamo, fromZuora, testId) must be_==(true).await
       }
 
-      "return false when dynamo is outdated and does not match zuora" in new happyContributorAttributes {
+      "return false when dynamo is outdated and does not match zuora" in new contributor {
         val fromDynamo = Future.successful(Some(supporterAttributes))
         val fromZuora = Future.successful(Some(friendAttributes))
 
@@ -108,7 +124,7 @@ class ZuoraAttributeServiceTest(implicit ee: ExecutionEnv) extends Specification
     }
 
     "attributesWithFlagFromDynamo" should {
-      "update return attributes with only adFree status copied from the dynamo attributes" in new happyContributorAttributes {
+      "update return attributes with only adFree status copied from the dynamo attributes" in new contributor {
         val fromDynamo = Future.successful(Some(contributorAttributes.copy(AdFree = Some(true), Tier = Some("Partner"))))
         val fromZuora = Future.successful(Some(contributorAttributes))
 
@@ -117,7 +133,7 @@ class ZuoraAttributeServiceTest(implicit ee: ExecutionEnv) extends Specification
         zuoraAttributeService.attributesWithFlagFromDynamo(fromZuora, fromDynamo) must be_==(expectedResult).await
       }
 
-      "not have an AdFree status either if there isn't one in dynamo" in new happyContributorAttributes {
+      "not have an AdFree status either if there isn't one in dynamo" in new contributor {
         val fromDynamo = Future.successful(Some(contributorAttributes.copy(Tier = Some("Partner"))))
         val fromZuora = Future.successful(Some(contributorAttributes))
 
@@ -127,31 +143,66 @@ class ZuoraAttributeServiceTest(implicit ee: ExecutionEnv) extends Specification
 
   }
 
-  trait happyContributorAttributes extends Scope {
-    //test Id has one subscription and it's a recurring contribution atm
-    implicit val mockSimpleClient = mock[SimpleClient[Future]]
-    val mockPatientZuoraRestService = mock[ZuoraRestService[Future]]
-    val mockSubscriptionService = mock[SubscriptionService[Future]]
+  trait contributor extends Scope {
     val mockScanamoService = mock[AttributeService]
-
-    import ZuoraRestService._
-    import com.gu.memsub.subsv2.reads.SubPlanReads.anyPlanReads
-
-
-    def cannedResponse(identityId: String): Future[\/[String, QueryResponse]] = Future.successful(if(identityId == testId) \/.left(s"account ids not found for $testId") else \/.right(oneAccountQueryResponse))
-    mockSimpleClient.post[RestQuery, QueryResponse]("action/query", RestQuery(s"select Id from account where IdentityId__c = '$testId'")) returns cannedResponse(testId)
-    mockPatientZuoraRestService.getAccounts(testId) returns cannedResponse(testId)
-
-    def cannedSubsResponse(accountId: AccountId) = Future.successful(if(accountId != testAccountId) \/.left(s"subscriptions not found for $testId") else \/.right(List(contributor)))
-    implicit def anyPlanMatcher = any[SubPlanReads[AnyPlan]]
-    //    mockSubscriptionService.subscriptionsForAccountId[AnyPlan](testAccountId)(anyPlanReads) returns cannedSubsResponse(testAccountId)
-
-    mockSubscriptionService.subscriptionsForAccountId[AnyPlan](any[AccountId])(anyPlanMatcher) returns cannedSubsResponse(testAccountId)
 
     mockScanamoService.get(testId) returns Future.successful(Some(contributorAttributes))
 
-    val zuoraAttributeService = new ZuoraAttributeService(mockPatientZuoraRestService, mockSubscriptionService, mockScanamoService)
+    def identityIdToAccountIds(identityId: String): Future[\/[String, QueryResponse]] = Future.successful(\/.right(oneAccountQueryResponse))
+    def subscriptionFromAccountId(accountId: AccountId)(reads: SubPlanReads[AnyPlan]) = Future.successful(\/.right(List(contributor)))
 
+    val zuoraAttributeService = new ZuoraAttributeService(identityIdToAccountIds, subscriptionFromAccountId, mockScanamoService)
+  }
+
+  trait contributorDigitalPack extends Scope {
+    val mockScanamoService = mock[AttributeService]
+
+    val contributorDigitalPackAttributes = Attributes(UserId = testId, None, None, None, None, RecurringContributionPaymentPlan = Some("Monthly Contribution"), None, DigitalSubscriptionExpiryDate = Some(digitalPackExpirationDate))
+    mockScanamoService.get(testId) returns Future.successful(Some(contributorDigitalPackAttributes))
+
+    def identityIdToAccountIds(identityId: String): Future[\/[String, QueryResponse]] = Future.successful(\/.right(twoAccountsQueryResponse))
+    def subscriptionFromAccountId(accountId: AccountId)(reads: SubPlanReads[AnyPlan]) = {
+      Future.successful {
+        accountId match {
+          case AccountId("accountId") => \/.right(List(contributor))
+          case AccountId("anotherTestAccountId") => \/.right(List(digipack))
+          case _ => \/.left(s"subscriptions not found for $testId")
+        }
+      }
+    }
+
+    val zuoraAttributeService = new ZuoraAttributeService(identityIdToAccountIds, subscriptionFromAccountId, mockScanamoService)
+  }
+
+  trait noAccounts extends Scope {
+    val emptyQueryResponse = QueryResponse(records = Nil, size = 0)
+    val mockScanamoService = mock[AttributeService]
+
+    mockScanamoService.get(testId) returns Future.successful(Some(contributorAttributes))
+
+    def identityIdToAccountIds(identityId: String): Future[\/[String, QueryResponse]] = Future.successful(\/.right(emptyQueryResponse))
+    def subscriptionFromAccountId(accountId: AccountId)(reads: SubPlanReads[AnyPlan]) = Future.successful(\/.right(Nil))
+
+    val zuoraAttributeService = new ZuoraAttributeService(identityIdToAccountIds, subscriptionFromAccountId, mockScanamoService)
+  }
+
+  trait accountButNoSubscriptions extends Scope {
+    val mockScanamoService = mock[AttributeService]
+
+    def identityIdToAccountIds(identityId: String): Future[\/[String, QueryResponse]] = Future.successful(\/.right(oneAccountQueryResponse))
+    def subscriptionFromAccountId(accountId: AccountId)(reads: SubPlanReads[AnyPlan]) = Future.successful(\/.right(Nil))
+
+    val zuoraAttributeService = new ZuoraAttributeService(identityIdToAccountIds, subscriptionFromAccountId, mockScanamoService)
+  }
+
+  trait errorWhenGettingSubs extends Scope {
+    val mockScanamoService = mock[AttributeService]
+    val testErrorMessage = "Something bad happened! D:"
+
+    def identityIdToAccountIds(identityId: String): Future[\/[String, QueryResponse]] = Future.successful(\/.right(oneAccountQueryResponse))
+    def subscriptionFromAccountId(accountId: AccountId)(reads: SubPlanReads[AnyPlan]) = Future.successful(\/.left(testErrorMessage))
+
+    val zuoraAttributeService = new ZuoraAttributeService(identityIdToAccountIds, subscriptionFromAccountId, mockScanamoService)
   }
 
 }

--- a/membership-attribute-service/test/testdata/SubscriptionTestData.scala
+++ b/membership-attribute-service/test/testdata/SubscriptionTestData.scala
@@ -10,9 +10,9 @@ import org.joda.time.LocalDate
 
 import scalaz.NonEmptyList
 
-object SubscriptionTestDataHelper {
+trait SubscriptionTestData {
 
-  val referenceDate = new LocalDate(2016, 10, 26)
+  def referenceDate: LocalDate
 
   val friendPlan = FreeSubscriptionPlan[Product.Membership, FreeCharge[Benefit.Friend.type]](
     RatePlanId("idFriend"), ProductRatePlanId("prpi"), "Friend", "desc", "Friend", Product.Membership,FreeCharge(Friend, Set(GBP)), referenceDate

--- a/membership-attribute-service/test/testdata/SubscriptionTestDataHelper.scala
+++ b/membership-attribute-service/test/testdata/SubscriptionTestDataHelper.scala
@@ -1,0 +1,62 @@
+package testdata
+
+import com.github.nscala_time.time.Implicits._
+import com.gu.i18n.Currency.GBP
+import com.gu.memsub.Benefit._
+import com.gu.memsub.Subscription.{ProductRatePlanChargeId, ProductRatePlanId, RatePlanId, _}
+import com.gu.memsub.subsv2._
+import com.gu.memsub.{Subscription => _, _}
+import org.joda.time.LocalDate
+
+import scalaz.NonEmptyList
+
+object SubscriptionTestDataHelper {
+
+  val referenceDate = new LocalDate(2016, 10, 26)
+
+  val friendPlan = FreeSubscriptionPlan[Product.Membership, FreeCharge[Benefit.Friend.type]](
+    RatePlanId("idFriend"), ProductRatePlanId("prpi"), "Friend", "desc", "Friend", Product.Membership,FreeCharge(Friend, Set(GBP)), referenceDate
+  )
+  def supporterPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan.Supporter = PaidSubscriptionPlan[Product.Membership, PaidCharge[Benefit.Supporter.type, BillingPeriod]](
+    RatePlanId("idSupporter"), ProductRatePlanId("prpi"), "Supporter", "desc", "Supporter", Product.Membership, List.empty, PaidCharge(Supporter, BillingPeriod.Year, PricingSummary(Map(GBP -> Price(49.0f, GBP))), ProductRatePlanChargeId("bar")), None, startDate, endDate
+  )
+  def digipackPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan.Digipack = PaidSubscriptionPlan[Product.ZDigipack, PaidCharge[Benefit.Digipack.type, BillingPeriod]](
+    RatePlanId("idDigipack"), ProductRatePlanId("prpi"), "Digipack", "desc", "Digital Pack", Product.Digipack, List.empty, PaidCharge(Digipack, BillingPeriod.Year, PricingSummary(Map(GBP -> Price(119.90f, GBP))), ProductRatePlanChargeId("baz")), None, startDate, endDate
+  )
+  def paperPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan.Delivery = PaidSubscriptionPlan[Product.Delivery, PaperCharges](
+    RatePlanId("idDigipack"), ProductRatePlanId("prpi"), "Sunday", "desc", "Sunday", Product.Delivery, List.empty, PaperCharges(Seq((SundayPaper, PricingSummary(Map(GBP -> Price(5.07f, GBP))))).toMap, None), None, startDate, endDate
+  )
+  def paperPlusPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan.Delivery = PaidSubscriptionPlan[Product.Delivery, PaperCharges](
+    RatePlanId("idDigipack"), ProductRatePlanId("prpi"), "Sunday+", "desc", "Sunday+", Product.Delivery, List.empty, PaperCharges(Seq((SundayPaper, PricingSummary(Map(GBP -> Price(5.07f, GBP))))).toMap, Some(PricingSummary(Map(GBP -> Price(119.90f, GBP))))), None, startDate, endDate
+  )
+  def contributorPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan.Contributor = PaidSubscriptionPlan[Product.Contribution, PaidCharge[Benefit.Contributor.type, BillingPeriod]](
+    RatePlanId("idContributor"), ProductRatePlanId("prpi"), "Monthly Contribution", "desc", "Monthly Contribution", Product.Contribution, List.empty, PaidCharge(Contributor, BillingPeriod.Month, PricingSummary(Map(GBP -> Price(5.0f, GBP))), ProductRatePlanChargeId("bar")), None, startDate, endDate
+  )
+
+  def toSubscription[P <: SubscriptionPlan.AnyPlan](isCancelled: Boolean)(plans: NonEmptyList[P]): Subscription[P] = {
+    Subscription(
+      id = Id(plans.head.id.get),
+      name = Name("AS-123123"),
+      accountId = AccountId("accountId"),
+      startDate = plans.head.start,
+      acceptanceDate = plans.head.start,
+      termStartDate = plans.head.start,
+      termEndDate = plans.head.start + 1.year,
+      casActivationDate = None,
+      promoCode = None,
+      isCancelled = isCancelled,
+      hasPendingFreePlan = false,
+      plans = plans,
+      readerType = ReaderType.Direct,
+      autoRenew = true
+    )
+  }
+
+  val digipack = toSubscription(false)(NonEmptyList(digipackPlan(referenceDate, referenceDate + 1.year)))
+  val sunday = toSubscription(false)(NonEmptyList(paperPlan(referenceDate, referenceDate + 1.year)))
+  val sundayPlus = toSubscription(false)(NonEmptyList(paperPlusPlan(referenceDate, referenceDate + 1.year)))
+  val membership = toSubscription(false)(NonEmptyList(supporterPlan(referenceDate, referenceDate + 1.year)))
+  val expiredMembership = toSubscription(false)(NonEmptyList(supporterPlan(referenceDate - 2.year, referenceDate - 1.year)))
+  val friend = toSubscription(false)(NonEmptyList(friendPlan))
+  val contributor = toSubscription(false)(NonEmptyList(contributorPlan(referenceDate, referenceDate + 1.month)))
+}


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
We initially did lookups directly from Zuora as a test, but now we are determining how to keep doing lookups via Zuora but cope with spikes of traffic. So, I think it's time to move the monster attributesFromZuora function out of the controller.

There's more refactoring left to do, but I think moving the code out of the controller is enough for a PR. 

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
- Move zuora lookup code out of the controller into a service
- Add some tests for identityId -> subscriptions

### trello card/screenshot/json/related PRs etc
[PR 209 - send some /features traffic to lookup via Zuora](https://github.com/guardian/members-data-api/pull/209)
[on trello](https://trello.com/c/VjKkm0Lp/228-endpoint-to-lookup-attributes-by-identity-id-based-only-on-calls-to-zuora)