### PR TITLE
Delete old config

### DIFF
--- a/membership-attribute-service/conf/DEV.public.conf
+++ b/membership-attribute-service/conf/DEV.public.conf
@@ -24,11 +24,6 @@ play.filters.cors.allowedOrigins = [
   "https://thegulocal.com"
 ]
 
-authentication {
-  key="a-nice-secret"
-}
-
-
 mma.cors.allowedOrigins = [
   "https://profile.code.dev-theguardian.com",
   "https://subscribe.code.dev-theguardian.com",


### PR DESCRIPTION
I forgot to do this in https://github.com/guardian/members-data-api/pull/284

To do: delete unused 'secret' from private conf files (and re-deploy)
- [x]  DEV
- [x] CODE
- [x] PROD