### PR TITLE
Remove wallet from Attributes

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -75,7 +75,7 @@ class AttributeController extends Controller with LoggingWithLogstashFields {
             def customFields(supporterType: String): List[LogField] = List(LogFieldString("lookup-endpoint-description", endpointDescription), LogFieldString("supporter-type", supporterType), LogFieldString("data-source", fromWhere))
 
             attributes match {
-              case Some(attrs @ Attributes(_, Some(tier), _, _, _, _, _, _, _)) =>
+              case Some(attrs @ Attributes(_, Some(tier), _, _, _, _, _, _)) =>
                 logInfoWithCustomFields(s"$identityId is a $tier member - $endpointDescription - $attrs found via $fromWhere", customFields("member"))
                 onSuccessMember(attrs).withHeaders(
                   "X-Gu-Membership-Tier" -> tier,

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -19,35 +19,11 @@ object ContentAccess {
   implicit val jsWrite = Json.writes[ContentAccess]
 }
 
-case class CardDetails(last4: String, expirationMonth: Int, expirationYear: Int, forProduct: String) {
-  def asLocalDate: LocalDate = new LocalDate(expirationYear, expirationMonth, 1).plusMonths(1).minusDays(1)
-}
-
-object CardDetails {
-  def fromStripeCard(stripeCard: com.gu.stripe.Stripe.Card, product: String) = {
-    CardDetails(last4 = stripeCard.last4, expirationMonth = stripeCard.exp_month, expirationYear = stripeCard.exp_year, forProduct = product)
-  }
-}
-
-case class Wallet(membershipCard: Option[CardDetails] = None, recurringContributionCard: Option[CardDetails] = None) {
-  val expiredCards: Seq[CardDetails] = Seq(membershipCard, recurringContributionCard).flatten.filter(_.asLocalDate.isBefore(now))
-  // TODO - val cardsExpiringSoon - I assume within 1 calendar month?
-}
-
-object Wallet {
-
-  implicit val cardWriter = Json.writes[CardDetails]
-
-  implicit val jsWrite = Json.writes[Wallet]
-
-}
-
 case class Attributes(
   UserId: String,
   Tier: Option[String] = None,
   MembershipNumber: Option[String] = None,
   AdFree: Option[Boolean] = None,
-  Wallet: Option[Wallet] = None,
   RecurringContributionPaymentPlan: Option[String] = None,
   MembershipJoinDate: Option[LocalDate] = None,
   DigitalSubscriptionExpiryDate: Option[LocalDate] = None,
@@ -78,7 +54,6 @@ object Attributes {
     (__ \ "tier").writeNullable[String] and
     (__ \ "membershipNumber").writeNullable[String] and
     (__ \ "adFree").writeNullable[Boolean] and
-    (__ \ "wallet").writeNullable[Wallet](Wallet.jsWrite) and
     (__ \ "recurringContributionPaymentPlan").writeNullable[String] and
     (__ \ "membershipJoinDate").writeNullable[LocalDate] and
     (__ \ "digitalSubscriptionExpiryDate").writeNullable[LocalDate] and

--- a/membership-attribute-service/app/models/Features.scala
+++ b/membership-attribute-service/app/models/Features.scala
@@ -17,22 +17,15 @@ object Features {
     )
 
   def fromAttributes(attributes: Attributes) = {
-    // TODO - confirm which notification we're doing first: 'your card is expiring soon' or 'your card has expired'
-
-    // It's too confusing to tell the customer about multiple card expirations, so just take the first
-    val maybeExpiredCard = attributes.Wallet.flatMap(_.expiredCards.headOption)
-
     Features(
       userId = Some(attributes.UserId),
       adFree = attributes.isAdFree,
       adblockMessage = !attributes.isPaidTier,
-      cardHasExpiredForProduct = maybeExpiredCard.map(_.forProduct),
-      cardExpiredOn = maybeExpiredCard.map(_.asLocalDate),
       membershipJoinDate = attributes.MembershipJoinDate
     )
   }
 
-  val unauthenticated = Features(None, adFree = false, adblockMessage = true, None, None, None)
+  val unauthenticated = Features(None, adFree = false, adblockMessage = true, None)
 
   def notAMember(attributes: Attributes) = {
     val adFree = attributes.AdFree.getOrElse(false)
@@ -44,7 +37,5 @@ case class Features(
   userId: Option[String],
   adFree: Boolean,
   adblockMessage: Boolean,
-  cardHasExpiredForProduct: Option[String],
-  cardExpiredOn: Option[LocalDate],
   membershipJoinDate: Option[LocalDate]
 )

--- a/membership-attribute-service/app/services/AttributesFromZuora.scala
+++ b/membership-attribute-service/app/services/AttributesFromZuora.scala
@@ -184,7 +184,6 @@ object AttributesFromZuora extends LoggingWithLogstashFields {
       maybeDynamoAttributes match {
         case Some(dynamoAttributes) => zuoraAttributes.copy(
           AdFree = dynamoAttributes.AdFree, //fetched from Dynamo in the Zuora lookup anyway (dynamo is the source of truth)
-          Wallet = dynamoAttributes.Wallet, //can't be found based on Zuora lookups, and not currently used
           MembershipNumber = dynamoAttributes.MembershipNumber, //I don't think membership number is needed and it comes from Salesforce
           MembershipJoinDate = dynamoAttributes.MembershipJoinDate.flatMap(_ => zuoraAttributes.MembershipJoinDate), //only compare if dynamo has value
           TTLTimestamp = dynamoAttributes.TTLTimestamp //TTL only in dynamo

--- a/membership-attribute-service/app/services/ScanamoAttributeService.scala
+++ b/membership-attribute-service/app/services/ScanamoAttributeService.scala
@@ -8,7 +8,7 @@ import com.gu.scanamo.syntax.{set => scanamoSet, _}
 import com.gu.scanamo.update.UpdateExpression
 import com.typesafe.scalalogging.LazyLogging
 import models.Attributes
-import org.joda.time.{DateTime, LocalDate}
+import org.joda.time.LocalDate
 import play.api.libs.concurrent.Execution.Implicits._
 
 import scala.concurrent.Future
@@ -54,7 +54,6 @@ class ScanamoAttributeService(client: AmazonDynamoDBAsync, table: String)
       scanamoSetOpt('Tier, attributes.Tier),
       scanamoSetOpt('MembershipNumber -> attributes.MembershipNumber),
       scanamoSetOpt('RecurringContributionPaymentPlan -> attributes.RecurringContributionPaymentPlan),
-      scanamoSetOpt('Wallet -> attributes.Wallet),
       scanamoSetOpt('MembershipJoinDate -> attributes.MembershipJoinDate),
       scanamoSetOpt('DigitalSubscriptionExpiryDate -> attributes.DigitalSubscriptionExpiryDate),
       scanamoSetOpt('TTLTimestamp -> attributes.TTLTimestamp)

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -4,7 +4,7 @@ import actions.BackendRequest
 import akka.actor.ActorSystem
 import components.TouchpointComponents
 import configuration.Config
-import models.{Attributes, CardDetails, Wallet}
+import models.Attributes
 import org.joda.time.LocalDate
 import org.specs2.mutable.Specification
 import org.specs2.specification.AfterAll
@@ -27,10 +27,6 @@ class AttributeControllerTest extends Specification with AfterAll {
     Tier = Some("patron"),
     MembershipNumber = Some("abc"),
     AdFree = Some(false),
-    Wallet = Some(Wallet(
-      recurringContributionCard = Some(CardDetails("4321", 6, 2018, "contribution")),
-      membershipCard = Some(CardDetails("1234", 5, 2017, "membership"))
-    )),
     MembershipJoinDate = Some(new LocalDate(2017, 5, 13)),
     RecurringContributionPaymentPlan = Some("Monthly Contribution"),
     DigitalSubscriptionExpiryDate = Some(new LocalDate(2100, 1, 1))
@@ -87,9 +83,7 @@ class AttributeControllerTest extends Specification with AfterAll {
                    |   "userId": "123",
                    |   "adblockMessage": false,
                    |   "adFree": false,
-                   |   "membershipJoinDate": "2017-05-13",
-                   |   "cardHasExpiredForProduct": "membership",
-                   |   "cardExpiredOn": "2017-05-31"
+                   |   "membershipJoinDate": "2017-05-13"
                    | }
                  """.stripMargin)
   }
@@ -121,20 +115,6 @@ class AttributeControllerTest extends Specification with AfterAll {
                    |   "tier": "patron",
                    |   "membershipNumber": "abc",
                    |   "userId": "123",
-                   |   "wallet": {
-                   |     "membershipCard": {
-                   |       "last4": "1234",
-                   |       "expirationMonth": 5,
-                   |       "expirationYear": 2017,
-                   |       "forProduct": "membership"
-                   |     },
-                   |     "recurringContributionCard": {
-                   |       "last4": "4321",
-                   |       "expirationMonth": 6,
-                   |       "expirationYear": 2018,
-                   |       "forProduct": "contribution"
-                   |     }
-                   |   },
                    |   "adFree": false,
                    |   "membershipJoinDate": "2017-05-13",
                    |   "recurringContributionPaymentPlan":"Monthly Contribution",

--- a/membership-attribute-service/test/models/AttributesTest.scala
+++ b/membership-attribute-service/test/models/AttributesTest.scala
@@ -36,16 +36,5 @@ class AttributesTest extends Specification {
         attrs.copy(Tier = Some("Friend"), RecurringContributionPaymentPlan = None).isContributor shouldEqual false
       }
     }
-
-    "expiredCards returns" should {
-      "all expired cards in the wallet" in {
-        val bothCards = Seq(CardDetails("1234", 1, 2017, "foo"), CardDetails("1234", 2, 2017, "foo"))
-        Wallet(membershipCard = bothCards.headOption, recurringContributionCard = bothCards.tail.headOption).expiredCards shouldEqual bothCards
-      }
-      "only the expired card in the wallet" in {
-        val bothCards = Seq(CardDetails("1234", 1, 2017, "foo"), CardDetails("1234", 2, 3000, "foo"))
-        Wallet(membershipCard = bothCards.headOption, recurringContributionCard = bothCards.tail.headOption).expiredCards shouldEqual bothCards.headOption.toSeq
-      }
-    }
   }
 }

--- a/membership-attribute-service/test/repositories/ScanamoAttributeServiceTest.scala
+++ b/membership-attribute-service/test/repositories/ScanamoAttributeServiceTest.scala
@@ -6,7 +6,7 @@ import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
 import com.amazonaws.services.dynamodbv2.model.CreateTableRequest
 import com.github.dwhjames.awswrap.dynamodb.{AmazonDynamoDBScalaClient, Schema}
-import models.{Attributes, CardDetails, Wallet}
+import models.Attributes
 import org.joda.time.{DateTime, LocalDate}
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mutable.Specification
@@ -133,8 +133,7 @@ class ScanamoAttributeServiceTest(implicit ee: ExecutionEnv) extends Specificati
     }
 
     "leave existing values in an attribute that cannot be determined from a zuora update alone" in {
-      val testWallet = Wallet(membershipCard = Some(CardDetails(last4 = "5678", expirationMonth = 5, expirationYear = 20, forProduct = "test")))
-      val existingAttributes = Attributes(UserId = "6789", AdFree = Some(true), DigitalSubscriptionExpiryDate = Some(LocalDate.now().minusWeeks(5)), MembershipNumber = Some("1234"), Wallet = Some(testWallet))
+      val existingAttributes = Attributes(UserId = "6789", AdFree = Some(true), DigitalSubscriptionExpiryDate = Some(LocalDate.now().minusWeeks(5)), MembershipNumber = Some("1234"))
       val updatedAttributes = Attributes(UserId = "6789", DigitalSubscriptionExpiryDate = Some(LocalDate.now().plusWeeks(5)))
       val attributesWithPreservedValues = existingAttributes.copy(DigitalSubscriptionExpiryDate = updatedAttributes.DigitalSubscriptionExpiryDate) //TTL is also only in dynamo, but the logic for it is in attributesFromZuora.
 

--- a/membership-attribute-service/test/services/AttributesMakerTest.scala
+++ b/membership-attribute-service/test/services/AttributesMakerTest.scala
@@ -18,7 +18,6 @@ class AttributesMakerTest extends Specification with SubscriptionTestData {
         Tier = None,
         MembershipNumber = None,
         AdFree = None,
-        Wallet = None,
         RecurringContributionPaymentPlan = None,
         MembershipJoinDate = None,
         DigitalSubscriptionExpiryDate = Some(referenceDate + 1.year)
@@ -32,7 +31,6 @@ class AttributesMakerTest extends Specification with SubscriptionTestData {
         Tier = None,
         MembershipNumber = None,
         AdFree = None,
-        Wallet = None,
         RecurringContributionPaymentPlan = None,
         MembershipJoinDate = None,
         DigitalSubscriptionExpiryDate = Some(referenceDate + 1.year)
@@ -50,7 +48,6 @@ class AttributesMakerTest extends Specification with SubscriptionTestData {
         Tier = Some("Supporter"),
         MembershipNumber = None,
         AdFree = None,
-        Wallet = None,
         RecurringContributionPaymentPlan = None,
         MembershipJoinDate = Some(referenceDate)
       )
@@ -64,7 +61,6 @@ class AttributesMakerTest extends Specification with SubscriptionTestData {
         Tier = None,
         MembershipNumber = None,
         AdFree = None,
-        Wallet = None,
         RecurringContributionPaymentPlan = Some("Monthly Contribution"),
         MembershipJoinDate = None
       )
@@ -79,7 +75,6 @@ class AttributesMakerTest extends Specification with SubscriptionTestData {
         Tier = None,
         MembershipNumber = None,
         AdFree = None,
-        Wallet = None,
         RecurringContributionPaymentPlan = Some("Monthly Contribution"),
         MembershipJoinDate = None
       )
@@ -93,7 +88,6 @@ class AttributesMakerTest extends Specification with SubscriptionTestData {
         Tier = Some("Supporter"),
         MembershipNumber = None,
         AdFree = None,
-        Wallet = None,
         RecurringContributionPaymentPlan = Some("Monthly Contribution"),
         MembershipJoinDate = Some(referenceDate)
       )
@@ -107,7 +101,6 @@ class AttributesMakerTest extends Specification with SubscriptionTestData {
         Tier = Some("Friend"),
         MembershipNumber = None,
         AdFree = None,
-        Wallet = None,
         RecurringContributionPaymentPlan = None,
         MembershipJoinDate = Some(referenceDate)
       )


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
PR [182](https://github.com/guardian/members-data-api/pull/182) added card expiry information to lookups via /user-attributes/features. We will be doing further work on credit card expiry messaging in the future, but not via card expiry stored in the membership-attributes-table. Also, the wallet is no longer being populated/updated as of [PR 256](https://github.com/guardian/members-data-api/pull/256/files) to remove the Salesforce hook. So, this PR removes wallet from Attributes. 

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->

- Remove wallet from Attributes. If there is an existing value for wallet, it remains: [the update function](https://github.com/guardian/members-data-api/blob/master/membership-attribute-service/app/services/ScanamoAttributeService.scala#L48). I think it's worth seeing if it's easy to add on removing the wallet when we add a TTL for each record that doesn't have one.

### trello card/screenshot/json/related PRs etc
[On trello](https://trello.com/c/WIIQuQIn/187-data-retention-for-membership-attributes-dynamo-table-members-data-api)

cc @paulbrown1982 @jacobwinch @johnduffell @AWare 