### PR TITLE
Tighten up logging permissions and set a retention policy

### DIFF
--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -115,11 +115,6 @@ Resources:
             Resource: "*"
             Effect: Allow
           - Action:
-            - logs:*
-            Resource:
-            - arn:aws:logs:*:*:*
-            Effect: Allow
-          - Action:
             - dynamodb:PutItem
             - dynamodb:GetItem
             - dynamodb:UpdateItem
@@ -172,13 +167,13 @@ Resources:
               Fn::FindInMap: [ StageVariables, { Ref: Stage }, DynamoDBFeatureToggleTableTestUsers ]
             Effect: Allow
           - Action:
-            - cloudwatch:PutMetricData
+            - cloudwatch:*
             Resource: "*"
             Effect: Allow
           - Action:
             - logs:CreateLogStream
             - logs:PutLogEvents
-            Resource: !Ref MembersDataApiLogGroup
+            Resource: !GetAtt MembersDataApiLogGroup
             Effect: Allow
       ManagedPolicyArns:
       - !Ref 'LoggingPolicy'
@@ -336,7 +331,7 @@ Resources:
     Type: "AWS::Logs::LogGroup"
     Properties:
       LogGroupName: !Sub members-data-api-${Stage}
-      RetentionInDays: 14
+      RetentionInDays: 26
 Outputs:
   LoadBalancerUrl:
     Value:

--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -172,9 +172,13 @@ Resources:
               Fn::FindInMap: [ StageVariables, { Ref: Stage }, DynamoDBFeatureToggleTableTestUsers ]
             Effect: Allow
           - Action:
-            - cloudwatch:*
-            - logs:*
+            - cloudwatch:PutMetricData
             Resource: "*"
+            Effect: Allow
+          - Action:
+            - logs:CreateLogStream
+            - logs:PutLogEvents
+            Resource: !Ref MembersDataApiLogGroup
             Effect: Allow
       ManagedPolicyArns:
       - !Ref 'LoggingPolicy'
@@ -328,6 +332,11 @@ Resources:
         FromPort: '443'
         ToPort: '443'
         CidrIp: 0.0.0.0/0
+  MembersDataApiLogGroup:
+    Type: "AWS::Logs::LogGroup"
+    Properties:
+      LogGroupName: !Sub members-data-api-${Stage}
+      RetentionInDays: 14
 Outputs:
   LoadBalancerUrl:
     Value:

--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -331,7 +331,7 @@ Resources:
     Type: "AWS::Logs::LogGroup"
     Properties:
       LogGroupName: !Sub members-data-api-${Stage}
-      RetentionInDays: 26
+      RetentionInDays: 30
 Outputs:
   LoadBalancerUrl:
     Value:

--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -173,7 +173,7 @@ Resources:
           - Action:
             - logs:CreateLogStream
             - logs:PutLogEvents
-            Resource: !GetAtt MembersDataApiLogGroup
+            Resource: !GetAtt MembersDataApiLogGroup.Arn
             Effect: Allow
       ManagedPolicyArns:
       - !Ref 'LoggingPolicy'

--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -171,6 +171,7 @@ Resources:
             Resource: "*"
             Effect: Allow
           - Action:
+            - logs:CreateLogGroup
             - logs:CreateLogStream
             - logs:PutLogEvents
             Resource: !GetAtt MembersDataApiLogGroup.Arn

--- a/membership-attribute-service/conf/logger.conf
+++ b/membership-attribute-service/conf/logger.conf
@@ -3,6 +3,6 @@ state_file = /var/awslogs/agent-state
 
 [membership-attribute-service]
 file = /var/log/membership-attribute-service/membership-attribute-service.log
-log_group_name = MembershipAttributeService-__STAGE
+log_group_name = members-data-api-__STAGE
 log_stream_name = __DATE/{instance_id}/membership-attribute-service.log
 datetime_format = %Y-%m-%d %H:%M-%S


### PR DESCRIPTION
### Why do we need this? 
GDPR

### The changes 
* New log group name
* Add the new log group to Cloudformation
* Remove duplicate logging permissions
* Restrict allowed actions (full list is [here](http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/permissions-reference-cwl.html))
* Restrict creation of log streams and put log events to the new, Cloudformed log group, so that we don't accidentally log events to a group without a retention policy.