### PR TITLE
Provide the Stripe public key to channels which allow card updating

### DIFF
--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -14,6 +14,7 @@ import com.gu.okhttp.RequestRunners
 import com.gu.salesforce.SimpleContactRepository
 import com.gu.stripe.StripeService
 import com.gu.touchpoint.TouchpointBackendConfig
+import com.gu.zuora.api.PaymentGateway
 import com.gu.zuora.rest.SimpleClient
 import com.gu.zuora.soap.ClientWithFeatureSupplier
 import com.gu.zuora.{ZuoraRestService, ZuoraService}
@@ -58,6 +59,7 @@ class TouchpointComponents(stage: String)(implicit system: ActorSystem) {
 
   lazy val ukStripeService = new StripeService(tpConfig.stripeUKMembership, RequestRunners.loggingRunner(metrics("stripe")))
   lazy val auStripeService = new StripeService(tpConfig.stripeAUMembership, RequestRunners.loggingRunner(metrics("stripe")))
+  lazy val stripeServicesByPaymentGateway: Map[PaymentGateway, StripeService] = Seq(ukStripeService, auStripeService).map(s => s.paymentGateway -> s).toMap
 
   lazy val ukContributionsStripeService = new StripeService(tpConfig.stripeUKContributions, RequestRunners.loggingRunner(metrics("stripe")))
 

--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -47,7 +47,7 @@ class AccountController extends LazyLogging {
       subscription <- EitherT(tp.subService.current[P](sfUser).map(_.headOption).map (_ \/> s"no current subscriptions for the sfUser $sfUser"))
       account <- EitherT(tp.zuoraService.getAccount(subscription.accountId).map(\/.right).recover { case x => \/.left(s"error receiving account for subscription: ${subscription.name} with account id ${subscription.accountId}. Reason: $x") })
       stripeService <- EitherT(Future.successful(account.paymentGateway.flatMap(tp.stripeServicesByPaymentGateway.get) \/> s"No Stripe service available for account: ${account.id}"))
-      updateResult <- EitherT(tp.paymentService.setPaymentCardWithStripeToken(subscription.accountId, stripeCardToken, stripeService, user).map(_ \/> "something missing when try to zuora payment card"))
+      updateResult <- EitherT(tp.paymentService.setPaymentCardWithStripeToken(subscription.accountId, stripeCardToken, stripeService, Some(user)).map(_ \/> "something missing when try to zuora payment card"))
     } yield updateResult match {
       case success: CardUpdateSuccess => {
         logger.info(s"Successfully updated card for identity user: $user")

--- a/membership-attribute-service/app/json/PaymentCardUpdateResultWriters.scala
+++ b/membership-attribute-service/app/json/PaymentCardUpdateResultWriters.scala
@@ -13,7 +13,7 @@ object PaymentCardUpdateResultWriters {
         "expiryMonth" -> details.expiryMonth,
         "expiryYear" -> details.expiryYear
       )
-    ).getOrElse(Json.obj("last4" -> "XXXX")) // effectively impossible to happen as this is used in a card update context
+    ).getOrElse(Json.obj("last4" -> "••••")) // effectively impossible to happen as this is used in a card update context
   }
 
   implicit val cardUpdateSuccessWrites = Writes[CardUpdateSuccess] { cus =>

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -31,11 +31,12 @@ object AccountDetails {
         )
         case card: PaymentCard => Json.obj(
           "paymentMethod" -> "Card",
-          "card" -> Json.obj(
-            "last4" -> card.paymentCardDetails.map(_.lastFourDigits).getOrElse[String]("XXXX"),
-            "type" -> card.cardType,
-            "stripePublicKeyForUpdate" -> stripePublicKey.mkString
-          )
+          "card" -> {
+            Json.obj(
+              "last4" -> card.paymentCardDetails.map(_.lastFourDigits).getOrElse[String]("••••"),
+              "type" -> card.cardType
+            ) ++ stripePublicKey.map(k => Json.obj("stripePublicKeyForUpdate" -> k)).getOrElse(Json.obj())
+          }
         )
         case dd: GoCardless => Json.obj(
           "paymentMethod" -> "DirectDebit",

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -6,18 +6,20 @@ import play.api.libs.json._
 import play.api.mvc.Results.Ok
 
 object AccountDetails {
-  implicit class ResultLike(details: (Contact, PaymentDetails)) {
+  implicit class ResultLike(details: (Contact, PaymentDetails, Option[String])) {
 
     def toResult = {
       val contact = details._1
       val paymentDetails = details._2
-      Ok(memberDetails(contact, paymentDetails) ++ toJson(paymentDetails))
+      val stripePublicKey = details._3
+      Ok(memberDetails(contact, paymentDetails) ++ toJson(paymentDetails, stripePublicKey))
     }
+
     private def memberDetails(contact: Contact, paymentDetails: PaymentDetails) =
       Json.obj("tier" -> paymentDetails.plan.name, "isPaidTier" -> (paymentDetails.plan.price.amount > 0f)) ++
         contact.regNumber.fold(Json.obj())({m => Json.obj("regNumber" -> m)})
 
-    private def toJson(paymentDetails: PaymentDetails): JsObject = {
+    private def toJson(paymentDetails: PaymentDetails, stripePublicKey: Option[String]): JsObject = {
 
       val endDate = paymentDetails.chargedThroughDate
         .getOrElse(paymentDetails.termEndDate)
@@ -31,7 +33,8 @@ object AccountDetails {
           "paymentMethod" -> "Card",
           "card" -> Json.obj(
             "last4" -> card.paymentCardDetails.map(_.lastFourDigits).getOrElse[String]("XXXX"),
-            "type" -> card.cardType
+            "type" -> card.cardType,
+            "stripePublicKeyForUpdate" -> stripePublicKey.mkString
           )
         )
         case dd: GoCardless => Json.obj(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSNS = "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.464"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.466"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.0"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
Credit cards used to pay for membership, Digipack and regular contributions can be updated on the Identity profile.theguardian.com pages. Right now the Stripe public key is hardcoded in that app. This change provides the public key used for updating the card along with the card details used for display. This is need for cards stored in Australia Stripe.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
Adding the relevant Stripe public key to the payment details feed so that client channels know what public key they need to use to do a card update.

cc @johnduffell @rupertbates @AWare @lmath 