### PR TITLE
Add monitoring to ensure that Dynamo TTL cleanup keeps working in PROD

### DIFF
--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -88,6 +88,9 @@ Mappings:
       DynamoDBFeatureToggleTable: arn:aws:dynamodb:*:*:table/MembershipFeatureToggles-DEV
       DynamoDBFeatureToggleTableTestUsers: arn:aws:dynamodb:*:*:table/MembershipFeatureToggles-UAT
 
+Conditions:
+  CreateProdMonitoring: !Equals [ !Ref Stage, PROD ]
+
 Resources:
   MembershipRole:
     Type: AWS::IAM::Role
@@ -333,6 +336,25 @@ Resources:
     Properties:
       LogGroupName: !Sub members-data-api-${Stage}
       RetentionInDays: 14
+  ExpiredTtlAlarm:
+        Type: AWS::CloudWatch::Alarm
+        Condition: CreateProdMonitoring
+        Properties:
+          AlarmActions:
+          - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:subscriptions_dev
+          AlarmName: !Sub Item with expired TTL found in MembershipAttributes-${Stage} Table
+          ComparisonOperator: GreaterThanThreshold
+          Dimensions:
+            - Name: Services
+              Value: ScanamoAttributeService
+            - Name: Stage
+              Value: !Sub ${Stage}
+          EvaluationPeriods: 1
+          MetricName: Old Dynamo Item
+          Namespace: members-data-api
+          Period: 60
+          Statistic: Sum
+          Threshold: 1
 Outputs:
   LoadBalancerUrl:
     Value:

--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -343,7 +343,7 @@ Resources:
           AlarmActions:
           - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:subscriptions_dev
           AlarmName: !Sub Item with expired TTL found in MembershipAttributes-${Stage} Table
-          ComparisonOperator: GreaterThanThreshold
+          ComparisonOperator: GreaterThanOrEqualToThreshold
           Dimensions:
             - Name: Services
               Value: ScanamoAttributeService

--- a/membership-attribute-service/app/services/AttributeService.scala
+++ b/membership-attribute-service/app/services/AttributeService.scala
@@ -3,6 +3,7 @@ package services
 import com.amazonaws.services.dynamodbv2.model.{DeleteItemResult, PutItemResult}
 import com.gu.scanamo.error.DynamoReadError
 import models.Attributes
+import org.joda.time.LocalDate
 
 import scala.concurrent.Future
 
@@ -11,5 +12,6 @@ trait AttributeService extends HealthCheckableService {
   def getMany(userIds: List[String]): Future[Seq[Attributes]]
   def delete(userId: String): Future[DeleteItemResult]
   def set(attributes: Attributes): Future[PutItemResult]
-  def update(attributes: Attributes) : Future[Either[DynamoReadError, Attributes]]
+  def update(attributes: Attributes): Future[Either[DynamoReadError, Attributes]]
+  def ttlAgeCheck(dynamoAttributes: Option[Attributes], identityId: String, currentDate: LocalDate): Unit
 }

--- a/membership-attribute-service/app/services/ScanamoAttributeService.scala
+++ b/membership-attribute-service/app/services/ScanamoAttributeService.scala
@@ -86,7 +86,7 @@ class ScanamoAttributeService(client: AmazonDynamoDBAsync, table: String)
     } yield TtlConversions.secondsToDateTime(ttl).isBefore(oldestAcceptedAge)
     if (tooOld.contains(true)) {
       logger.error(s"Dynamo Attributes for $identityId have an old TTL. The oldest accepted age is: $oldestAcceptedAge - are we still cleaning the table correctly?")
-      metrics.put("Old Dynamo Item", 1)
+      metrics.put("Old Dynamo Item", 1) //referenced in CloudFormation
     }
   }
 


### PR DESCRIPTION
### Why do we need this? 

To ensure that we stay GDPR compliant, we want to make sure that the data retention rules that were put in place with https://github.com/guardian/members-data-api/pull/280 don't get accidentally lifted or invalidated. Thanks to @johnduffell for suggesting this clever idea.

### The changes 

* Add a TTL age check when we read attributes from Dynamo
* Publish metric data if the age check fails
* Add alert which listens to the metric to CloudFormation template.

### trello card/screenshot/json/related PRs etc
https://trello.com/c/WIIQuQIn/187-data-retention-for-membership-attributes-dynamo-table-members-data-api