### PR TITLE
Serve from the cache if the future fails on calls to Zuora

### DIFF
--- a/membership-attribute-service/app/services/AttributesFromZuora.scala
+++ b/membership-attribute-service/app/services/AttributesFromZuora.scala
@@ -42,7 +42,7 @@ object AttributesFromZuora extends LoggingWithLogstashFields {
     }
 
 
-    val attributesFromDynamo = dynamoAttributeService.get(identityId)
+    val attributesFromDynamo: Future[(String, Option[Attributes])] = dynamoAttributeService.get(identityId) map { attributes => ("Dynamo", attributes)}
 
     val attributesFromZuora: Future[Disjunction[String, Option[Attributes]]] = attributesDisjunction.run.map {
         _.leftMap { errorMsg =>
@@ -54,13 +54,16 @@ object AttributesFromZuora extends LoggingWithLogstashFields {
     val attributesFromZuoraOrDynamoFallback: Future[(String, Option[Attributes])] = for {
       dynamoAttributes <- attributesFromDynamo
       attributesFromZuora <- attributesFromZuora
-    } yield attributesFromZuora.fold(_ => ("Dynamo", dynamoAttributes), ("Zuora", _))
+    } yield attributesFromZuora.fold(_ => dynamoAttributes, ("Zuora", _))
 
-    attributesFromZuoraOrDynamoFallback flatMap { attributesFromSomewhere =>
+    val zuoraOrCachedAttributes = attributesFromZuoraOrDynamoFallback fallbackTo attributesFromDynamo
+
+    zuoraOrCachedAttributes flatMap { attributesFromSomewhere =>
       val (fromWhere: String, attributes: Option[Attributes]) = attributesFromSomewhere
 
       if(fromWhere == "Zuora") {
-        attributesFromDynamo map { (dynamoAttributes: Option[Attributes]) =>
+        attributesFromDynamo map { sourceAndAttributes =>
+          val (_, dynamoAttributes) = sourceAndAttributes
           val canSkipCacheUpdate: Boolean = dynamoAndZuoraAgree(dynamoAttributes, attributes, identityId)
           val zuoraAttributesWithAdfree: Option[Attributes] = attributesWithAdFreeFlagFromDynamo(attributes, dynamoAttributes)
 
@@ -78,6 +81,7 @@ object AttributesFromZuora extends LoggingWithLogstashFields {
       else Future.successful(fromWhere, attributes)
     }
   }
+
   private def updateCache(identityId: String, zuoraAttributesWithAdfree: Option[Attributes], dynamoAttributeService: AttributeService): Future[Unit] = {
     zuoraAttributesWithAdfree match {
       case Some(attributes) =>

--- a/membership-attribute-service/app/services/AttributesFromZuora.scala
+++ b/membership-attribute-service/app/services/AttributesFromZuora.scala
@@ -53,8 +53,8 @@ object AttributesFromZuora extends LoggingWithLogstashFields {
 
     val attributesFromZuoraOrDynamoFallback: Future[(String, Option[Attributes])] = for {
       dynamoAttributes <- attributesFromDynamo
-      attributesFromZuora <- attributesFromZuora
-    } yield attributesFromZuora.fold(_ => dynamoAttributes, ("Zuora", _))
+      zuoraAttributes <- attributesFromZuora
+    } yield zuoraAttributes.fold(_ => dynamoAttributes, ("Zuora", _))
 
     val zuoraOrCachedAttributes = attributesFromZuoraOrDynamoFallback fallbackTo attributesFromDynamo
 

--- a/membership-attribute-service/app/services/AttributesFromZuora.scala
+++ b/membership-attribute-service/app/services/AttributesFromZuora.scala
@@ -62,8 +62,7 @@ object AttributesFromZuora extends LoggingWithLogstashFields {
       val (fromWhere: String, attributes: Option[Attributes]) = attributesFromSomewhere
 
       if(fromWhere == "Zuora") {
-        attributesFromDynamo map { sourceAndAttributes =>
-          val (_, dynamoAttributes) = sourceAndAttributes
+        attributesFromDynamo map { case (_, dynamoAttributes) =>
           val canSkipCacheUpdate: Boolean = dynamoAndZuoraAgree(dynamoAttributes, attributes, identityId)
           val zuoraAttributesWithAdfree: Option[Attributes] = attributesWithAdFreeFlagFromDynamo(attributes, dynamoAttributes)
 


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
We should return a value from the cache if there is one when the future fails on calls to Zuora because it's better than returning a 500. 

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
- If an individual call to {/me, /me/membership, /me/features} fails because the future fails on a call to Zuora, we return the value from the cache, if there is one.

### trello card/screenshot/json/related PRs etc
[PR 246](https://github.com/guardian/members-data-api/pull/246) handles lefts on calls to Zuora by serving from the cache, but this happens rarely.  

cc @jacobwinch @pvighi @paulbrown1982 