### PR TITLE
Do a Stripe lookup in the /mma-[product] controller get accurate card details

### DIFF
--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -76,7 +76,7 @@ class AccountController extends LazyLogging {
         case card: PaymentCard =>
           (for {
             zuoraPaymentMethod <- tp.zuoraService.getPaymentMethod(paymentMethodId).liftM[OptionT]
-            customerId <- OptionT(Future.successful(zuoraPaymentMethod.secondTokenId))
+            customerId <- OptionT(Future.successful(zuoraPaymentMethod.secondTokenId.map(_.trim).filter(_.startsWith("cus_"))))
             stripeCustomer <- OptionT((Try(tp.ukStripeService.Customer.read(customerId)).toOption orElse Try(tp.auStripeService.Customer.read(customerId)).toOption).sequence)
           } yield {
             // TODO consider broadcasting to a queue somewhere iff the payment method in Zuora is out of date compared to Stripe

--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -9,6 +9,7 @@ import com.gu.memsub.subsv2.reads.SubPlanReads
 import com.gu.memsub.subsv2.reads.SubPlanReads._
 import com.gu.services.model.PaymentDetails
 import com.typesafe.scalalogging.LazyLogging
+import components.TouchpointComponents
 import configuration.Config
 import json.PaymentCardUpdateResultWriters._
 import models.AccountDetails._
@@ -20,9 +21,13 @@ import play.api.mvc.Results._
 import play.filters.cors.CORSActionBuilder
 
 import scala.concurrent.Future
+import scala.util.Try
+import scalaz.std.option._
 import scalaz.std.scalaFuture._
+import scalaz.syntax.monad._
 import scalaz.syntax.std.option._
-import scalaz.{-\/, EitherT, OptionT, \/, \/-}
+import scalaz.syntax.traverse._
+import scalaz.{-\/, EitherT, OptionT, \/, \/-, _}
 
 class AccountController extends LazyLogging {
 
@@ -65,8 +70,29 @@ class AccountController extends LazyLogging {
     }
   }
 
+  private def getUpToDatePaymentDetailsFromStripe(defaultPaymentMethodId: Option[String], paymentDetails: PaymentDetails)(implicit tp: TouchpointComponents): Future[PaymentDetails] = {
+    defaultPaymentMethodId.flatMap { paymentMethodId =>
+      paymentDetails.paymentMethod.map {
+        case card: PaymentCard =>
+          (for {
+            zuoraPaymentMethod <- tp.zuoraService.getPaymentMethod(paymentMethodId).liftM[OptionT]
+            customerId <- OptionT(Future.successful(zuoraPaymentMethod.secondTokenId))
+            stripeCustomer <- OptionT((Try(tp.ukStripeService.Customer.read(customerId)).toOption orElse Try(tp.auStripeService.Customer.read(customerId)).toOption).sequence)
+          } yield {
+            // TODO consider broadcasting to a queue somewhere iff the payment method in Zuora is out of date compared to Stripe
+            card.copy(
+              cardType = Some(stripeCustomer.card.`type`),
+              paymentCardDetails = Some(PaymentCardDetails(stripeCustomer.card.last4, stripeCustomer.card.exp_month, stripeCustomer.card.exp_year))
+            )
+          }).run
+      }
+    }.sequence.map { maybeUpdatedPaymentCard =>
+      paymentDetails.copy(paymentMethod = maybeUpdatedPaymentCard getOrElse paymentDetails.paymentMethod)
+    }
+  }
+
   def paymentDetails[P <: SubscriptionPlan.Paid : SubPlanReads, F <: SubscriptionPlan.Free : SubPlanReads] = mmaAction.async { implicit request =>
-    val tp = request.touchpoint
+    implicit val tp: TouchpointComponents = request.touchpoint
     val maybeUserId = authenticationService.userId
 
     logger.info(s"Attempting to retrieve payment details for identity user: $maybeUserId")
@@ -74,11 +100,12 @@ class AccountController extends LazyLogging {
       user <- OptionEither.liftFutureEither(maybeUserId)
       contact <- OptionEither(tp.contactRepo.get(user))
       freeOrPaidSub <- OptionEither(tp.subService.either[F, P](contact).map(_.leftMap(message => s"couldn't read sub from zuora for crmId ${contact.salesforceAccountId} due to $message")))
-      details <- OptionEither.liftOption(tp.paymentService.paymentDetails(freeOrPaidSub).map(\/.right))
       sub = freeOrPaidSub.fold(identity, identity)
-      account <- OptionEither.liftOption(tp.zuoraService.getAccount(sub.accountId).map(\/.right).recover { case x => \/.left(s"error receiving account for subscription: ${sub.name} with account id ${sub.accountId}. Reason: $x") })
+      account <- OptionEither.liftOption(tp.zuoraService.getAccount(sub.accountId).map(\/.right).recover { case x => \/.left(s"error retrieving account for subscription: ${sub.name} with account id ${sub.accountId}. Reason: $x") })
       publicKey = account.paymentGateway.flatMap(tp.stripeServicesByPaymentGateway.get).map(_.publicKey)
-    } yield (contact, details, publicKey).toResult).run.run.map {
+      paymentDetails <- OptionEither.liftOption(tp.paymentService.paymentDetails(freeOrPaidSub).map(\/.right).recover { case x => \/.left(s"error retrieving payment details for subscription: ${sub.name}. Reason: $x") })
+      upToDatePaymentDetails <- OptionEither.liftOption(getUpToDatePaymentDetailsFromStripe(account.defaultPaymentMethodId, paymentDetails).map(\/.right).recover { case x => \/.left(s"error getting up-to-date  details for payment method Id: ${account.defaultPaymentMethodId.mkString}. Reason: $x") })
+    } yield (contact, upToDatePaymentDetails, publicKey).toResult).run.run.map {
       case \/-(Some(result)) =>
         logger.info(s"Successfully retrieved payment details result for identity user: $maybeUserId")
         result


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
The changes to support Australia Stripe cards and fix a bug with Zuora cards, removed the Stripe lookup in membership-common. This meant that we showed four ****s instead of the last 4 digits for older members/subscribers.
This change introduces it into Members Data API instead - as it is aware of the Touchpoint backend and so can pick the right Stripe account.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
Do a Stripe lookup for all payment cards with a non-empty secondTokenId to get accurate card details, as Zuora's details on the payment method may be latent.]

cc @jacobwinch @svillafe @rupertbates @pvighi @Ap0c 

