### PR TITLE
Remove zuora healthcheck

### DIFF
--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -7,7 +7,6 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
 import scalaz.std.scalaFuture._
 import com.gu.config
 import com.gu.i18n.Country
-import com.gu.zuora.api.InvoiceTemplate
 import com.gu.memsub.services.PaymentService
 import com.gu.memsub.subsv2.services.SubscriptionService.CatalogMap
 import com.gu.memsub.subsv2.services._
@@ -67,10 +66,11 @@ class TouchpointComponents(stage: String)(implicit system: ActorSystem) {
     RequestRunners.loggingRunner(metrics("zuora-soap")),
     RequestRunners.loggingRunner(metrics("zuora-soap"))
   )
-  lazy val contactRepo = new SimpleContactRepository(tpConfig.salesforce, system.scheduler, Config.applicationName)
+  lazy val contactRepo: SimpleContactRepository = new SimpleContactRepository(tpConfig.salesforce, system.scheduler, Config.applicationName)
+  lazy val salesforceService: SalesforceService = new SalesforceService(contactRepo)
   lazy val attrService: AttributeService = new ScanamoAttributeService(new AmazonDynamoDBAsyncClient(com.gu.aws.CredentialsProvider).withRegion(Regions.EU_WEST_1), dynamoAttributesTable)
   lazy val behaviourService: BehaviourService = new ScanamoBehaviourService(new AmazonDynamoDBAsyncClient(com.gu.aws.CredentialsProvider).withRegion(Regions.EU_WEST_1), dynamoBehaviourTable)
-  lazy val featureToggleService: ScanamoFeatureToggleService = new ScanamoFeatureToggleService(new AmazonDynamoDBAsyncClient(com.gu.aws.CredentialsProvider).withRegion(Regions.EU_WEST_1), dynamoFeatureToggleTable)
+  lazy val featureToggleService: FeatureToggleService = new ScanamoFeatureToggleService(new AmazonDynamoDBAsyncClient(com.gu.aws.CredentialsProvider).withRegion(Regions.EU_WEST_1), dynamoFeatureToggleTable)
   lazy val zuoraService = new ZuoraService(soapClient)
   implicit lazy val simpleClient = new SimpleClient[Future](tpConfig.zuoraRest, ZuoraRequestCounter.withZuoraRequestCounter(RequestRunners.futureRunner))
   lazy val patientSimpleClient = new SimpleClient[Future](tpConfig.zuoraRest, ZuoraRequestCounter.withZuoraRequestCounter(RequestRunners.configurableFutureRunner(30 seconds)))

--- a/membership-attribute-service/app/controllers/HealthCheckController.scala
+++ b/membership-attribute-service/app/controllers/HealthCheckController.scala
@@ -33,7 +33,7 @@ class HealthCheckController extends Results with LazyLogging {
       }
   }
 
-  private lazy val services = Set(wrappedZuoraService, salesforceService, featureToggleService, attrService)
+  private lazy val services = Set(wrappedZuoraService, salesforceService, featureToggleService, attrService, behaviourService)
 
   private lazy val tests = services.map(service => new BoolTest(service.serviceName, () => service.checkHealth))
 

--- a/membership-attribute-service/app/controllers/HealthCheckController.scala
+++ b/membership-attribute-service/app/controllers/HealthCheckController.scala
@@ -3,9 +3,7 @@ package controllers
 import play.api.libs.json.Json
 import play.api.mvc.{Action, Results}
 import components.NormalTouchpointComponents._
-import com.github.nscala_time.time.Imports._
-import com.typesafe.scalalogging.LazyLogging
-import services.HealthCheckableService
+import com.typesafe.scalalogging.StrictLogging
 
 trait Test {
   def ok: Boolean
@@ -17,23 +15,10 @@ class BoolTest(name: String, exec: () => Boolean) extends Test {
   override def ok = exec()
 }
 
-class HealthCheckController extends Results with LazyLogging {
+class HealthCheckController extends Results with StrictLogging {
 
-  private lazy val wrappedZuoraService = new HealthCheckableService {
-    private val duration = 2.minutes
-    override def serviceName = "ZuoraService"
-    override def checkHealth: Boolean =
-      if (zuoraService.lastPingTimeWithin(duration)) {
-        true
-      } else {
-        logger.error(s"${this.serviceName} has not responded within the last ${duration.getMinutes} minutes.")
-        // Return true rather than false, because we don't want Zuora to fail the healthcheck.
-        // However we do want to log outages because we have an SLA from Zuora where we can claim compensation.
-        true
-      }
-  }
-
-  private lazy val services = Set(wrappedZuoraService, salesforceService, featureToggleService, attrService, behaviourService)
+  // behaviourService, Stripe and all Zuora services are not critical
+  private lazy val services = Set(salesforceService, featureToggleService, attrService)
 
   private lazy val tests = services.map(service => new BoolTest(service.serviceName, () => service.checkHealth))
 
@@ -44,7 +29,7 @@ class HealthCheckController extends Results with LazyLogging {
       if (failures.isEmpty) {
         Ok(Json.obj("status" -> "ok", "gitCommitId" -> app.BuildInfo.gitCommitId))
       } else {
-        failures.flatMap(_.messages).foreach(msg => logger.error(msg))
+        failures.flatMap(_.messages).foreach(msg => logger.warn(msg))
         ServiceUnavailable("Service Unavailable")
       }
     }

--- a/membership-attribute-service/app/prodtest/FeatureToggleDataUpdatedOnSchedule.scala
+++ b/membership-attribute-service/app/prodtest/FeatureToggleDataUpdatedOnSchedule.scala
@@ -4,13 +4,13 @@ import akka.actor.ActorSystem
 import com.gu.memsub.util.ScheduledTask
 import com.typesafe.scalalogging.LazyLogging
 import models.ZuoraLookupFeatureData
-import services.ScanamoFeatureToggleService
+import services.FeatureToggleService
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.DurationInt
 import scalaz.{-\/, \/-}
 
-class FeatureToggleDataUpdatedOnSchedule(featureToggleService: ScanamoFeatureToggleService, stage: String)(implicit ec: ExecutionContext, system: ActorSystem) extends LazyLogging {
+class FeatureToggleDataUpdatedOnSchedule(featureToggleService: FeatureToggleService, stage: String)(implicit ec: ExecutionContext, system: ActorSystem) extends LazyLogging {
 
   private val updateZuoraLookupFeatureDataTask: ScheduledTask[ZuoraLookupFeatureData] = {
     val featureName = "AttributesFromZuoraLookup"

--- a/membership-attribute-service/app/services/AttributeService.scala
+++ b/membership-attribute-service/app/services/AttributeService.scala
@@ -1,12 +1,12 @@
 package services
 
-import com.amazonaws.services.dynamodbv2.model.{DeleteItemResult, PutItemResult, UpdateItemResult}
+import com.amazonaws.services.dynamodbv2.model.{DeleteItemResult, PutItemResult}
 import com.gu.scanamo.error.DynamoReadError
 import models.Attributes
 
 import scala.concurrent.Future
 
-trait AttributeService {
+trait AttributeService extends HealthCheckableService {
   def get(userId: String): Future[Option[Attributes]]
   def getMany(userIds: List[String]): Future[Seq[Attributes]]
   def delete(userId: String): Future[DeleteItemResult]

--- a/membership-attribute-service/app/services/BehaviourService.scala
+++ b/membership-attribute-service/app/services/BehaviourService.scala
@@ -5,7 +5,7 @@ import models.Behaviour
 
 import scala.concurrent.Future
 
-trait BehaviourService {
+trait BehaviourService extends HealthCheckableService {
   def get(userId: String): Future[Option[Behaviour]]
   def set(behaviour: Behaviour): Future[PutItemResult]
   def delete(userId: String): Future[DeleteItemResult]

--- a/membership-attribute-service/app/services/FeatureToggleService.scala
+++ b/membership-attribute-service/app/services/FeatureToggleService.scala
@@ -1,0 +1,10 @@
+package services
+
+import models.FeatureToggle
+
+import scala.concurrent.Future
+import scalaz.\/
+
+trait FeatureToggleService extends HealthCheckableService {
+  def get(featureName: String): Future[\/[String, FeatureToggle]]
+}

--- a/membership-attribute-service/app/services/HealthCheckableService.scala
+++ b/membership-attribute-service/app/services/HealthCheckableService.scala
@@ -1,0 +1,6 @@
+package services
+
+trait HealthCheckableService {
+  def serviceName: String = this.getClass.getSimpleName
+  def checkHealth: Boolean
+}

--- a/membership-attribute-service/app/services/SalesforceService.scala
+++ b/membership-attribute-service/app/services/SalesforceService.scala
@@ -1,0 +1,7 @@
+package services
+
+import com.gu.salesforce.ContactRepository
+
+class SalesforceService(contactRepository: ContactRepository) extends HealthCheckableService {
+  override def checkHealth: Boolean = contactRepository.salesforce.isAuthenticated
+}

--- a/membership-attribute-service/app/services/ScanamoAttributeService.scala
+++ b/membership-attribute-service/app/services/ScanamoAttributeService.scala
@@ -16,7 +16,7 @@ import scala.concurrent.Future
 class ScanamoAttributeService(client: AmazonDynamoDBAsync, table: String)
     extends AttributeService with LazyLogging {
 
-  def checkHealth: Boolean = client.listTables(table).getTableNames.contains(table)
+  def checkHealth: Boolean = client.describeTable(table).getTable.getTableStatus == "ACTIVE"
 
   implicit val jodaStringFormat = DynamoFormat.coercedXmap[LocalDate, String, IllegalArgumentException](
     LocalDate.parse(_)

--- a/membership-attribute-service/app/services/ScanamoAttributeService.scala
+++ b/membership-attribute-service/app/services/ScanamoAttributeService.scala
@@ -1,6 +1,6 @@
 package services
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
 import com.amazonaws.services.dynamodbv2.model.{DeleteItemResult, PutItemResult}
 import com.gu.scanamo._
 import com.gu.scanamo.error.{DynamoReadError, MissingProperty}
@@ -13,8 +13,10 @@ import play.api.libs.concurrent.Execution.Implicits._
 
 import scala.concurrent.Future
 
-class ScanamoAttributeService(client: AmazonDynamoDBAsyncClient, table: String)
+class ScanamoAttributeService(client: AmazonDynamoDBAsync, table: String)
     extends AttributeService with LazyLogging {
+
+  def checkHealth: Boolean = client.listTables(table).getTableNames.contains(table)
 
   implicit val jodaStringFormat = DynamoFormat.coercedXmap[LocalDate, String, IllegalArgumentException](
     LocalDate.parse(_)

--- a/membership-attribute-service/app/services/ScanamoBehaviourService.scala
+++ b/membership-attribute-service/app/services/ScanamoBehaviourService.scala
@@ -12,6 +12,8 @@ import scala.concurrent.Future
 
 class ScanamoBehaviourService(client: AmazonDynamoDBAsync, table: String) extends BehaviourService with LazyLogging {
 
+  def checkHealth: Boolean = client.describeTable(table).getTable.getTableStatus == "ACTIVE"
+
   val scanamo = Table[Behaviour](table)
   def run[T] = ScanamoAsync.exec[T](client) _
 

--- a/membership-attribute-service/app/services/ScanamoBehaviourService.scala
+++ b/membership-attribute-service/app/services/ScanamoBehaviourService.scala
@@ -1,15 +1,16 @@
 package services
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
 import com.amazonaws.services.dynamodbv2.model.{DeleteItemResult, PutItemResult}
 import com.gu.scanamo.syntax._
 import com.gu.scanamo.{ScanamoAsync, Table}
 import com.typesafe.scalalogging.LazyLogging
 import models.Behaviour
 import play.api.libs.concurrent.Execution.Implicits._
+
 import scala.concurrent.Future
 
-class ScanamoBehaviourService(client: AmazonDynamoDBAsyncClient, table: String) extends BehaviourService with LazyLogging {
+class ScanamoBehaviourService(client: AmazonDynamoDBAsync, table: String) extends BehaviourService with LazyLogging {
 
   val scanamo = Table[Behaviour](table)
   def run[T] = ScanamoAsync.exec[T](client) _

--- a/membership-attribute-service/app/services/ScanamoFeatureToggleService.scala
+++ b/membership-attribute-service/app/services/ScanamoFeatureToggleService.scala
@@ -1,6 +1,6 @@
 package services
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
 import com.gu.scanamo._
 import com.gu.scanamo.error.DynamoReadError
 import com.gu.scanamo.syntax.{set => scanamoSet, _}
@@ -13,7 +13,9 @@ import scalaz.\/
 import scalaz.syntax.std.either._
 import scalaz.syntax.std.option._
 
-class ScanamoFeatureToggleService(client: AmazonDynamoDBAsyncClient, table: String) extends LazyLogging {
+class ScanamoFeatureToggleService(client: AmazonDynamoDBAsync, table: String) extends FeatureToggleService with LazyLogging {
+
+  def checkHealth: Boolean = client.listTables(table).getTableNames.contains(table)
 
   private val scanamo = Table[FeatureToggle](table)
   def run[T] = ScanamoAsync.exec[T](client) _

--- a/membership-attribute-service/app/services/ScanamoFeatureToggleService.scala
+++ b/membership-attribute-service/app/services/ScanamoFeatureToggleService.scala
@@ -15,7 +15,7 @@ import scalaz.syntax.std.option._
 
 class ScanamoFeatureToggleService(client: AmazonDynamoDBAsync, table: String) extends FeatureToggleService with LazyLogging {
 
-  def checkHealth: Boolean = client.listTables(table).getTableNames.contains(table)
+  def checkHealth: Boolean = client.describeTable(table).getTable.getTableStatus == "ACTIVE"
 
   private val scanamo = Table[FeatureToggle](table)
   def run[T] = ScanamoAsync.exec[T](client) _

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -53,6 +53,7 @@ class AttributeControllerTest extends Specification with AfterAll {
   private object FakeWithBackendAction extends ActionRefiner[Request, BackendRequest] {
     override protected def refine[A](request: Request[A]): Future[Either[Result, BackendRequest[A]]] = {
       val a = new AttributeService {
+        override def checkHealth: Boolean = ???
         override def set(attributes: Attributes) = ???
         override def get(userId: String) = Future { if (userId == validUserId ) Some(attributes) else None }
         override def delete(userId: String) = ???


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
[Retrospective action](https://docs.google.com/document/d/1GYqi3VrfogEmODi2vh86WU6xRi8uP82IrI0W3FfHzqo/edit#heading=h.bx4ztaqu25hd): Zuora outages should only degrade certain services not take down this app. Its critical function now has a backup cache in Dynamo which kicks in if it can't talk to Zuora.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
- Stopped a failing Zuora health check from taking Members Data API out of service, instead it just logs the failure, so we can track it. I'll raise another PR to add/change this to a CloudWatch Metric.
- Refactored how the health is checked on Service classes, applying a HealthCheckableService trait and overriding the checkHealth on each concrete class.
- Added healthchecks for the 3 Dynamo DB services and created a new SalesforceService wrapper of the SimpleContactRepository so that the HealthCheckController can be generalised.

### trello card/screenshot/json/related PRs etc
https://trello.com/c/VEHrvjkj

cc @jacobwinch @johnduffell @davidfurey @joelochlann 