### PR TITLE
Migrate au customers to au stripe

### DIFF
--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -3,8 +3,11 @@ package components
 import akka.actor.ActorSystem
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
+
 import scalaz.std.scalaFuture._
 import com.gu.config
+import com.gu.i18n.Country
+import com.gu.zuora.api.InvoiceTemplate
 import com.gu.memsub.services.PaymentService
 import com.gu.memsub.subsv2.services.SubscriptionService.CatalogMap
 import com.gu.memsub.subsv2.services._
@@ -13,7 +16,7 @@ import com.gu.okhttp.RequestRunners
 import com.gu.salesforce.SimpleContactRepository
 import com.gu.stripe.StripeService
 import com.gu.touchpoint.TouchpointBackendConfig
-import com.gu.zuora.api.PaymentGateway
+import com.gu.zuora.api.{InvoiceTemplate, InvoiceTemplates, PaymentGateway}
 import com.gu.zuora.rest.SimpleClient
 import com.gu.zuora.soap.ClientWithFeatureSupplier
 import com.gu.zuora.{ZuoraRestService, ZuoraService}
@@ -42,6 +45,7 @@ class TouchpointComponents(stage: String)(implicit system: ActorSystem) {
   lazy val dynamoAttributesTable = environmentConf.getString("dynamodb.table")
   lazy val dynamoBehaviourTable = environmentConf.getString("behaviour.dynamodb.table")
   lazy val dynamoFeatureToggleTable = environmentConf.getString("featureToggles.dynamodb.table")
+  lazy val invoiceTemplatesConf = environmentConf.getConfig(s"zuora.invoiceTemplateIds")
 
   lazy val digitalPackPlans = config.DigitalPackRatePlanIds.fromConfig(digitalPackConf)
   lazy val productIds = config.SubsV2ProductIds(environmentConf.getConfig("zuora.productIds"))
@@ -56,6 +60,7 @@ class TouchpointComponents(stage: String)(implicit system: ActorSystem) {
   lazy val auStripeService = new StripeService(tpConfig.stripeAUMembership, RequestRunners.loggingRunner(metrics("stripe")))
   lazy val allStripeServices = Seq(ukStripeService, auStripeService)
   lazy val stripeServicesByPaymentGateway: Map[PaymentGateway, StripeService] = allStripeServices.map(s => s.paymentGateway -> s).toMap
+  lazy val invoiceTemplateIdsByCountry: Map[Country, InvoiceTemplate] = InvoiceTemplates.fromConfig(invoiceTemplatesConf).map(it => (it.country, it)).toMap
 
   lazy val soapClient = new ClientWithFeatureSupplier(Set.empty, tpConfig.zuoraSoap,
     RequestRunners.loggingRunner(metrics("zuora-soap")),

--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -54,7 +54,8 @@ class TouchpointComponents(stage: String)(implicit system: ActorSystem) {
 
   lazy val ukStripeService = new StripeService(tpConfig.stripeUKMembership, RequestRunners.loggingRunner(metrics("stripe")))
   lazy val auStripeService = new StripeService(tpConfig.stripeAUMembership, RequestRunners.loggingRunner(metrics("stripe")))
-  lazy val stripeServicesByPaymentGateway: Map[PaymentGateway, StripeService] = Seq(ukStripeService, auStripeService).map(s => s.paymentGateway -> s).toMap
+  lazy val allStripeServices = Seq(ukStripeService, auStripeService)
+  lazy val stripeServicesByPaymentGateway: Map[PaymentGateway, StripeService] = allStripeServices.map(s => s.paymentGateway -> s).toMap
 
   lazy val soapClient = new ClientWithFeatureSupplier(Set.empty, tpConfig.zuoraSoap,
     RequestRunners.loggingRunner(metrics("zuora-soap")),

--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -60,6 +60,7 @@ class TouchpointComponents(stage: String)(implicit system: ActorSystem) {
   lazy val auStripeService = new StripeService(tpConfig.stripeAUMembership, RequestRunners.loggingRunner(metrics("stripe")))
   lazy val allStripeServices = Seq(ukStripeService, auStripeService)
   lazy val stripeServicesByPaymentGateway: Map[PaymentGateway, StripeService] = allStripeServices.map(s => s.paymentGateway -> s).toMap
+  lazy val stripeServicesByPublicKey: Map[String, StripeService] = allStripeServices.map(s => s.publicKey -> s).toMap
   lazy val invoiceTemplateIdsByCountry: Map[Country, InvoiceTemplate] = InvoiceTemplates.fromConfig(invoiceTemplatesConf).map(it => (it.country, it)).toMap
 
   lazy val soapClient = new ClientWithFeatureSupplier(Set.empty, tpConfig.zuoraSoap,

--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -8,6 +8,8 @@ import com.gu.memsub.subsv2.reads.ChargeListReads._
 import com.gu.memsub.subsv2.reads.SubPlanReads
 import com.gu.memsub.subsv2.reads.SubPlanReads._
 import com.gu.services.model.PaymentDetails
+import com.gu.stripe.StripeService
+import com.gu.zuora.api.RegionalStripeGateways
 import com.typesafe.scalalogging.LazyLogging
 import components.TouchpointComponents
 import configuration.Config
@@ -40,18 +42,17 @@ class AccountController extends LazyLogging {
 
     // TODO - refactor to use the Zuora-only based lookup, like in AttributeController.pickAttributes - https://trello.com/c/RlESb8jG
 
-    val updateForm = Form { single("stripeToken" -> nonEmptyText) }
+    val updateForm = Form { tuple("stripeToken" -> nonEmptyText, "publicKey" -> text) }
     val tp = request.touchpoint
     val maybeUserId = authenticationService.userId
     logger.info(s"Attempting to update card for $maybeUserId")
     (for {
-      user <- EitherT(Future.successful( maybeUserId \/> "no identity cookie for user"))
-      stripeCardToken <- EitherT(Future.successful(updateForm.bindFromRequest().value \/> "no card token submitted with request"))
+      user <- EitherT(Future.successful(maybeUserId \/> "no identity cookie for user"))
+      (stripeCardToken, stripePublicKey) <- EitherT(Future.successful(updateForm.bindFromRequest().value \/> "no card token submitted with request"))
       sfUser <- EitherT(tp.contactRepo.get(user).map(_.flatMap(_ \/> s"no SF user $user")))
       subscription <- EitherT(tp.subService.current[P](sfUser).map(_.headOption).map (_ \/> s"no current subscriptions for the sfUser $sfUser"))
-      account <- EitherT(tp.zuoraService.getAccount(subscription.accountId).map(\/.right).recover { case x => \/.left(s"error receiving account for subscription: ${subscription.name} with account id ${subscription.accountId}. Reason: $x") })
-      stripeService <- EitherT(Future.successful(account.paymentGateway.flatMap(tp.stripeServicesByPaymentGateway.get) \/> s"No Stripe service available for account: ${account.id}"))
-      updateResult <- EitherT(tp.paymentService.setPaymentCardWithStripeToken(subscription.accountId, stripeCardToken, stripeService, Some(user)).map(_ \/> "something missing when try to zuora payment card"))
+      stripeService <- EitherT(Future.successful(tp.allStripeServices.find(_.publicKey == stripePublicKey)).map(_ \/> s"No Stripe service for public key: $stripePublicKey"))
+      updateResult <- EitherT(tp.paymentService.setPaymentCardWithStripeToken(subscription.accountId, stripeCardToken, stripeService, maybeUserId).map(_ \/> "something missing when try to zuora payment card"))
     } yield updateResult match {
       case success: CardUpdateSuccess => {
         logger.info(s"Successfully updated card for identity user: $user")
@@ -69,18 +70,14 @@ class AccountController extends LazyLogging {
     }
   }
 
-  private def getUpToDatePaymentDetailsFromStripe(defaultPaymentMethodId: Option[String], paymentDetails: PaymentDetails)(implicit tp: TouchpointComponents): Future[PaymentDetails] = {
+  private def getUpToDatePaymentDetailsFromStripe(defaultPaymentMethodId: Option[String], paymentDetails: PaymentDetails, stripeService: StripeService)(implicit tp: TouchpointComponents): Future[PaymentDetails] = {
     paymentDetails.paymentMethod.map {
       case card: PaymentCard =>
         (for {
           paymentMethodId <- OptionT(Future.successful(defaultPaymentMethodId.map(_.trim).filter(_.nonEmpty)))
           zuoraPaymentMethod <- tp.zuoraService.getPaymentMethod(paymentMethodId).liftM[OptionT]
           customerId <- OptionT(Future.successful(zuoraPaymentMethod.secondTokenId.map(_.trim).filter(_.startsWith("cus_"))))
-          maybeUkStripeCustomer <- tp.ukStripeService.Customer.read(customerId).map(Option(_)).recover { case _ => None }.liftM[OptionT]
-          maybeStripeCustomer <-
-            // Performance optimisation not to go to AU Stripe if UK is one gotten above
-            if (maybeUkStripeCustomer.nonEmpty) Future.successful(maybeUkStripeCustomer).liftM[OptionT]
-            else tp.auStripeService.Customer.read(customerId).map(Option(_)).recover { case _ => None }.liftM[OptionT]
+          maybeStripeCustomer <- stripeService.Customer.read(customerId).map(Option(_)).recover { case _ => None }.liftM[OptionT]
         } yield {
           // TODO consider broadcasting to a queue somewhere iff the payment method in Zuora is out of date compared to Stripe
           card.copy(
@@ -105,11 +102,12 @@ class AccountController extends LazyLogging {
       freeOrPaidSub <- OptionEither(tp.subService.either[F, P](contact).map(_.leftMap(message => s"couldn't read sub from zuora for crmId ${contact.salesforceAccountId} due to $message")))
       details <- OptionEither.liftOption(tp.paymentService.paymentDetails(freeOrPaidSub).map(\/.right))
       sub = freeOrPaidSub.fold(identity, identity)
-      account <- OptionEither.liftOption(tp.zuoraService.getAccount(sub.accountId).map(\/.right).recover { case x => \/.left(s"error receiving account for subscription: ${sub.name} with account id ${sub.accountId}. Reason: $x") })
-      publicKey = account.paymentGateway.flatMap(tp.stripeServicesByPaymentGateway.get).map(_.publicKey)
+      account <- OptionEither.liftOption(tp.zuoraService.getAccount(sub.accountId).map(\/.right).recover { case x => \/.left(s"error retrieving account for subscription: ${sub.name} with account id ${sub.accountId}. Reason: $x") })
+      billToContact <- OptionEither.liftOption(tp.zuoraService.getContact(account.billToId).map(\/.right).recover { case x => \/.left(s"error retrieving bill to contact id (${account.billToId}) for account id ${account.id}. Reason $x")})
+      stripeService = billToContact.country.map(RegionalStripeGateways.getGatewayForCountry).flatMap(tp.stripeServicesByPaymentGateway.get).getOrElse(tp.ukStripeService)
       paymentDetails <- OptionEither.liftOption(tp.paymentService.paymentDetails(freeOrPaidSub).map(\/.right).recover { case x => \/.left(s"error retrieving payment details for subscription: ${sub.name}. Reason: $x") })
-      upToDatePaymentDetails <- OptionEither.liftOption(getUpToDatePaymentDetailsFromStripe(account.defaultPaymentMethodId, paymentDetails).map(\/.right).recover { case x => \/.left(s"error getting up-to-date details for payment method id: ${account.defaultPaymentMethodId.mkString}. Reason: $x") })
-    } yield (contact, upToDatePaymentDetails, publicKey).toResult).run.run.map {
+      upToDatePaymentDetails <- OptionEither.liftOption(getUpToDatePaymentDetailsFromStripe(account.defaultPaymentMethodId, paymentDetails, stripeService).map(\/.right).recover { case x => \/.left(s"error getting up-to-date details for payment method id: ${account.defaultPaymentMethodId.mkString}. Reason: $x") })
+    } yield (contact, upToDatePaymentDetails, stripeService.publicKey).toResult).run.run.map {
       case \/-(Some(result)) =>
         logger.info(s"Successfully retrieved payment details result for identity user: ${maybeUserId.mkString}")
         result

--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -53,7 +53,6 @@ class AccountController extends LazyLogging {
       sfUser <- EitherT(tp.contactRepo.get(user).map(_.flatMap(_ \/> s"no SF user $user")))
       subscription <- EitherT(tp.subService.current[P](sfUser).map(_.headOption).map (_ \/> s"no current subscriptions for the sfUser $sfUser"))
       stripeService <- EitherT(Future.successful(tp.allStripeServices.find(_.publicKey == stripePublicKey)).map(_ \/> s"No Stripe service for public key: $stripePublicKey"))
-      //invoiceTemplate <- invoiceTemplateIdsByCountry
       updateResult <- EitherT(tp.paymentService.setPaymentCardWithStripeToken(subscription.accountId, stripeCardToken, stripeService, maybeUserId).map(_ \/> "something missing when try to zuora payment card"))
     } yield updateResult match {
       case success: CardUpdateSuccess => {

--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -119,7 +119,7 @@ class AccountController extends LazyLogging {
       accountSummary <- OptionEither.liftOption(tp.zuoraRestService.getAccount(sub.accountId))
       stripeService = accountSummary.billToContact.country.map(RegionalStripeGateways.getGatewayForCountry).flatMap(tp.stripeServicesByPaymentGateway.get).getOrElse(tp.ukStripeService)
       paymentDetails <- OptionEither.liftOption(tp.paymentService.paymentDetails(freeOrPaidSub).map(\/.right).recover { case x => \/.left(s"error retrieving payment details for subscription: ${sub.name}. Reason: $x") })
-      upToDatePaymentDetails <- OptionEither.liftOption(getUpToDatePaymentDetailsFromStripe(accountSummary.id, paymentDetails, stripeService).map(\/.right).recover { case x => \/.left(s"error getting up-to-date details for payment method id: ${account.defaultPaymentMethodId.mkString}. Reason: $x") })
+      upToDatePaymentDetails <- OptionEither.liftOption(getUpToDatePaymentDetailsFromStripe(accountSummary.id, paymentDetails).map(\/.right).recover { case x => \/.left(s"error getting up-to-date card details for payment method of account: ${accountSummary.id}. Reason: $x") })
     } yield (contact, upToDatePaymentDetails, stripeService.publicKey).toResult).run.run.map {
       case \/-(Some(result)) =>
         logger.info(s"Successfully retrieved payment details result for identity user: ${maybeUserId.mkString}")

--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -53,6 +53,7 @@ class AccountController extends LazyLogging {
       sfUser <- EitherT(tp.contactRepo.get(user).map(_.flatMap(_ \/> s"no SF user $user")))
       subscription <- EitherT(tp.subService.current[P](sfUser).map(_.headOption).map (_ \/> s"no current subscriptions for the sfUser $sfUser"))
       stripeService <- EitherT(Future.successful(tp.allStripeServices.find(_.publicKey == stripePublicKey)).map(_ \/> s"No Stripe service for public key: $stripePublicKey"))
+      //invoiceTemplate <- invoiceTemplateIdsByCountry
       updateResult <- EitherT(tp.paymentService.setPaymentCardWithStripeToken(subscription.accountId, stripeCardToken, stripeService, maybeUserId).map(_ \/> "something missing when try to zuora payment card"))
     } yield updateResult match {
       case success: CardUpdateSuccess => {

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -6,7 +6,7 @@ import play.api.libs.json._
 import play.api.mvc.Results.Ok
 
 object AccountDetails {
-  implicit class ResultLike(details: (Contact, PaymentDetails, Option[String])) {
+  implicit class ResultLike(details: (Contact, PaymentDetails, String)) {
 
     def toResult = {
       val contact = details._1
@@ -19,7 +19,7 @@ object AccountDetails {
       Json.obj("tier" -> paymentDetails.plan.name, "isPaidTier" -> (paymentDetails.plan.price.amount > 0f)) ++
         contact.regNumber.fold(Json.obj())({m => Json.obj("regNumber" -> m)})
 
-    private def toJson(paymentDetails: PaymentDetails, stripePublicKey: Option[String]): JsObject = {
+    private def toJson(paymentDetails: PaymentDetails, stripePublicKey: String): JsObject = {
 
       val endDate = paymentDetails.chargedThroughDate
         .getOrElse(paymentDetails.termEndDate)
@@ -34,8 +34,9 @@ object AccountDetails {
           "card" -> {
             Json.obj(
               "last4" -> card.paymentCardDetails.map(_.lastFourDigits).getOrElse[String]("••••"),
-              "type" -> card.cardType.getOrElse[String]("unknown")
-            ) ++ stripePublicKey.map(k => Json.obj("stripePublicKeyForUpdate" -> k)).getOrElse(Json.obj())
+              "type" -> card.cardType.getOrElse[String]("unknown"),
+              "stripePublicKeyForUpdate" -> stripePublicKey
+            )
           }
         )
         case dd: GoCardless => Json.obj(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSNS = "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.476"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.477"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.0"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSNS = "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.468"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.471"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.0"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSNS = "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.471"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.1-SNAPSHOT"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.0"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSNS = "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.1-SNAPSHOT"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.476"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.0"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
We want customers in Australia to transition over to the new AU Stripe account both organically as they update their payment details, and upon advice from the contact centre should they phone up and complain about international bank charges.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
This change determines which Stripe account is used to generate the card token by receiving the Stripe public key back in the AJAX call from the MMA page. This means Members Data API now knows, reliably, which Stripe account to create the Customer object in. It also lets us save a call to retrieve the account object.

### Depends on: ###
https://github.com/guardian/frontend/pull/18089 and https://github.com/guardian/membership-common/pull/543

### Tested in code ###
Test script: 
1) Create a new UK Supporter in CODE
2) Change Billing Country to AU in Zuora. Do card update. 
3) Change Billing country to UK in Zuora. Do card update.

### Screenshots ###
Before:
<img width="775" alt="picture 225" src="https://user-images.githubusercontent.com/1515970/32561513-4e4eff98-c4a4-11e7-90f1-4c09475a628e.png">

After:

<img width="859" alt="picture 226" src="https://user-images.githubusercontent.com/1515970/32561526-52c18ea6-c4a4-11e7-82ac-9860614a2eef.png">

cc @jacobwinch @johnduffell 

