### PR TITLE
Enabling a local SSM agent client to act upon the members-data-api instances

### DIFF
--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -181,6 +181,7 @@ Resources:
             Effect: Allow
       ManagedPolicyArns:
       - !Ref 'LoggingPolicy'
+      - 'arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM'
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
To allow us to use [ssm-agent](https://github.com/guardian/ssm-scala) client to act upon the members-data-api instances

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
To cloudformation

### trello card/screenshot/json/related PRs etc

cc @shtukas
