### PR TITLE
Remove old Salesforce wiring

### DIFF
--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -39,8 +39,6 @@ class TouchpointComponents(stage: String)(implicit system: ActorSystem) {
   lazy val digitalPackConf = environmentConf.getConfig(s"zuora.ratePlanIds.digitalpack")
   lazy val paperCatalogConf = environmentConf.getConfig(s"zuora.productIds.subscriptions")
   lazy val membershipConf = environmentConf.getConfig(s"zuora.ratePlanIds.membership")
-  lazy val sfOrganisationId = environmentConf.getString("salesforce.organization-id")
-  lazy val sfSecret = environmentConf.getString("salesforce.hook-secret")
   lazy val dynamoAttributesTable = environmentConf.getString("dynamodb.table")
   lazy val dynamoBehaviourTable = environmentConf.getString("behaviour.dynamodb.table")
   lazy val dynamoFeatureToggleTable = environmentConf.getString("featureToggles.dynamodb.table")

--- a/membership-attribute-service/conf/touchpoint.DEV.conf
+++ b/membership-attribute-service/conf/touchpoint.DEV.conf
@@ -3,9 +3,5 @@ touchpoint.backend.environments {
     dynamodb.table = MembershipAttributes-DEV
     behaviour.dynamodb.table = MembershipBehaviour-DEV
     featureToggles.dynamodb.table = MembershipFeatureToggles-DEV
-    salesforce {
-      hook-secret = "secret-key"
-      organization-id = "orgIdxxxxxxxxxxxxx"
-    }
   }
 }

--- a/membership-attribute-service/conf/touchpoint.PROD.conf
+++ b/membership-attribute-service/conf/touchpoint.PROD.conf
@@ -3,9 +3,5 @@ touchpoint.backend.environments {
     dynamodb.table = MembershipAttributes-PROD
     behaviour.dynamodb.table = MembershipBehaviour-PROD
     featureToggles.dynamodb.table = MembershipFeatureToggles-PROD
-    salesforce {
-      hook-secret = null
-      organization-id = null
-    }
   }
 }

--- a/membership-attribute-service/conf/touchpoint.UAT.conf
+++ b/membership-attribute-service/conf/touchpoint.UAT.conf
@@ -3,9 +3,5 @@ touchpoint.backend.environments {
     dynamodb.table = MembershipAttributes-UAT
     behaviour.dynamodb.table = MembershipBehaviour-UAT
     featureToggles.dynamodb.table = MembershipFeatureToggles-UAT
-    salesforce {
-      hook-secret = ""
-      organization-id = "xxxxxxxxxxxxxxxxxx"
-    }
   }
 }


### PR DESCRIPTION
### Why do we need this? 
This config is no longer used - this PR is a follow up to https://github.com/guardian/members-data-api/pull/256

### The changes 
* Remove references to Salesforce org id and hook 'secrets', as these are no longer required.

### trello card/screenshot/json/related PRs etc
https://github.com/guardian/members-data-api/pull/256

This allows us to delete these values from the PROD private conf file (I'll do this after merging this PR).