### PR TITLE
Set a name in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 import Dependencies._
 
 val appVersion = "1.0-SNAPSHOT"
+name := "members-data-api"
 
 def buildInfoSettings = Seq(
   buildInfoKeys := Seq[BuildInfoKey](


### PR DESCRIPTION
So that the project shows up in IntelliJ as members-data-api rather than root.

This is particularly needed in the 'Open Recent' menu where otherwise it is hard to distinguish between this project and any number of other projects with the name 'root' 
