### PR TITLE
Fix card update 403

### DIFF
--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -16,6 +16,7 @@ import configuration.Config
 import json.PaymentCardUpdateResultWriters._
 import models.AccountDetails._
 import models.ApiErrors._
+import play.api.mvc.Controller
 import play.api.data.Form
 import play.api.data.Forms._
 import play.api.http.DefaultHttpErrorHandler
@@ -31,7 +32,7 @@ import scalaz.syntax.std.option._
 import scalaz.syntax.traverse._
 import scalaz.{-\/, EitherT, OptionT, \/, \/-, _}
 
-class AccountController extends LazyLogging {
+class AccountController extends Controller with LazyLogging {
 
   lazy val authenticationService: AuthenticationService = IdentityAuthService
   lazy val corsCardFilter = CORSActionBuilder(Config.mmaCardCorsConfig, DefaultHttpErrorHandler)

--- a/membership-attribute-service/conf/application.conf
+++ b/membership-attribute-service/conf/application.conf
@@ -20,6 +20,6 @@ logger.application=INFO
 # These users are the only ones who can potentially get a positive adfree response until the system is deemed stable
 identity.prerelease-users = []
 
-play.filters.csrf.contentType.blackList = ["application/x-www-form-urlencoded", "multipart/form-data", "text/plain"]
+play.filters.csrf.contentType.blackList = ["multipart/form-data", "text/plain"]
 
 include file("/etc/gu/members-data-api.private.conf")

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -9,6 +9,7 @@ GET        /user-attributes/me/mma-membership               controllers.AccountC
 GET        /user-attributes/me/mma-monthlycontribution      controllers.AccountController.monthlyContributionDetails
 GET        /user-attributes/me/mma-paper                    controllers.AccountController.paperDetails
 
+#NOCSRF
 POST       /user-attributes/me/membership-update-card       controllers.AccountController.membershipUpdateCard
 OPTIONS    /user-attributes/me/membership-update-card       controllers.AccountController.membershipUpdateCard
 

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -9,7 +9,6 @@ GET        /user-attributes/me/mma-membership               controllers.AccountC
 GET        /user-attributes/me/mma-monthlycontribution      controllers.AccountController.monthlyContributionDetails
 GET        /user-attributes/me/mma-paper                    controllers.AccountController.paperDetails
 
-#NOCSRF
 POST       /user-attributes/me/membership-update-card       controllers.AccountController.membershipUpdateCard
 OPTIONS    /user-attributes/me/membership-update-card       controllers.AccountController.membershipUpdateCard
 


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
Fix an issue where card updates would not work

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
- Remove "application/x-www-form-urlencoded" from the CSRF blacklist - it is used for card update.
- Added that AccountController extends Controller just to be consistent with all the others!

### trello card/screenshot/json/related PRs etc
Many User Help queries.

cc @svillafe @rupertbates 