### PR TITLE
Remove shared ssh key access

### DIFF
--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -1,9 +1,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: Membership Attributes service
 Parameters:
-  KeyName:
-    Description: The EC2 Key Pair to allow SSH access to the instances
-    Type: AWS::EC2::KeyPair::KeyName
   Stage:
     Description: Environment name
     Type: String
@@ -261,8 +258,6 @@ Resources:
   LaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
-      KeyName:
-        Ref: KeyName
       ImageId:
         Ref: AmiId
       SecurityGroups:


### PR DESCRIPTION
### Why do we need this? 
GDPR work - we now get ssh keys as part of the [amigo bake](https://amigo.gutools.co.uk/roles#s3-ssh-keys).

### The changes 
* Remove shared ssh key access from Cloudformation.

### trello card/screenshot/json/related PRs etc
As per: https://github.com/guardian/membership-frontend/pull/1739