### PR TITLE
Serve from cache if concurrency count over a threshold

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -8,7 +8,7 @@ import com.gu.scanamo.error.DynamoReadError
 import configuration.Config
 import configuration.Config.authentication
 import loghandling.LoggingField.{LogField, LogFieldString}
-import loghandling.LoggingWithLogstashFields
+import loghandling.{LoggingWithLogstashFields, ZuoraRequestCounter}
 import models.ApiError._
 import models.ApiErrors._
 import models.Features._
@@ -32,6 +32,7 @@ import services.AttributesFromZuora._
 class AttributeController extends Controller with LoggingWithLogstashFields {
 
   val keys = authentication.keys.map(key => s"Bearer $key")
+  private val ConcurrentCallThreshold = 1
 
   def apiKeyFilter(): ActionBuilder[Request] = new ActionBuilder[Request] {
     def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) = {
@@ -51,22 +52,29 @@ class AttributeController extends Controller with LoggingWithLogstashFields {
   private def lookup(endpointDescription: String, onSuccessMember: Attributes => Result, onSuccessSupporter: Attributes => Result, onNotFound: Result, endpointEligibleForTest: Boolean, sendAttributesIfNotFound: Boolean = false) =
   {
     def pickAttributes(identityId: String) (implicit request: BackendRequest[AnyContent]): (String, Future[Option[Attributes]]) = {
+      def attributesFromDynamo(identityId: String) = request.touchpoint.attrService.get(identityId)
+
       if(endpointEligibleForTest){
-        val percentageInTest = request.touchpoint.featureToggleData.getPercentageTrafficForZuoraLookupTask.get()
+      val percentageInTest = request.touchpoint.featureToggleData.getPercentageTrafficForZuoraLookupTask.get()
         isInTest(identityId, percentageInTest) match {
           case true => {
-            val attributesFromZuora = getAttributes(
-              identityId = identityId,
-              identityIdToAccountIds = request.touchpoint.zuoraRestService.getAccounts,
-              subscriptionsForAccountId = accountId => reads => request.touchpoint.subService.subscriptionsForAccountId[AnyPlan](accountId)(reads),
-              dynamoAttributeGetter = request.touchpoint.attrService.get,
-              dynamoAttributeUpdater = attributes => request.touchpoint.attrService.update(attributes))
+            if(ZuoraRequestCounter.get < ConcurrentCallThreshold) {
+              val attributesFromZuora = getAttributes(
+                identityId = identityId,
+                identityIdToAccountIds = request.touchpoint.zuoraRestService.getAccounts,
+                subscriptionsForAccountId = accountId => reads => request.touchpoint.subService.subscriptionsForAccountId[AnyPlan](accountId)(reads),
+                dynamoAttributeGetter = attributesFromDynamo,
+                dynamoAttributeUpdater = attributes => request.touchpoint.attrService.update(attributes))
 
-            ("Zuora", attributesFromZuora)
+              ("Zuora", attributesFromZuora)
+            } else {
+              ("Dynamo - too many concurrent calls to Zuora", attributesFromDynamo(identityId))
+            }
+
           }
-          case false => ("Dynamo", request.touchpoint.attrService.get(identityId))
+          case false => ("Dynamo - not in Zuora lookup bucket", attributesFromDynamo(identityId))
         }
-      } else ("Dynamo", request.touchpoint.attrService.get(identityId))
+      } else ("Dynamo - as this endpoint always does", attributesFromDynamo(identityId))
     }
 
     backendAction.async { implicit request =>

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -32,7 +32,7 @@ import services.AttributesFromZuora._
 class AttributeController extends Controller with LoggingWithLogstashFields {
 
   val keys = authentication.keys.map(key => s"Bearer $key")
-  private val ConcurrentCallThreshold = 1
+  private val ConcurrentCallThreshold = 15
 
   def apiKeyFilter(): ActionBuilder[Request] = new ActionBuilder[Request] {
     def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) = {

--- a/membership-attribute-service/app/models/FeatureToggle.scala
+++ b/membership-attribute-service/app/models/FeatureToggle.scala
@@ -1,3 +1,5 @@
 package models
 
-case class FeatureToggle(FeatureName: String, TrafficPercentage: Option[Int])
+case class FeatureToggle(FeatureName: String, TrafficPercentage: Option[Int], ConcurrentZuoraCallThreshold: Option[Int])
+
+case class ZuoraLookupFeatureData(TrafficPercentage: Int, ConcurrentZuoraCallThreshold: Int)

--- a/membership-attribute-service/app/prodtest/FeatureToggleDataUpdatedOnSchedule.scala
+++ b/membership-attribute-service/app/prodtest/FeatureToggleDataUpdatedOnSchedule.scala
@@ -3,6 +3,7 @@ package prodtest
 import akka.actor.ActorSystem
 import com.gu.memsub.util.ScheduledTask
 import com.typesafe.scalalogging.LazyLogging
+import models.ZuoraLookupFeatureData
 import services.ScanamoFeatureToggleService
 
 import scala.concurrent.ExecutionContext
@@ -11,25 +12,29 @@ import scalaz.{-\/, \/-}
 
 class FeatureToggleDataUpdatedOnSchedule(featureToggleService: ScanamoFeatureToggleService, stage: String)(implicit ec: ExecutionContext, system: ActorSystem) extends LazyLogging {
 
-  private val updateZuoraTrafficPercentageTask: ScheduledTask[Int] = {
-    val featureName = "UpdateAttributesFromZuoraLookupPercentage"
-    ScheduledTask[Int](featureName, 0, 0.seconds, 30.seconds) {
+  private val updateZuoraLookupFeatureDataTask: ScheduledTask[ZuoraLookupFeatureData] = {
+    val featureName = "UpdateAttributesFromZuoraLookup"
+    val defaultFeatureValues = ZuoraLookupFeatureData(TrafficPercentage = 0, ConcurrentZuoraCallThreshold = 10)
+
+    ScheduledTask[ZuoraLookupFeatureData](featureName, defaultFeatureValues, 0.seconds, 30.seconds) {
       featureToggleService.get("AttributesFromZuoraLookup") map { result =>
         result match {
           case \/-(feature) =>
-            val percentage = feature.TrafficPercentage.getOrElse(0)
-            logger.info(s"$featureName scheduled task set percentage to $percentage in $stage")
-            percentage
+            val percentage = feature.TrafficPercentage.getOrElse(defaultFeatureValues.TrafficPercentage)
+            val threshold = feature.ConcurrentZuoraCallThreshold.getOrElse(defaultFeatureValues.ConcurrentZuoraCallThreshold)
+            logger.info(s"$featureName scheduled task set percentage to $percentage and zuora concurrency threshold to $threshold in $stage")
+            ZuoraLookupFeatureData(percentage, threshold)
           case -\/(e) =>
-            logger.warn(s"Tried to update the percentage of traffic for $featureName, but that feature was not " +
-              s"found in the table. Setting traffic to 0% in $stage. Error: $e")
-            0
+            logger.warn(s"Tried to update the percentage of traffic for $featureName and the zuora concurrency threshold, but that feature was not " +
+              s"found in the table. Setting traffic to ${defaultFeatureValues.TrafficPercentage}% and concurrency threshold to " +
+              s"${defaultFeatureValues.ConcurrentZuoraCallThreshold} in $stage. Error: $e")
+            defaultFeatureValues
         }
       }
     }
   }
 
-  updateZuoraTrafficPercentageTask.start()
+  updateZuoraLookupFeatureDataTask.start()
 
-  def getPercentageTrafficForZuoraLookupTask = updateZuoraTrafficPercentageTask
+  def getZuoraLookupFeatureDataTask = updateZuoraLookupFeatureDataTask
 }


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
Now that we have a way to [lookup attributes via Zuora](https://github.com/guardian/members-data-api/pull/205) and [update the membership-attributes dynamo table](https://github.com/guardian/members-data-api/pull/239) on these lookups we want to be able to send 100% of the traffic to lookup attributes via Zuora.

However, during push notifications, this generates too many calls to Zuora. This is the simplest possible way to address that: just checking on each lookup call if the number of concurrent calls to Zuora is over a threshold.


### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
- On each lookup call to Zuora, check to see if the number of concurrent calls is over a threshold, and if it is, serve the response from Dynamo

### trello card/screenshot/json/related PRs etc
[lookup attributes via Zuora](https://github.com/guardian/members-data-api/pull/205)
[update the membership-attributes dynamo table on lookups via Zuora](https://github.com/guardian/members-data-api/pull/239)

There are default values in the agent that updates current percentage of lookup traffic via zuora and the Zuora and the threshold for concurrent calls to Zuora on that instance. I put in a default value of 10 concurrent calls per instance by looking at the pattern of concurrent calls for when the traffic was at 100% 

![concurrency-count-annotated](https://user-images.githubusercontent.com/3072877/31073874-d64d2728-a765-11e7-94be-8faf9d51e1da.png)
cc @jacobwinch @paulbrown1982 @pvighi  @AWare 
