### PR TITLE
On lookups, fallback to Dynamo cache if getting subscriptions from Zuora fails

### DIFF
--- a/membership-attribute-service/test/services/AttributesFromZuoraTest.scala
+++ b/membership-attribute-service/test/services/AttributesFromZuoraTest.scala
@@ -75,6 +75,14 @@ class AttributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
         val attributes: Future[Option[Attributes]] = AttributesFromZuora.getAttributes(testId, identityIdToAccountIds, subscriptionFromAccountId, dynamoAttributeGetter, dynamoAttributeUpdater, referenceDate)
         attributes must be_==(None).await
       }
+
+      "still return attributes if there aren't any stored in Dynamo" in new contributor {
+        override def dynamoAttributeGetter(identityId: String): Future[Option[Attributes]] = Future.successful(None)
+
+        val attributes: Future[Option[Attributes]] = AttributesFromZuora.getAttributes(testId, identityIdToAccountIds, subscriptionFromAccountId, dynamoAttributeGetter, dynamoAttributeUpdater, referenceDate)
+        attributes must be_==(Some(contributorAttributes)).await
+      }
+
     }
 
     "getSubscriptions" should {


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
So that we can return a response on calls to {/me, /me/features, /me/membership} even if there is a failure in getting subscriptions for a user.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
- If we fail to get subscriptions for a user from Zuora, we return the response from the cache if we have something stored in the cache. 

### trello card/screenshot/json/related PRs etc
[PR 239 - update the cache on zuora lookups](https://github.com/guardian/members-data-api/pull/239)
[PR 243 - serve from the cache if concurrent calls to zuora is over a threshold](https://github.com/guardian/members-data-api/pull/243)

cc @paulbrown1982 @jacobwinch @pvighi @AWare 