### PR TITLE
Added cancel my account functionality

### DIFF
--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -59,7 +59,7 @@ class AccountController extends Controller with LazyLogging {
       case -\/(message) =>
         logger.warn(s"Failed to update card for user $maybeUserId, due to $message")
         NotFound()//notFound
-      case \/-(result) => Ok("todo")
+      case \/-(result) => Ok("Subscription cancelled correctly")
     }
 
   }

--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -41,7 +41,7 @@ class AccountController extends Controller with LazyLogging {
   lazy val mmaCardAction = NoCacheAction andThen corsCardFilter andThen BackendFromCookieAction
 
 
-  def cancelAccount [P <: SubscriptionPlan.AnyPlan : SubPlanReads] = mmaCardAction.async { implicit request =>
+  def cancelContribution [P <: SubscriptionPlan.AnyPlan : SubPlanReads] = mmaCardAction.async { implicit request =>
     val tp = request.touchpoint
     val cancelForm = Form { single("reason" -> nonEmptyText) }
 
@@ -161,7 +161,7 @@ class AccountController extends Controller with LazyLogging {
     }
   }
 
-  def contributionCancelAccount = cancelAccount[SubscriptionPlan.Contributor]
+  def cancelRegularContribution = cancelContribution[SubscriptionPlan.Contributor]
 
   def membershipUpdateCard = updateCard[SubscriptionPlan.PaidMember]
   def digitalPackUpdateCard = updateCard[SubscriptionPlan.Digipack]

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -21,8 +21,8 @@ OPTIONS    /user-attributes/me/paper-update-card      controllers.AccountControl
 POST       /user-attributes/me/contribution-update-card      controllers.AccountController.contributionUpdateCard
 OPTIONS    /user-attributes/me/contribution-update-card      controllers.AccountController.contributionUpdateCard
 
-POST       /user-attributes/me/cancel-account                controllers.AccountController.contributionCancelAccount
-OPTIONS    /user-attributes/me/cancel-account                controllers.AccountController.contributionCancelAccount
+POST       /user-attributes/me/cancel-regular-contribution   controllers.AccountController.contributionCancelAccount
+OPTIONS    /user-attributes/me/cancel-regular-contribution   controllers.AccountController.contributionCancelAccount
 
 POST       /user-behaviour/capture                          controllers.BehaviourController.capture
 POST       /user-behaviour/remove                           controllers.BehaviourController.remove

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -21,8 +21,8 @@ OPTIONS    /user-attributes/me/paper-update-card      controllers.AccountControl
 POST       /user-attributes/me/contribution-update-card      controllers.AccountController.contributionUpdateCard
 OPTIONS    /user-attributes/me/contribution-update-card      controllers.AccountController.contributionUpdateCard
 
-POST       /user-attributes/me/cancel-regular-contribution   controllers.AccountController.contributionCancelAccount
-OPTIONS    /user-attributes/me/cancel-regular-contribution   controllers.AccountController.contributionCancelAccount
+POST       /user-attributes/me/cancel-regular-contribution   controllers.AccountController.cancelRegularContribution
+OPTIONS    /user-attributes/me/cancel-regular-contribution   controllers.AccountController.cancelRegularContribution
 
 POST       /user-behaviour/capture                          controllers.BehaviourController.capture
 POST       /user-behaviour/remove                           controllers.BehaviourController.remove

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -21,6 +21,9 @@ OPTIONS    /user-attributes/me/paper-update-card      controllers.AccountControl
 POST       /user-attributes/me/contribution-update-card      controllers.AccountController.contributionUpdateCard
 OPTIONS    /user-attributes/me/contribution-update-card      controllers.AccountController.contributionUpdateCard
 
+POST       /user-attributes/me/cancel-account                controllers.AccountController.contributionCancelAccount
+OPTIONS    /user-attributes/me/cancel-account                controllers.AccountController.contributionCancelAccount
+
 POST       /user-behaviour/capture                          controllers.BehaviourController.capture
 POST       /user-behaviour/remove                           controllers.BehaviourController.remove
 POST       /abandoned-cart/email                            controllers.BehaviourController.sendCartReminderEmail

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSNS = "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.478"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.483"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.0"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"


### PR DESCRIPTION
### Why do we need this? 
We need to provide to our user a way of cancelling their account. This PR adds a new endpoint to the API which will:

* Disable Autopay
* Cancel contributor subscription
* Update Reason for cancelling

The new url is:

`[POST] /user-attributes/me/cancel-regular-contribution`

