### PR TITLE
Fix for when Zuora has no card type stored

### DIFF
--- a/membership-attribute-service/app/json/PaymentCardUpdateResultWriters.scala
+++ b/membership-attribute-service/app/json/PaymentCardUpdateResultWriters.scala
@@ -7,7 +7,8 @@ import play.api.libs.functional.syntax._
 object PaymentCardUpdateResultWriters {
 
   implicit val paymentCardWrites: Writes[PaymentCard] = Writes[PaymentCard] { paymentCard =>
-    Json.obj("type" -> paymentCard.cardType.getOrElse("unknown").replace(" ", "")) ++ paymentCard.paymentCardDetails.map(details =>
+    Json.obj("type" -> paymentCard.cardType.getOrElse[String]("unknown").replace(" ", "")) ++
+      paymentCard.paymentCardDetails.map(details =>
       Json.obj(
         "last4" -> details.lastFourDigits,
         "expiryMonth" -> details.expiryMonth,

--- a/membership-attribute-service/app/json/PaymentCardUpdateResultWriters.scala
+++ b/membership-attribute-service/app/json/PaymentCardUpdateResultWriters.scala
@@ -7,7 +7,7 @@ import play.api.libs.functional.syntax._
 object PaymentCardUpdateResultWriters {
 
   implicit val paymentCardWrites: Writes[PaymentCard] = Writes[PaymentCard] { paymentCard =>
-    Json.obj("type" -> paymentCard.cardType.replace(" ", "")) ++ paymentCard.paymentCardDetails.map(details =>
+    Json.obj("type" -> paymentCard.cardType.getOrElse("unknown").replace(" ", "")) ++ paymentCard.paymentCardDetails.map(details =>
       Json.obj(
         "last4" -> details.lastFourDigits,
         "expiryMonth" -> details.expiryMonth,

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -34,7 +34,7 @@ object AccountDetails {
           "card" -> {
             Json.obj(
               "last4" -> card.paymentCardDetails.map(_.lastFourDigits).getOrElse[String]("••••"),
-              "type" -> card.cardType
+              "type" -> card.cardType.getOrElse("unknown")
             ) ++ stripePublicKey.map(k => Json.obj("stripePublicKeyForUpdate" -> k)).getOrElse(Json.obj())
           }
         )

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -34,7 +34,7 @@ object AccountDetails {
           "card" -> {
             Json.obj(
               "last4" -> card.paymentCardDetails.map(_.lastFourDigits).getOrElse[String]("••••"),
-              "type" -> card.cardType.getOrElse("unknown")
+              "type" -> card.cardType.getOrElse[String]("unknown")
             ) ++ stripePublicKey.map(k => Json.obj("stripePublicKeyForUpdate" -> k)).getOrElse(Json.obj())
           }
         )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSNS = "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.467"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.468"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.0"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
This fixes the issue in profile.theguardian.com where no card data comes through from older members where we have not captured the card type. People cannot update their expired card, and User Help and TP are getting a lot of contacts!

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
Fix for when Zuora has no card type stored.  Now that membership-common doesn't go through to Stripe for each call to getPaymentMethod. A backfill of these Stripe data into Zuora will happen very soon.

See: https://github.com/guardian/membership-common/pull/538

cc @jacobwinch @pvighi @AWare @lmath 