### PR TITLE
Fix issue with Zuora card mask numbers

### DIFF
--- a/membership-attribute-service/app/json/PaymentCardUpdateResultWriters.scala
+++ b/membership-attribute-service/app/json/PaymentCardUpdateResultWriters.scala
@@ -7,7 +7,7 @@ import play.api.libs.functional.syntax._
 object PaymentCardUpdateResultWriters {
 
   implicit val paymentCardWrites: Writes[PaymentCard] = Writes[PaymentCard] { paymentCard =>
-    Json.obj("type" -> paymentCard.cardType) ++ paymentCard.paymentCardDetails.map(details =>
+    Json.obj("type" -> paymentCard.cardType.replace(" ", "")) ++ paymentCard.paymentCardDetails.map(details =>
       Json.obj(
         "last4" -> details.lastFourDigits,
         "expiryMonth" -> details.expiryMonth,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSNS = "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.466"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.467"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.0"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
Fix issue with Zuora card mask numbers: https://github.com/guardian/membership-common/pull/537

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
Upgrade to latest membership-common which fixes the mask number issue, and make the Amex card type strings consistent between Stripe and Zuora by removing the space. A following release in Frontend will fix the CSS class.

### trello card/screenshot/json/related PRs etc
![picture 187](https://user-images.githubusercontent.com/1515970/30913480-3ec528be-a388-11e7-97ef-1f66c5496afe.png)

![picture 188](https://user-images.githubusercontent.com/1515970/30913600-ba9c6ede-a388-11e7-9a64-47205d29393d.png)


Now:
![picture 189](https://user-images.githubusercontent.com/1515970/30913602-bdf0db1a-a388-11e7-84a6-87ad19c5d32b.png)


cc @AWare 