### PR TITLE
On Zuora lookups, update the cache when all subs are expired or cancelled too.

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -65,8 +65,7 @@ class AttributeController extends Controller with LoggingWithLogstashFields {
                 identityId = identityId,
                 identityIdToAccountIds = request.touchpoint.zuoraRestService.getAccounts,
                 subscriptionsForAccountId = accountId => reads => request.touchpoint.subService.subscriptionsForAccountId[AnyPlan](accountId)(reads),
-                dynamoAttributeGetter = attributesFromDynamo,
-                dynamoAttributeUpdater = attributes => request.touchpoint.attrService.update(attributes))
+                dynamoAttributeService = request.touchpoint.attrService)
 
               ("Zuora", attributesFromZuora)
             } else {

--- a/membership-attribute-service/app/prodtest/FeatureToggleDataUpdatedOnSchedule.scala
+++ b/membership-attribute-service/app/prodtest/FeatureToggleDataUpdatedOnSchedule.scala
@@ -13,11 +13,11 @@ import scalaz.{-\/, \/-}
 class FeatureToggleDataUpdatedOnSchedule(featureToggleService: ScanamoFeatureToggleService, stage: String)(implicit ec: ExecutionContext, system: ActorSystem) extends LazyLogging {
 
   private val updateZuoraLookupFeatureDataTask: ScheduledTask[ZuoraLookupFeatureData] = {
-    val featureName = "UpdateAttributesFromZuoraLookup"
+    val featureName = "AttributesFromZuoraLookup"
     val defaultFeatureValues = ZuoraLookupFeatureData(TrafficPercentage = 0, ConcurrentZuoraCallThreshold = 10)
 
     ScheduledTask[ZuoraLookupFeatureData](featureName, defaultFeatureValues, 0.seconds, 30.seconds) {
-      featureToggleService.get("AttributesFromZuoraLookup") map { result =>
+      featureToggleService.get(featureName) map { result =>
         result match {
           case \/-(feature) =>
             val percentage = feature.TrafficPercentage.getOrElse(defaultFeatureValues.TrafficPercentage)


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
Now when we send 100% of lookup traffic through Zuora, we will still serve from the dynamo table (as a cache) during spikes of traffic or if to calls to Zuora to get subscription information fail. 

When we do a lookup via Zuora, if there are no active subscriptions from Zuora/the attributes are None, then the update to the cache should mean that the entry for that user is removed from the table. Then, when we need to serve from the cache later on we report that the user has no active subscriptions.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
* When we do a lookup via Zuora, if there are no active subscriptions from Zuora/the attributes are None, then the update to the cache should mean that the entry for that user is removed from the table.

### trello card/screenshot/json/related PRs etc
[on trello](https://trello.com/c/IFuUjZnO/224-supporters-who-cancel-downgrade-are-never-removed-from-dynamo)
[PR 239 - on zuora lookups, update the dynamo cache](https://github.com/guardian/members-data-api/pull/239)
[PR 243 - serve from cache if concurrency over a threshold](https://github.com/guardian/members-data-api/pull/243)
[PR 246 - fallback to cache if a zuora lookup fails](https://github.com/guardian/members-data-api/pull/246)