### PR TITLE
Adds mma-paper endpoint to allow paper subscribers to update their card details

### DIFF
--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -124,11 +124,13 @@ class AccountController extends LazyLogging {
 
   def membershipUpdateCard = updateCard[SubscriptionPlan.PaidMember]
   def digitalPackUpdateCard = updateCard[SubscriptionPlan.Digipack]
+  def paperUpdateCard = updateCard[SubscriptionPlan.PaperPlan]
   def contributionUpdateCard = updateCard[SubscriptionPlan.Contributor]
 
   def membershipDetails = paymentDetails[SubscriptionPlan.PaidMember, SubscriptionPlan.FreeMember]
   def monthlyContributionDetails = paymentDetails[SubscriptionPlan.Contributor, Nothing]
   def digitalPackDetails = paymentDetails[SubscriptionPlan.Digipack, Nothing]
+  def paperDetails = paymentDetails[SubscriptionPlan.PaperPlan, Nothing]
 }
 
 // this is helping us stack future/either/option

--- a/membership-attribute-service/conf/DEV.public.conf
+++ b/membership-attribute-service/conf/DEV.public.conf
@@ -31,7 +31,8 @@ authentication {
 
 mma.cors.allowedOrigins = [
   "https://profile.code.dev-theguardian.com",
-  "https://profile.thegulocal.com"
+  "https://profile.thegulocal.com",
+  "https://sub.thegulocal.com"
 ]
 
 ft.cors.allowedOrigins = [

--- a/membership-attribute-service/conf/PROD.public.conf
+++ b/membership-attribute-service/conf/PROD.public.conf
@@ -24,6 +24,7 @@ mma.cors.allowedOrigins = [
   "https://profile.thegulocal.com",
   "https://profile.theguardian.com",
   "https://profile.code.dev-theguardian.com",
+  "https://subscribe.theguardian.com",
 ]
 
 ft.cors.allowedOrigins = [

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -7,12 +7,16 @@ GET        /user-attributes/me/features                     controllers.Attribut
 GET        /user-attributes/me/mma-digitalpack              controllers.AccountController.digitalPackDetails
 GET        /user-attributes/me/mma-membership               controllers.AccountController.membershipDetails
 GET        /user-attributes/me/mma-monthlycontribution      controllers.AccountController.monthlyContributionDetails
+GET        /user-attributes/me/mma-paper                    controllers.AccountController.paperDetails
 
 POST       /user-attributes/me/membership-update-card       controllers.AccountController.membershipUpdateCard
 OPTIONS    /user-attributes/me/membership-update-card       controllers.AccountController.membershipUpdateCard
 
 POST       /user-attributes/me/digitalpack-update-card      controllers.AccountController.digitalPackUpdateCard
 OPTIONS    /user-attributes/me/digitalpack-update-card      controllers.AccountController.digitalPackUpdateCard
+
+POST       /user-attributes/me/paper-update-card      controllers.AccountController.paperUpdateCard
+OPTIONS    /user-attributes/me/paper-update-card      controllers.AccountController.paperUpdateCard
 
 POST       /user-attributes/me/contribution-update-card      controllers.AccountController.contributionUpdateCard
 OPTIONS    /user-attributes/me/contribution-update-card      controllers.AccountController.contributionUpdateCard


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
This allows paper subscribers to change their cards*. 
*(Accompanying subs-frontend and frontend prs incomong)
### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
Uses existing types on the mma methods.
### trello card/screenshot/json/related PRs etc
