### PR TITLE
Updated to use the latest membership-common

### DIFF
--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -56,8 +56,11 @@ class TouchpointComponents(stage: String)(implicit system: ActorSystem) {
   implicit lazy val _bt = tpConfig
   lazy val metrics = new ServiceMetrics(tpConfig.zuoraRest.envName, Config.applicationName,_: String)
 
-  lazy val stripeService = new StripeService(tpConfig.stripe, RequestRunners.loggingRunner(metrics("stripe")))
-  lazy val giraffeStripeService = new StripeService(tpConfig.giraffe, RequestRunners.loggingRunner(metrics("stripe")))
+  lazy val ukStripeService = new StripeService(tpConfig.stripeUKMembership, RequestRunners.loggingRunner(metrics("stripe")))
+  lazy val auStripeService = new StripeService(tpConfig.stripeAUMembership, RequestRunners.loggingRunner(metrics("stripe")))
+
+  lazy val ukContributionsStripeService = new StripeService(tpConfig.stripeUKContributions, RequestRunners.loggingRunner(metrics("stripe")))
+
   lazy val soapClient = new ClientWithFeatureSupplier(Set.empty, tpConfig.zuoraSoap,
     RequestRunners.loggingRunner(metrics("zuora-soap")),
     RequestRunners.loggingRunner(metrics("zuora-soap"))
@@ -76,7 +79,7 @@ class TouchpointComponents(stage: String)(implicit system: ActorSystem) {
   lazy val futureCatalog: Future[CatalogMap] = catalogService.catalog.map(_.fold[CatalogMap](error => {println(s"error: ${error.list.mkString}"); Map()}, _.map))
 
   lazy val subService = new SubscriptionService[Future](productIds, futureCatalog, simpleClient, zuoraService.getAccountIds)
-  lazy val paymentService = new PaymentService(stripeService, zuoraService, catalogService.unsafeCatalog.productMap)
+  lazy val paymentService = new PaymentService(zuoraService, catalogService.unsafeCatalog.productMap)
   lazy val featureToggleData = new FeatureToggleDataUpdatedOnSchedule(featureToggleService, stage)
 
 }

--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -45,7 +45,7 @@ class AccountController extends LazyLogging {
       sfUser <- EitherT(tp.contactRepo.get(user).map(_.flatMap(_ \/> s"no SF user $user")))
       subscription <- EitherT(tp.subService.current[P](sfUser).map(_.headOption).map (_ \/> s"no current subscriptions for the sfUser $sfUser"))
       account <- EitherT(tp.zuoraService.getAccount(subscription.accountId).map(x => Some(x)).map(_ \/> s"no account for subscription: ${subscription.name} with account id ${subscription.accountId}"))
-      stripeService = if (account.paymentGateway.contains(tp.auStripeService.paymentGateway.gatewayName)) tp.auStripeService else tp.ukStripeService
+      stripeService = if (account.paymentGateway.contains(tp.auStripeService.paymentGateway)) tp.auStripeService else tp.ukStripeService
       stripeCardToken <- EitherT(Future.successful(updateForm.bindFromRequest().value \/> "no card token submitted with request"))
       updateResult <- EitherT(tp.paymentService.setPaymentCardWithStripeToken(subscription.accountId, stripeCardToken, stripeService).map(_ \/> "something missing when try to zuora payment card"))
     } yield updateResult match {

--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -3,7 +3,7 @@ import actions._
 import play.api.libs.concurrent.Execution.Implicits._
 import services.{AuthenticationService, IdentityAuthService}
 import com.gu.memsub._
-import com.gu.memsub.subsv2.{Subscription, SubscriptionPlan}
+import com.gu.memsub.subsv2.SubscriptionPlan
 import com.gu.memsub.subsv2.reads.ChargeListReads._
 import com.gu.memsub.subsv2.reads.SubPlanReads
 import com.gu.memsub.subsv2.reads.SubPlanReads._
@@ -20,9 +20,9 @@ import play.api.mvc.Results._
 import play.filters.cors.CORSActionBuilder
 
 import scala.concurrent.Future
-import scalaz.{-\/, EitherT, OptionT, \/, \/-}
 import scalaz.std.scalaFuture._
 import scalaz.syntax.std.option._
+import scalaz.{-\/, EitherT, OptionT, \/, \/-}
 
 class AccountController extends LazyLogging {
 
@@ -33,6 +33,9 @@ class AccountController extends LazyLogging {
   lazy val mmaCardAction = NoCacheAction andThen corsCardFilter andThen BackendFromCookieAction
 
   def updateCard[P <: SubscriptionPlan.AnyPlan : SubPlanReads] = mmaCardAction.async { implicit request =>
+
+    // TODO - refactor to use the Zuora-only based lookup, like in AttributeController.pickAttributes - https://trello.com/c/RlESb8jG
+
     val updateForm = Form { single("stripeToken" -> nonEmptyText) }
     val tp = request.touchpoint
     val maybeUserId = authenticationService.userId
@@ -41,8 +44,10 @@ class AccountController extends LazyLogging {
       user <- EitherT(Future.successful( maybeUserId \/> "no identity cookie for user"))
       sfUser <- EitherT(tp.contactRepo.get(user).map(_.flatMap(_ \/> s"no SF user $user")))
       subscription <- EitherT(tp.subService.current[P](sfUser).map(_.headOption).map (_ \/> s"no current subscriptions for the sfUser $sfUser"))
+      account <- EitherT(tp.zuoraService.getAccount(subscription.accountId).map(x => Some(x)).map(_ \/> s"no account for subscription: ${subscription.name} with account id ${subscription.accountId}"))
+      stripeService = if (account.paymentGateway.contains(tp.auStripeService.paymentGateway.gatewayName)) tp.auStripeService else tp.ukStripeService
       stripeCardToken <- EitherT(Future.successful(updateForm.bindFromRequest().value \/> "no card token submitted with request"))
-      updateResult <- EitherT(tp.paymentService.setPaymentCardWithStripeToken(subscription.accountId, stripeCardToken).map(_ \/> "something missing when try to zuora payment card"))
+      updateResult <- EitherT(tp.paymentService.setPaymentCardWithStripeToken(subscription.accountId, stripeCardToken, stripeService).map(_ \/> "something missing when try to zuora payment card"))
     } yield updateResult match {
       case success: CardUpdateSuccess => {
         logger.info(s"Successfully updated card for identity user: $user")

--- a/membership-attribute-service/app/controllers/StripeHookController.scala
+++ b/membership-attribute-service/app/controllers/StripeHookController.scala
@@ -11,6 +11,7 @@ import play.api.mvc._
 import scala.concurrent.Future
 import scalaz.OptionT
 import scalaz.std.scalaFuture._
+import com.gu.stripe.Stripe.Deserializer._
 
 
 class StripeHookController extends Controller with LazyLogging {

--- a/membership-attribute-service/app/controllers/StripeHookController.scala
+++ b/membership-attribute-service/app/controllers/StripeHookController.scala
@@ -1,22 +1,22 @@
 package controllers
 
 import actions.NoCacheAction
-import com.gu.stripe.Stripe
-import com.typesafe.scalalogging.LazyLogging
-import play.api.libs.concurrent.Execution.Implicits._
 import com.gu.stripe.Stripe._
-import com.gu.stripe.Stripe.Deserializer._
+import com.typesafe.scalalogging.LazyLogging
 import components.{NormalTouchpointComponents, TestTouchpointComponents}
-
-import scalaz.std.scalaFuture._
+import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.Json
 import play.api.mvc._
 
 import scala.concurrent.Future
 import scalaz.OptionT
+import scalaz.std.scalaFuture._
 
 
 class StripeHookController extends Controller with LazyLogging {
+
+  // TODO - confirm if these are deprecated and the class can be deleted.
+  // Right now I'm leaving it hardcoded to the uk contributions stripe service.
 
   def updatePrefs = NoCacheAction.async { implicit request =>
     request.body.asJson.map(Json.fromJson[Event[StripeObject]](_)).fold[Future[Result]] {
@@ -25,7 +25,7 @@ class StripeHookController extends Controller with LazyLogging {
       (for {
         e <- OptionT(Future.successful(event.asOpt))
         tp = if (e.liveMode) NormalTouchpointComponents else TestTouchpointComponents
-        eventFromStripe <- OptionT(tp.giraffeStripeService.Event.findCharge(e.id))
+        eventFromStripe <- OptionT(tp.ukContributionsStripeService.Event.findCharge(e.id))
         identityId <- OptionT(tp.identityService.user(eventFromStripe.`object`.receipt_email))
         allowMarketing <- OptionT(Future.successful(eventFromStripe.`object`.metadata.get("marketing-opt-in").map(_ == "true")))
       } yield {
@@ -45,8 +45,8 @@ class StripeHookController extends Controller with LazyLogging {
       (for {
         e <- OptionT(Future.successful(event.asOpt))
         tp = if (e.liveMode) NormalTouchpointComponents else TestTouchpointComponents
-        eventFromStripe <- OptionT(tp.giraffeStripeService.Event.findCharge(e.id))
-        balanceTransaction <- OptionT(tp.giraffeStripeService.BalanceTransaction.read(eventFromStripe.`object`.balance_transaction.mkString))
+        eventFromStripe <- OptionT(tp.ukContributionsStripeService.Event.findCharge(e.id))
+        balanceTransaction <- OptionT(tp.ukContributionsStripeService.BalanceTransaction.read(eventFromStripe.`object`.balance_transaction.mkString))
       } yield {
         tp.snsGiraffeService.publish(eventFromStripe.`object`, balanceTransaction)
         Ok(Json.obj("event " + eventFromStripe.id + " was found, sent to " + tp.giraffeSns -> true))

--- a/membership-attribute-service/app/json/PaymentCardUpdateResultWriters.scala
+++ b/membership-attribute-service/app/json/PaymentCardUpdateResultWriters.scala
@@ -6,10 +6,15 @@ import play.api.libs.functional.syntax._
 
 object PaymentCardUpdateResultWriters {
 
-  implicit val paymentCardWrites: Writes[PaymentCard] = (
-    (JsPath \ "type").write[String] and
-    (JsPath \ "last4").write[String]
-  )(unlift(PaymentCard.unapply))
+  implicit val paymentCardWrites: Writes[PaymentCard] = Writes[PaymentCard] { paymentCard =>
+    Json.obj("type" -> paymentCard.cardType) ++ paymentCard.paymentCardDetails.map(details =>
+      Json.obj(
+        "last4" -> details.lastFourDigits,
+        "expiryMonth" -> details.expiryMonth,
+        "expiryYear" -> details.expiryYear
+      )
+    ).getOrElse(Json.obj("last4" -> "XXXX")) // effectively impossible to happen as this is used in a card update context
+  }
 
   implicit val cardUpdateSuccessWrites = Writes[CardUpdateSuccess] { cus =>
     paymentCardWrites.writes(cus.newPaymentCard)

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -30,7 +30,7 @@ object AccountDetails {
         case card: PaymentCard => Json.obj(
           "paymentMethod" -> "Card",
           "card" -> Json.obj(
-            "last4" -> card.lastFourDigits,
+            "last4" -> card.paymentCardDetails.map(_.lastFourDigits).getOrElse[String]("XXXX"),
             "type" -> card.cardType
           )
         )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSNS = "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.440"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.1-SNAPSHOT"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.0"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSNS = "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.1-SNAPSHOT"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.464"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.0"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
Part of the Australia international charging change. See: https://github.com/guardian/membership-frontend/pull/1725

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
- Updated to use the latest [membership-common](https://github.com/guardian/membership-common/pull/534), which requires services to choose which Stripe account to connect with. Also made some possible deprecation notes and TODOs.
- Switched to using the touchpoint.paymentService in the Salesforce hook (this is kinda moot as this is likely going away). However the change is really there to support the AU cards in the AccountDetails page in Identity.

cc @johnduffell @desbo @lmath 