### PR TITLE
Remove multipart from csrf blacklist.

### DIFF
--- a/membership-attribute-service/conf/application.conf
+++ b/membership-attribute-service/conf/application.conf
@@ -20,6 +20,6 @@ logger.application=INFO
 # These users are the only ones who can potentially get a positive adfree response until the system is deemed stable
 identity.prerelease-users = []
 
-play.filters.csrf.contentType.blackList = ["multipart/form-data", "text/plain"]
+play.filters.csrf.contentType.blackList = ["text/plain"]
 
 include file("/etc/gu/members-data-api.private.conf")


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
This blacklisting breaks the subs manage page.
### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->

### trello card/screenshot/json/related PRs etc
