### PR TITLE
Don't make returning zuora attributes depend on the cache update

### DIFF
--- a/membership-attribute-service/test/services/AttributesFromZuoraTest.scala
+++ b/membership-attribute-service/test/services/AttributesFromZuoraTest.scala
@@ -5,20 +5,22 @@ import services.AttributesFromZuora._
 import com.gu.memsub.Subscription.AccountId
 import com.gu.memsub.subsv2.SubscriptionPlan.AnyPlan
 import com.gu.memsub.subsv2.reads.SubPlanReads
+import com.gu.scanamo.error.{DynamoReadError, MissingProperty}
 import com.gu.zuora.ZuoraRestService.{AccountIdRecord, QueryResponse}
 import models.Attributes
 import org.joda.time.LocalDate
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
-import org.specs2.specification.Scope
+import org.specs2.specification.{BeforeEach, Scope}
 import testdata.SubscriptionTestData
 
-import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, Future}
 import scalaz.\/
 
 
-class AttributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification with SubscriptionTestData with Mockito {
+class AttributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification with SubscriptionTestData with Mockito with BeforeEach {
 
   override def referenceDate = new LocalDate(2016, 9, 20)
 
@@ -31,12 +33,16 @@ class AttributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
   val twoAccountsQueryResponse = QueryResponse(records = List(AccountIdRecord(testAccountId), AccountIdRecord(anotherTestAccountId)), size = 2)
   val contributorAttributes = Attributes(UserId = testId, None, None, None, None, RecurringContributionPaymentPlan = Some("Monthly Contribution"), None, None)
 
-  val friendAttributes = Attributes(UserId = testId, Some("Friend"), None, None, None, None, Some(joinDate), None)
-  val supporterAttributes = Attributes(UserId = testId, Some("Supporter"), None, None, None, None, Some(joinDate), None)
+  val friendAttributes = Attributes(UserId = testId, Some("Friend"), None, None, None, None, Some(referenceDate), None)
+  val supporterAttributes = Attributes(UserId = testId, Some("Supporter"), None, None, None, None, Some(referenceDate), None)
 
   val mockDynamoAttributesService = mock[AttributeService]
 
   def dynamoAttributeUpdater(attributes: Attributes) = Future.successful(Right(attributes))
+
+  override def before = {
+    org.mockito.Mockito.reset(mockDynamoAttributesService)
+  }
 
   "ZuoraAttributeService" should {
 
@@ -92,10 +98,17 @@ class AttributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
         there was no(mockDynamoAttributesService).delete(anyString)
       }
 
-      "still return attributes if there aren't any stored in Dynamo" in new contributor {
+      "still return attributes if there aren't any stored in Dynamo" in {
+
+        mockDynamoAttributesService.update(contributorAttributes) returns Future.successful(Right(contributorAttributes))
+
+        def identityIdToAccountIds(identityId: String): Future[\/[String, QueryResponse]] = Future.successful(\/.right(oneAccountQueryResponse))
+        def subscriptionFromAccountId(accountId: AccountId)(reads: SubPlanReads[AnyPlan]) = Future.successful(\/.right(List(contributor)))
+
         val attributes: Future[(String, Option[Attributes])] = AttributesFromZuora.getAttributes(testId, identityIdToAccountIds, subscriptionFromAccountId, mockDynamoAttributesService, referenceDate)
         attributes must be_==("Zuora", Some(contributorAttributes)).await
 
+        there was one(mockDynamoAttributesService).update(contributorAttributes)
         there was no(mockDynamoAttributesService).delete(anyString)
       }
 
@@ -112,6 +125,25 @@ class AttributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
 
         there was one(mockDynamoAttributesService).delete(testId)
       }
+
+
+      "update the attributes in dynamo if zuora is more up to date" in {
+        //friend in Dynamo, upgraded in Zuora
+        val friendAttributes = supporterAttributes.copy(Tier = Some("Friend"))
+
+        mockDynamoAttributesService.get(testId) returns Future.successful(Some(friendAttributes))
+        mockDynamoAttributesService.update(any[Attributes]) returns Future.successful(Right(supporterAttributes))
+
+        def subscriptionFromAccountId(accountId: AccountId)(reads: SubPlanReads[AnyPlan]) = Future.successful(\/.right(List(membership)))
+        def identityIdToAccountIds(identityId: String): Future[\/[String, QueryResponse]] = Future.successful(\/.right(oneAccountQueryResponse))
+
+        val attributes: Future[(String, Option[Attributes])] = AttributesFromZuora.getAttributes(testId, identityIdToAccountIds, subscriptionFromAccountId, mockDynamoAttributesService, referenceDate)
+        attributes must be_==("Zuora", Some(supporterAttributes)).await
+
+        there was one(mockDynamoAttributesService).update(supporterAttributes)
+        there was no(mockDynamoAttributesService).delete(anyString)
+      }
+
 
     }
 
@@ -180,14 +212,14 @@ class AttributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
 
         val expectedResult = Some(contributorAttributes.copy(AdFree = Some(true)))
 
-        AttributesFromZuora.attributesWithFlagFromDynamo(fromZuora, fromDynamo) must be_==(expectedResult)
+        AttributesFromZuora.attributesWithAdFreeFlagFromDynamo(fromZuora, fromDynamo) must be_==(expectedResult)
       }
 
       "not have an AdFree status either if there isn't one in dynamo" in new contributor {
         val fromDynamo = Some(contributorAttributes.copy(Tier = Some("Partner")))
         val fromZuora = Some(contributorAttributes)
 
-        AttributesFromZuora.attributesWithFlagFromDynamo(fromZuora, fromDynamo) must be_==(Some(contributorAttributes))
+        AttributesFromZuora.attributesWithAdFreeFlagFromDynamo(fromZuora, fromDynamo) must be_==(Some(contributorAttributes))
       }
     }
 


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
We should just update the cache as a best effort, and return attributes from Zuora regardless, if we have them. 

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
- Start the cache update and log if it fails but return attributes from Zuora regardless

### trello card/screenshot/json/related PRs etc
[pr 247 - update the cache for cancelled or expired subs too](https://github.com/guardian/members-data-api/pull/247)