### PR TITLE
On zuora lookups, write updated information to the dynamo table

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -62,7 +62,7 @@ class AttributeController extends Controller with LoggingWithLogstashFields {
               dynamoAttributeGetter = request.touchpoint.attrService.get)
 
               attributesFromZuora.map(_.map(request.touchpoint.attrService.update(_))).onFailure {
-                case error => log.warn(s"Tried update attributes for $identityId but then ${error.getMessage}", error)
+                case error => log.warn(s"Tried updating attributes for $identityId but then ${error.getMessage}", error)
               }
             ("Zuora", attributesFromZuora)
           }

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -60,6 +60,10 @@ class AttributeController extends Controller with LoggingWithLogstashFields {
               identityIdToAccountIds = request.touchpoint.zuoraRestService.getAccounts,
               subscriptionsForAccountId = accountId => reads => request.touchpoint.subService.subscriptionsForAccountId[AnyPlan](accountId)(reads),
               dynamoAttributeGetter = request.touchpoint.attrService.get)
+
+              attributesFromZuora.map(_.map(request.touchpoint.attrService.update(_))).onFailure {
+                case error => log.warn(s"Tried update attributes for $identityId but then ${error.getMessage}", error)
+              }
             ("Zuora", attributesFromZuora)
           }
           case false => ("Dynamo", request.touchpoint.attrService.get(identityId))
@@ -105,22 +109,6 @@ class AttributeController extends Controller with LoggingWithLogstashFields {
       }
   }
 
-  private def zuoraLookup(endpointDescription: String) =
-    backendAction.async { implicit request =>
-      authenticationService.userId(request) match {
-        case Some(identityId) =>
-          getAttributes(identityId, request.touchpoint.zuoraRestService.getAccounts, accountId => reads => request.touchpoint.subService.subscriptionsForAccountId[AnyPlan](accountId)(reads), request.touchpoint.attrService.get).map {
-            case Some(attrs) =>
-              log.info(s"Successfully retrieved attributes from Zuora for user $identityId: $attrs")
-              attrs
-            case _ => notFound
-          }
-        case None =>
-          metrics.put(s"$endpointDescription-cookie-auth-failed", 1)
-          Future(unauthorized)
-      }
-  }
-
   val notFound = ApiError("Not found", "Could not find user in the database", 404)
   val notAMember = ApiError("Not found", "User was found but they are not a member", 404)
 
@@ -133,7 +121,6 @@ class AttributeController extends Controller with LoggingWithLogstashFields {
   def membership = lookup("membership", onSuccessMember = membershipAttributesFromAttributes, onSuccessSupporter = _ => notAMember, onNotFound = notFound, endpointEligibleForTest = true)
   def attributes = lookup("attributes", onSuccessMember = identity[Attributes], onSuccessSupporter = identity[Attributes], onNotFound = notFound, endpointEligibleForTest = true, sendAttributesIfNotFound = true)
   def features = lookup("features", onSuccessMember = Features.fromAttributes, onSuccessSupporter = Features.notAMember, onNotFound = Features.unauthenticated, endpointEligibleForTest = true)
-  def zuoraMe = zuoraLookup("zuoraLookup")
 
   def updateAttributes(identityId : String): Action[AnyContent] = backendForSyncWithZuora.async { implicit request =>
 

--- a/membership-attribute-service/app/services/ScanamoAttributeService.scala
+++ b/membership-attribute-service/app/services/ScanamoAttributeService.scala
@@ -50,7 +50,8 @@ class ScanamoAttributeService(client: AmazonDynamoDBAsyncClient, table: String)
       scanamoSetOpt('MembershipNumber -> attributes.MembershipNumber),
       scanamoSetOpt('RecurringContributionPaymentPlan -> attributes.RecurringContributionPaymentPlan),
       scanamoSetOpt('Wallet -> attributes.Wallet),
-      scanamoSetOpt('MembershipJoinDate -> attributes.MembershipJoinDate)
+      scanamoSetOpt('MembershipJoinDate -> attributes.MembershipJoinDate),
+      scanamoSetOpt('DigitalSubscriptionExpiryDate -> attributes.DigitalSubscriptionExpiryDate)
     ).flatten match {
       case first :: remaining =>
         run(

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -26,5 +26,4 @@ POST       /stripe-hook-sns                                 controllers.StripeHo
 POST       /user-attributes/:identityId                     controllers.AttributeController.updateAttributes(identityId : String)
 #The endpoint below will replace /user-attributes/me/membership in the long term
 GET        /user-attributes/me                              controllers.AttributeController.attributes
-GET        /user-attributes/zuora-lookup                    controllers.AttributeController.zuoraMe
 


### PR DESCRIPTION
Also, I was sick of updating `/me/zuora-lookup` as it's not actually being used so I'm removing it. 

<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
We are moving towards doing member/supporter attributes lookups by getting subscription information directly from Zuora because then the information will be more up to date. 

However, during spikes of traffic such as push notifications we will make too many requests to Zuora. So this PR updates the the MembershipAttributes table when we do a Zuora lookup. That way, during a spike of traffic or a Zuora outage we have the option to serve from the Dynamo table, though it may be stale. 

There will be a PR to follow to detect when to serve from the dynamo table instead. 

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
- When we get attributes to Zuora,  we now use this information to update the `MembershipAttributes` dynamo table.
- Removed `/me/zuora-lookup` endpoint because it is not actually in use anymore.
- `update` in the ScanamoAttributeService should also update DigitalSubscriptionExpiryDate, if it's available. 

### trello card/screenshot/json/related PRs etc
[PR 209 - send some /features traffic to lookup via Zuora](https://github.com/guardian/members-data-api/pull/209)
[on trello](https://trello.com/c/VjKkm0Lp/228-endpoint-to-lookup-attributes-by-identity-id-based-only-on-calls-to-zuora)

cc @paulbrown1982 @johnduffell @pvighi @AWare @jacobwinch 