### PR TITLE
Log that the attributes came from Dynamo if they do because getting subs from Zuora failed

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -50,7 +50,7 @@ class AttributeController extends Controller with LoggingWithLogstashFields {
 
   private def lookup(endpointDescription: String, onSuccessMember: Attributes => Result, onSuccessSupporter: Attributes => Result, onNotFound: Result, endpointEligibleForTest: Boolean, sendAttributesIfNotFound: Boolean = false) =
   {
-    def pickAttributes(identityId: String) (implicit request: BackendRequest[AnyContent]): (String, Future[Option[Attributes]]) = {
+    def pickAttributes(identityId: String) (implicit request: BackendRequest[AnyContent]): Future[(String, Option[Attributes])] = {
       def attributesFromDynamo(identityId: String) = request.touchpoint.attrService.get(identityId)
 
       if(endpointEligibleForTest){
@@ -61,52 +61,54 @@ class AttributeController extends Controller with LoggingWithLogstashFields {
         isInTest(identityId, percentageInTest) match {
           case true => {
             if(ZuoraRequestCounter.get < concurrentCallThreshold) {
-              val attributesFromZuora = getAttributes(
+              getAttributes(
                 identityId = identityId,
                 identityIdToAccountIds = request.touchpoint.zuoraRestService.getAccounts,
                 subscriptionsForAccountId = accountId => reads => request.touchpoint.subService.subscriptionsForAccountId[AnyPlan](accountId)(reads),
                 dynamoAttributeService = request.touchpoint.attrService)
-
-              ("Zuora", attributesFromZuora)
             } else {
-              ("Dynamo - too many concurrent calls to Zuora", attributesFromDynamo(identityId))
+              attributesFromDynamo(identityId) map {("Dynamo - too many concurrent calls to Zuora", _)}
             }
 
           }
-          case false => ("Dynamo - not in Zuora lookup bucket", attributesFromDynamo(identityId))
+          case false => attributesFromDynamo(identityId) map {("Dynamo - not in Zuora lookup bucket", _)}
         }
-      } else ("Dynamo - as this endpoint always does", attributesFromDynamo(identityId))
+      } else attributesFromDynamo(identityId) map {("Dynamo - as this endpoint always does", _)}
     }
 
     backendAction.async { implicit request =>
       authenticationService.userId(request) match {
         case Some(identityId) =>
-          val (fromWhere, attributes) = pickAttributes(identityId)
-          def customFields(supporterType: String): List[LogField] = List(LogFieldString("lookup-endpoint-description", endpointDescription), LogFieldString("supporter-type", supporterType), LogFieldString("data-source", fromWhere))
+          pickAttributes(identityId) map { pickedAttributes =>
 
-          attributes.map {
-            case Some(attrs @ Attributes(_, Some(tier), _, _, _, _, _, _)) =>
-              logInfoWithCustomFields(s"$identityId is a $tier member - $endpointDescription - $attrs found via $fromWhere", customFields("member"))
-              onSuccessMember(attrs).withHeaders(
-                "X-Gu-Membership-Tier" -> tier,
-                "X-Gu-Membership-Is-Paid-Tier" -> attrs.isPaidTier.toString
-              )
-            case Some(attrs) =>
-              attrs.DigitalSubscriptionExpiryDate.foreach { date =>
-                logInfoWithCustomFields(s"$identityId is a digital subscriber expiring $date", customFields("digital-subscriber"))
-              }
-              attrs.RecurringContributionPaymentPlan.foreach { paymentPlan =>
-                logInfoWithCustomFields(s"$identityId is a regular $paymentPlan contributor", customFields("contributor"))
-              }
-              attrs.AdFree.foreach { _ =>
-                logInfoWithCustomFields(s"$identityId is an ad-free reader", customFields("ad-free-reader"))
-              }
-              logInfoWithCustomFields(s"$identityId supports the guardian - $attrs - found via $fromWhere", customFields("supporter"))
-              onSuccessSupporter(attrs)
-            case None if sendAttributesIfNotFound =>
-              Attributes(identityId, AdFree = Some(false))
-            case _ =>
-              onNotFound
+            val (fromWhere: String, attributes: Option[Attributes]) = pickedAttributes
+
+            def customFields(supporterType: String): List[LogField] = List(LogFieldString("lookup-endpoint-description", endpointDescription), LogFieldString("supporter-type", supporterType), LogFieldString("data-source", fromWhere))
+
+            attributes match {
+              case Some(attrs @ Attributes(_, Some(tier), _, _, _, _, _, _)) =>
+                logInfoWithCustomFields(s"$identityId is a $tier member - $endpointDescription - $attrs found via $fromWhere", customFields("member"))
+                onSuccessMember(attrs).withHeaders(
+                  "X-Gu-Membership-Tier" -> tier,
+                  "X-Gu-Membership-Is-Paid-Tier" -> attrs.isPaidTier.toString
+                )
+              case Some(attrs) =>
+                attrs.DigitalSubscriptionExpiryDate.foreach { date =>
+                  logInfoWithCustomFields(s"$identityId is a digital subscriber expiring $date", customFields("digital-subscriber"))
+                }
+                attrs.RecurringContributionPaymentPlan.foreach { paymentPlan =>
+                  logInfoWithCustomFields(s"$identityId is a regular $paymentPlan contributor", customFields("contributor"))
+                }
+                attrs.AdFree.foreach { _ =>
+                  logInfoWithCustomFields(s"$identityId is an ad-free reader", customFields("ad-free-reader"))
+                }
+                logInfoWithCustomFields(s"$identityId supports the guardian - $attrs - found via $fromWhere", customFields("supporter"))
+                onSuccessSupporter(attrs)
+              case None if sendAttributesIfNotFound =>
+                Attributes(identityId, AdFree = Some(false))
+              case _ =>
+                onNotFound
+            }
           }
         case None =>
           metrics.put(s"$endpointDescription-cookie-auth-failed", 1)


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
[PR 246 - fallback to dynamo if getting subs from Zuora fails](https://github.com/guardian/members-data-api/pull/246) adds a change so that if a lookup via Zuora fails, we return a value from the Dynamo cache, if there is one.

However, this meant logging where we attempted to get attributes from rather than where they came from. This change ensures that in the case where we attempt to get attributes from Zuora but need to fallback to return to the dynamo cache that we log that the attributes came from the cache. 

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->

- Adds logging if the attributes came direct from Zuora or from the cache

### trello card/screenshot/json/related PRs etc
[PR 246 - fallback to dynamo if getting subs from Zuora fails](https://github.com/guardian/members-data-api/pull/246)

cc @paulbrown1982 @jacobwinch @pvighi 