### PR TITLE
update dynamo only if we get some updated values from zuora

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -59,16 +59,10 @@ class AttributeController extends Controller with LoggingWithLogstashFields {
               identityId = identityId,
               identityIdToAccountIds = request.touchpoint.zuoraRestService.getAccounts,
               subscriptionsForAccountId = accountId => reads => request.touchpoint.subService.subscriptionsForAccountId[AnyPlan](accountId)(reads),
-              dynamoAttributeGetter = request.touchpoint.attrService.get)
+              dynamoAttributeGetter = request.touchpoint.attrService.get,
+              dynamoAttributeUpdater = attributes => request.touchpoint.attrService.update(attributes))
 
-              val cachedAttributes: OptionT[Future, Attributes] = for {
-                attributes <- OptionT(attributesFromZuora)
-                _ = request.touchpoint.attrService.update(attributes).onFailure {
-                  case error => log.warn(s"Tried updating attributes for $identityId but then ${error.getMessage}", error)
-                }
-              } yield attributes
-
-            ("Zuora", cachedAttributes.run)
+            ("Zuora", attributesFromZuora)
           }
           case false => ("Dynamo", request.touchpoint.attrService.get(identityId))
         }

--- a/membership-attribute-service/app/services/AttributesFromZuora.scala
+++ b/membership-attribute-service/app/services/AttributesFromZuora.scala
@@ -70,7 +70,7 @@ object AttributesFromZuora extends LoggingWithLogstashFields {
         val attributesAfterUpdate = for {
             attributes <- OptionT(zuoraAttributesWithAdfree)
           _ = dynamoAttributeUpdater(attributes).map { result =>
-            result.left.map { error: DynamoReadError => log.warn(s"Tried updating attributes for $identityId but then ${DynamoReadError.describe(error)}") }
+            result.left.map { error: DynamoReadError => log.error(s"Tried updating attributes for $identityId but then ${DynamoReadError.describe(error)}") }
           }.onFailure {
             case error => log.warn(s"Tried updating attributes for $identityId but then ${error.getMessage}", error)
           }

--- a/membership-attribute-service/test/services/AttributesFromZuoraTest.scala
+++ b/membership-attribute-service/test/services/AttributesFromZuoraTest.scala
@@ -32,11 +32,13 @@ class AttributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
   val friendAttributes = Attributes(UserId = testId, Some("Friend"), None, None, None, None, Some(joinDate), None)
   val supporterAttributes = Attributes(UserId = testId, Some("Supporter"), None, None, None, None, Some(joinDate), None)
 
+  def dynamoAttributeUpdater(attributes: Attributes) = Future.successful(Right(attributes))
+
   "ZuoraAttributeService" should {
 
     "attributesFromZuora" should {
       "return attributes for a user who has many subscriptions" in new contributorDigitalPack {
-        val attributes: Future[Option[Attributes]] = AttributesFromZuora.getAttributes(testId, identityIdToAccountIds, subscriptionFromAccountId, dynamoAttributeGetter, referenceDate)
+        val attributes: Future[Option[Attributes]] = AttributesFromZuora.getAttributes(testId, identityIdToAccountIds, subscriptionFromAccountId, dynamoAttributeGetter, dynamoAttributeUpdater, referenceDate)
         attributes must be_==(Some(contributorDigitalPackAttributes)).await
       }
 
@@ -46,12 +48,12 @@ class AttributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
 
         override def dynamoAttributeGetter(identityId: String): Future[Option[Attributes]] = Future.successful(Some(outdatedAttributesButWithAdFree))
 
-        val attributes: Future[Option[Attributes]] = AttributesFromZuora.getAttributes(testId, identityIdToAccountIds, subscriptionFromAccountId, dynamoAttributeGetter, referenceDate)
+        val attributes: Future[Option[Attributes]] = AttributesFromZuora.getAttributes(testId, identityIdToAccountIds, subscriptionFromAccountId, dynamoAttributeGetter, dynamoAttributeUpdater, referenceDate)
         attributes must be_==(Some(contributorDigitalPackAdfreeAttributes)).await
       }
 
       "return None if the user has no account ids" in new noAccounts {
-        val attributes: Future[Option[Attributes]] = AttributesFromZuora.getAttributes(testId, identityIdToAccountIds, subscriptionFromAccountId, dynamoAttributeGetter, referenceDate)
+        val attributes: Future[Option[Attributes]] = AttributesFromZuora.getAttributes(testId, identityIdToAccountIds, subscriptionFromAccountId, dynamoAttributeGetter, dynamoAttributeUpdater, referenceDate)
         attributes must be_==(None).await
       }
     }


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
To reduce the number of dynamo write requests needed (and so ££ spent on write capacity)

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
- Move the updating of dynamo from the controller to the attributesFromZuora function. We already query dynamo to get the adFree flag here and do a comparison between the two, so then we just update if the comparison says Zuora is more up to date.

### trello card/screenshot/json/related PRs etc
[PR 239 - On zuora lookups, write updated information to the dynamo table](https://github.com/guardian/members-data-api/pull/239)

cc @paulbrown1982 @johnduffell @pvighi @AWare @jacobwinch 

Write capacity graph of MembershipAttributes-PROD before this change
![writecapacitygraph_annotated](https://user-images.githubusercontent.com/3072877/30872142-022643c2-a2e1-11e7-9694-4f5956dd80bb.png)
