### PR TITLE
The new healthcheck requires DescribeTable permissions

### DIFF
--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -128,6 +128,7 @@ Resources:
             - dynamodb:UpdateItem
             - dynamodb:DeleteItem
             - dynamodb:BatchGetItem
+            - dynamodb:DescribeTable
             Resource:
               Fn::FindInMap: [ StageVariables, { Ref: Stage }, DynamoDBTable ]
             Effect: Allow
@@ -137,6 +138,7 @@ Resources:
             - dynamodb:UpdateItem
             - dynamodb:DeleteItem
             - dynamodb:BatchGetItem
+            - dynamodb:DescribeTable
             Resource:
               Fn::FindInMap: [ StageVariables, { Ref: Stage }, DynamoDBTableTestUsers ]
             Effect: Allow
@@ -146,6 +148,7 @@ Resources:
             - dynamodb:UpdateItem
             - dynamodb:DeleteItem
             - dynamodb:BatchGetItem
+            - dynamodb:DescribeTable
             Resource:
               Fn::FindInMap: [ StageVariables, { Ref: Stage }, DynamoDBBehaviourTable ]
             Effect: Allow
@@ -155,16 +158,19 @@ Resources:
             - dynamodb:UpdateItem
             - dynamodb:DeleteItem
             - dynamodb:BatchGetItem
+            - dynamodb:DescribeTable
             Resource:
               Fn::FindInMap: [ StageVariables, { Ref: Stage }, DynamoDBBehaviourTableTestUsers ]
             Effect: Allow
           - Action:
             - dynamodb:GetItem
+            - dynamodb:DescribeTable
             Resource:
               Fn::FindInMap: [ StageVariables, { Ref: Stage }, DynamoDBFeatureToggleTable ]
             Effect: Allow
           - Action:
             - dynamodb:GetItem
+            - dynamodb:DescribeTable
             Resource:
               Fn::FindInMap: [ StageVariables, { Ref: Stage }, DynamoDBFeatureToggleTableTestUsers ]
             Effect: Allow


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
The new healthcheck requires DescribeTable permissions.

This should allow https://github.com/guardian/members-data-api/pull/269 to be released.

cc @jacobwinch 
