### PR TITLE
Make sure ScanamoAttributeServiceTest doesn't need credentials in the default profile

### DIFF
--- a/membership-attribute-service/test/repositories/ScanamoAttributeServiceTest.scala
+++ b/membership-attribute-service/test/repositories/ScanamoAttributeServiceTest.scala
@@ -2,6 +2,7 @@ package repositories
 
 import java.util.UUID
 
+import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
 import com.amazonaws.client.builder.AwsClientBuilder
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClientBuilder
 import com.amazonaws.services.dynamodbv2.model._
@@ -32,7 +33,8 @@ class ScanamoAttributeServiceTest(implicit ee: ExecutionEnv) extends Specificati
   private val endpoint = new AwsClientBuilder.EndpointConfiguration("http://localhost:8000/", "eu-west-1")
   private val awsDynamoClient = AmazonDynamoDBAsyncClientBuilder
     .standard()
-    .withEndpointConfiguration(endpoint) // .withCredentials(new BasicAWSCredentials("foo", "bar"))
+    .withEndpointConfiguration(endpoint)
+    .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials("foo", "bar")))
     .build()
 
   private val testTable = "MembershipAttributes-TEST"


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
I was getting 
```
cannot create an instance for class repositories.ScanamoAttributeServiceTest
[error]   caused by com.amazonaws.SdkClientException: Unable to load AWS credentials from any provider in the chain
```
when running the tests but they worked if I put membership aws credentials in my default profile. I think we need to give credentials to the builder or else they will look for credentials in the default profile.
### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
- I put the stub credentials back in so that the test still works on a dev box with named profile credentials only

### trello card/screenshot/json/related PRs etc
