### PR TITLE
Use 14 day retention limit

### DIFF
--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -332,7 +332,7 @@ Resources:
     Type: "AWS::Logs::LogGroup"
     Properties:
       LogGroupName: !Sub members-data-api-${Stage}
-      RetentionInDays: 30
+      RetentionInDays: 14
 Outputs:
   LoadBalancerUrl:
     Value:


### PR DESCRIPTION
### Why do we need this? 
Due to the comments on https://github.com/guardian/members-data-api/pull/275, I've decided to use a 14 day retention limit for this log group. Since we are currently keeping logs in Kibana for a longer period anyway, we can use this as an opportunity to evaluate whether this is too short to be practical, without losing the ability to debug issues.

### The changes 
* Use 14 day retention policy.

### trello card/screenshot/json/related PRs etc
https://github.com/guardian/members-data-api/pull/275