### PR TITLE
Revert "remove play 2.6 deprecations"

### DIFF
--- a/membership-attribute-service/app/actions/CommonActions.scala
+++ b/membership-attribute-service/app/actions/CommonActions.scala
@@ -12,7 +12,7 @@ class CommonActions(touchpointBackends: TouchpointBackends, bodyParser: BodyPars
   def noCache(result: Result): Result = NoCache(result)
 
   val NoCacheAction = resultModifier(noCache)
-  val BackendFromCookieAction = NoCacheAction andThen new WithBackendFromCookieAction(touchpointBackends)
+  val BackendFromCookieAction = NoCacheAction andThen new WithBackendFromCookieAction(touchpointBackends, ex)
 
   private def resultModifier(f: Result => Result) = new ActionBuilder[Request, AnyContent] {
     override val parser = bodyParser

--- a/membership-attribute-service/app/actions/WithBackendFromCookieAction.scala
+++ b/membership-attribute-service/app/actions/WithBackendFromCookieAction.scala
@@ -4,9 +4,12 @@ import components.TouchpointBackends
 import configuration.Config
 import play.api.mvc.{ActionRefiner, Request, Result}
 import services.IdentityAuthService
-import scala.concurrent.{ExecutionContext, Future}
 
-class WithBackendFromCookieAction(touchpointBackends: TouchpointBackends)(implicit ex: ExecutionContext) extends ActionRefiner[Request, BackendRequest] {
+import scala.concurrent.{ExecutionContext, Future}
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+
+
+class WithBackendFromCookieAction(touchpointBackends: TouchpointBackends, ex: ExecutionContext) extends ActionRefiner[Request, BackendRequest] {
   override val executionContext = ex
   override protected def refine[A](request: Request[A]): Future[Either[Result, BackendRequest[A]]] = Future {
     val firstName = IdentityAuthService.username(request).flatMap(_.split(' ').headOption) //Identity checks for test users by first name

--- a/membership-attribute-service/app/components/NormalTouchpointComponents.scala
+++ b/membership-attribute-service/app/components/NormalTouchpointComponents.scala
@@ -1,0 +1,7 @@
+package components
+
+import akka.actor.ActorSystem
+import configuration.Config
+
+
+class NormalTouchpointComponents(system: ActorSystem) extends TouchpointComponents(Config.defaultTouchpointBackendStage)(system)

--- a/membership-attribute-service/app/components/TestTouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TestTouchpointComponents.scala
@@ -1,0 +1,6 @@
+package components
+
+import akka.actor.ActorSystem
+import configuration.Config
+
+class TestTouchpointComponents(system: ActorSystem) extends TouchpointComponents(Config.testTouchpointBackendStage)(system)

--- a/membership-attribute-service/app/components/TouchpointBackends.scala
+++ b/membership-attribute-service/app/components/TouchpointBackends.scala
@@ -3,9 +3,7 @@ package components
 import akka.actor.ActorSystem
 import configuration.Config
 
-import scala.concurrent.ExecutionContext
-
-class TouchpointBackends(actorSystem: ActorSystem)(implicit executionContext: ExecutionContext){
-  val normal =  new TouchpointComponents(Config.defaultTouchpointBackendStage)(actorSystem, executionContext)
-  val test = new TouchpointComponents(Config.testTouchpointBackendStage)(actorSystem, executionContext)
+class TouchpointBackends(actorSystem: ActorSystem){
+  val normal =  new TouchpointComponents(Config.defaultTouchpointBackendStage)(actorSystem)
+  val test = new TouchpointComponents(Config.testTouchpointBackendStage)(actorSystem)
 }

--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -24,11 +24,10 @@ import loghandling.ZuoraRequestCounter
 import prodtest.FeatureToggleDataUpdatedOnSchedule
 import services.IdentityService.IdentityConfig
 import services._
-
 import scala.concurrent.duration._
-import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.{Await, Future}
 
-class TouchpointComponents(stage: String)(implicit  system: ActorSystem, executionContext: ExecutionContext) {
+class TouchpointComponents(stage: String)(implicit system: ActorSystem) {
   implicit val ec = system.dispatcher
   lazy val conf = Config.config.getConfig("touchpoint.backend")
   lazy val environmentConf = conf.getConfig(s"environments.$stage")

--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -1,5 +1,6 @@
 package controllers
 import actions._
+import play.api.libs.concurrent.Execution.Implicits._
 import services.{AuthenticationService, IdentityAuthService}
 import com.gu.memsub._
 import com.gu.memsub.subsv2.{Subscription, SubscriptionPlan}
@@ -16,12 +17,11 @@ import json.PaymentCardUpdateResultWriters._
 import models.AccountDetails._
 import models.ApiError
 import models.ApiErrors._
-import play.api.mvc.{BaseController, ControllerComponents}
+import play.api.mvc.Controller
 import play.api.data.Form
 import play.api.data.Forms._
 import play.api.libs.json.Json
-
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 import scalaz.std.option._
 import scalaz.std.scalaFuture._
 import scalaz.syntax.monad._
@@ -29,9 +29,8 @@ import scalaz.syntax.std.option._
 import scalaz.syntax.traverse._
 import scalaz.{-\/, EitherT, OptionT, \/, \/-, _}
 
-class AccountController(commonActions: CommonActions, override val controllerComponents: ControllerComponents) extends BaseController with LazyLogging {
+class AccountController(commonActions: CommonActions) extends Controller with LazyLogging {
   import commonActions._
-  implicit val executionContext: ExecutionContext= controllerComponents.executionContext
   lazy val authenticationService: AuthenticationService = IdentityAuthService
   lazy val corsMmaUpdateFilter = CORSFilter(Config.mmaUpdateCorsConfig)
   lazy val mmaCorsFilter = CORSFilter(Config.mmaCorsConfig)
@@ -244,7 +243,7 @@ object OptionEither {
   def apply[A](m: Future[\/[String, Option[A]]]): OptionT[FutureEither, A] =
     OptionT[FutureEither, A](EitherT[Future, String, Option[A]](m))
 
-  def liftOption[A](x: Future[\/[String, A]])(implicit ex: ExecutionContext): OptionT[FutureEither, A] =
+  def liftOption[A](x: Future[\/[String, A]]): OptionT[FutureEither, A] =
     apply(x.map(_.map[Option[A]](Some.apply)))
 
   def liftFutureEither[A](x: Option[A]): OptionT[FutureEither, A] =

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -10,16 +10,17 @@ import models.ApiErrors._
 import models.Features._
 import models._
 import monitoring.Metrics
+import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.Json
 import play.api.mvc._
-import services.{AttributesFromZuora, AuthenticationService, IdentityAuthService}
+import services.{AuthenticationService, IdentityAuthService}
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
+import services.AttributesFromZuora._
 
-class AttributeController(attributesFromZuora: AttributesFromZuora, commonActions: CommonActions, override val controllerComponents: ControllerComponents) extends BaseController with LoggingWithLogstashFields {
-  import attributesFromZuora._
+class AttributeController(commonActions: CommonActions) extends Controller with LoggingWithLogstashFields {
+
   import commonActions._
-  implicit val executionContext: ExecutionContext = controllerComponents.executionContext
   lazy val corsFilter = CORSFilter(Config.corsConfig)
   lazy val backendAction = NoCacheAction andThen corsFilter andThen BackendFromCookieAction
   lazy val authenticationService: AuthenticationService = IdentityAuthService
@@ -37,8 +38,8 @@ class AttributeController(attributesFromZuora: AttributesFromZuora, commonAction
         dynamoAttributeService = dynamoService
       )
     } else {
-      val attributes: Future[Option[Attributes]] = dynamoService.get(identityId).map(maybeDynamoAttributes => maybeDynamoAttributes.map(DynamoAttributes.asAttributes(_)))(executionContext)
-      attributes.map(("Dynamo - too many concurrent calls to Zuora", _))(executionContext)
+      val attributes: Future[Option[Attributes]] = dynamoService.get(identityId) map { maybeDynamoAttributes => maybeDynamoAttributes.map(DynamoAttributes.asAttributes(_))}
+      attributes map {("Dynamo - too many concurrent calls to Zuora", _)}
     }
   }
 

--- a/membership-attribute-service/app/controllers/BehaviourController.scala
+++ b/membership-attribute-service/app/controllers/BehaviourController.scala
@@ -5,17 +5,16 @@ import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
 import models.Behaviour
 import monitoring.Metrics
+import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.{JsValue, Json}
-import play.api.mvc.{AnyContent, BaseController, ControllerComponents}
+import play.api.mvc.{AnyContent, Controller}
 import services.IdentityService.IdentityId
 import services.{AuthenticationService, IdentityAuthService, SQSAbandonedCartEmailService}
+import scala.concurrent.Future
 
-import scala.concurrent.{ExecutionContext, Future}
-
-class BehaviourController(commonActions: CommonActions, override val controllerComponents: ControllerComponents) extends BaseController with LazyLogging {
+class BehaviourController(commonActions: CommonActions) extends Controller with LazyLogging {
 
   import commonActions._
-  implicit val executionContext: ExecutionContext = controllerComponents.executionContext
   lazy val corsFilter = CORSFilter(Config.corsConfig)
   lazy val backendAction = corsFilter andThen BackendFromCookieAction
   lazy val authenticationService: AuthenticationService = IdentityAuthService

--- a/membership-attribute-service/app/controllers/HealthCheckController.scala
+++ b/membership-attribute-service/app/controllers/HealthCheckController.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import play.api.libs.json.Json
-import play.api.mvc.{BaseController, ControllerComponents, Results}
+import play.api.mvc.{Action, Results}
 import components.TouchpointBackends
 import com.typesafe.scalalogging.StrictLogging
 
@@ -15,7 +15,7 @@ class BoolTest(name: String, exec: () => Boolean) extends Test {
   override def ok = exec()
 }
 
-class HealthCheckController(touchPointBackends:TouchpointBackends,  override val controllerComponents: ControllerComponents) extends BaseController with StrictLogging {
+class HealthCheckController(touchPointBackends:TouchpointBackends) extends Results with StrictLogging {
 
   val touchpointComponents = touchPointBackends.normal
   // behaviourService, Stripe and all Zuora services are not critical

--- a/membership-attribute-service/app/filters/AddEC2InstanceHeader.scala
+++ b/membership-attribute-service/app/filters/AddEC2InstanceHeader.scala
@@ -1,12 +1,13 @@
 package filters
 
 import akka.stream.Materializer
-import play.api.libs.ws.WSClient
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import play.api.libs.ws.{WSClient}
 import play.api.mvc._
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
-class AddEC2InstanceHeader (wSClient: WSClient)(implicit val mat: Materializer,ex: ExecutionContext) extends Filter {
+class AddEC2InstanceHeader (wSClient: WSClient)(implicit val mat: Materializer) extends Filter {
 
   // http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
   lazy val instanceIdF = wSClient.url("http://169.254.169.254/latest/meta-data/instance-id").get().map(_.body)

--- a/membership-attribute-service/app/filters/AddGuIdentityHeaders.scala
+++ b/membership-attribute-service/app/filters/AddGuIdentityHeaders.scala
@@ -1,17 +1,21 @@
 package filters
 
+import javax.inject.Inject
+
 import akka.stream.Materializer
 import configuration.Config
+import play.api.http.HeaderNames
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.mvc._
 import services.IdentityAuthService
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
 /*
  * This is a candidate for inclusion in https://github.com/guardian/memsub-common-play-auth ,
  * this particular version is a tweaked copy from https://github.com/guardian/subscriptions-frontend/blob/ea805479/app/filters/AddGuIdentityHeaders.scala
  */
-class AddGuIdentityHeaders (implicit val mat: Materializer, ex: ExecutionContext) extends Filter {
+class AddGuIdentityHeaders (implicit val mat: Materializer) extends Filter {
 
   def apply(nextFilter: RequestHeader => Future[Result])(request: RequestHeader): Future[Result] = for {
     result <- nextFilter(request)

--- a/membership-attribute-service/app/filters/CheckCacheHeadersFilter.scala
+++ b/membership-attribute-service/app/filters/CheckCacheHeadersFilter.scala
@@ -1,12 +1,15 @@
 package filters
 
+import javax.inject.Inject
+
 import akka.stream.Materializer
 import controllers.Cached.suitableForCaching
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.mvc._
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
-class CheckCacheHeadersFilter (implicit val mat: Materializer, ex: ExecutionContext) extends Filter {
+class CheckCacheHeadersFilter (implicit val mat: Materializer) extends Filter {
 
   def apply(nextFilter: RequestHeader => Future[Result])(requestHeader: RequestHeader): Future[Result] = {
     nextFilter(requestHeader).map { result =>

--- a/membership-attribute-service/app/monitoring/ErrorHandling.scala
+++ b/membership-attribute-service/app/monitoring/ErrorHandling.scala
@@ -10,6 +10,7 @@ import play.api.routing.Router
 import play.core.SourceMapper
 import models.ApiErrors.{notFound, internalError, badRequest}
 import play.api.libs.json.Json
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import scala.concurrent._
 
 class ErrorHandler(
@@ -17,7 +18,7 @@ class ErrorHandler(
                     config: Configuration,
                     sourceMapper: Option[SourceMapper],
                     router: => Option[Router]
-                  )(implicit executionContext: ExecutionContext) extends DefaultHttpErrorHandler(env, config, sourceMapper, router) with LazyLogging{
+                  ) extends DefaultHttpErrorHandler(env, config, sourceMapper, router) with LazyLogging{
 
   override def onClientError(request: RequestHeader, statusCode: Int, message: String = ""): Future[Result] = {
     super.onClientError(request, statusCode, message).map(Cached(_))

--- a/membership-attribute-service/app/services/AttributesFromZuora.scala
+++ b/membership-attribute-service/app/services/AttributesFromZuora.scala
@@ -10,13 +10,15 @@ import loghandling.LoggingField.LogField
 import loghandling.{LoggingWithLogstashFields, ZuoraRequestCounter}
 import models.{Attributes, DynamoAttributes, ZuoraAttributes}
 import org.joda.time.{DateTime, LocalDate}
-import scala.concurrent.{ExecutionContext, Future}
+import play.api.libs.concurrent.Execution.Implicits._
+
+import scala.concurrent.Future
 import scalaz.std.list._
 import scalaz.std.scalaFuture._
 import scalaz.syntax.traverse._
 import scalaz.{-\/, Disjunction, EitherT, \/, \/-, _}
 
-class AttributesFromZuora(implicit val executionContext: ExecutionContext) extends LoggingWithLogstashFields {
+object AttributesFromZuora extends LoggingWithLogstashFields {
 
   def getAttributes(identityId: String,
                     identityIdToAccountIds: String => Future[String \/ QueryResponse],

--- a/membership-attribute-service/app/services/IdentityService.scala
+++ b/membership-attribute-service/app/services/IdentityService.scala
@@ -2,13 +2,14 @@ package services
 
 import com.typesafe.scalalogging.LazyLogging
 import play.api.libs.json.{JsValue, Json, __}
+import play.api.libs.concurrent.Execution.Implicits._
 import java.net.URLEncoder.encode
 
 import IdentityService._
 import com.gu.okhttp.RequestRunners
 import okhttp3.{MediaType, Request, RequestBody, ResponseBody}
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
 object IdentityService {
 
@@ -32,7 +33,7 @@ object IdentityService {
 
 }
 
-class IdentityService(state: IdentityConfig, client: RequestRunners.FutureHttpClient)(implicit executionContext: ExecutionContext) extends LazyLogging {
+class IdentityService(state: IdentityConfig, client: RequestRunners.FutureHttpClient) extends LazyLogging {
 
   def user(id: IdentityId) = {
     client(userIdRequest(state)(id).build).map { response =>

--- a/membership-attribute-service/app/services/ScanamoAttributeService.scala
+++ b/membership-attribute-service/app/services/ScanamoAttributeService.scala
@@ -10,10 +10,10 @@ import com.typesafe.scalalogging.LazyLogging
 import models.DynamoAttributes
 import monitoring.Metrics
 import org.joda.time.{DateTime, LocalDate}
+import play.api.libs.concurrent.Execution.Implicits._
+import scala.concurrent.Future
 
-import scala.concurrent.{ExecutionContext, Future}
-
-class ScanamoAttributeService(client: AmazonDynamoDBAsync, table: String)(implicit executionContext: ExecutionContext)
+class ScanamoAttributeService(client: AmazonDynamoDBAsync, table: String)
     extends AttributeService with LazyLogging {
 
   val metrics = Metrics("ScanamoAttributeService") //referenced in CloudFormation

--- a/membership-attribute-service/app/services/ScanamoBehaviourService.scala
+++ b/membership-attribute-service/app/services/ScanamoBehaviourService.scala
@@ -6,10 +6,11 @@ import com.gu.scanamo.syntax._
 import com.gu.scanamo.{ScanamoAsync, Table}
 import com.typesafe.scalalogging.LazyLogging
 import models.Behaviour
+import play.api.libs.concurrent.Execution.Implicits._
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
-class ScanamoBehaviourService(client: AmazonDynamoDBAsync, table: String)(implicit ex: ExecutionContext) extends BehaviourService with LazyLogging {
+class ScanamoBehaviourService(client: AmazonDynamoDBAsync, table: String) extends BehaviourService with LazyLogging {
 
   def checkHealth: Boolean = client.describeTable(table).getTable.getTableStatus == "ACTIVE"
 

--- a/membership-attribute-service/app/services/ScanamoFeatureToggleService.scala
+++ b/membership-attribute-service/app/services/ScanamoFeatureToggleService.scala
@@ -6,13 +6,14 @@ import com.gu.scanamo.error.DynamoReadError
 import com.gu.scanamo.syntax.{set => scanamoSet, _}
 import com.typesafe.scalalogging.LazyLogging
 import models.FeatureToggle
+import play.api.libs.concurrent.Execution.Implicits._
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 import scalaz.\/
 import scalaz.syntax.std.either._
 import scalaz.syntax.std.option._
 
-class ScanamoFeatureToggleService(client: AmazonDynamoDBAsync, table: String)(implicit executionContext: ExecutionContext) extends FeatureToggleService with LazyLogging {
+class ScanamoFeatureToggleService(client: AmazonDynamoDBAsync, table: String) extends FeatureToggleService with LazyLogging {
 
   def checkHealth: Boolean = client.describeTable(table).getTable.getTableStatus == "ACTIVE"
 

--- a/membership-attribute-service/app/wiring/AppLoader.scala
+++ b/membership-attribute-service/app/wiring/AppLoader.scala
@@ -1,7 +1,7 @@
 package wiring
 
 import actions.CommonActions
-import components.TouchpointBackends
+import components.{TouchpointBackends}
 import configuration.Config
 import controllers._
 import filters.{AddEC2InstanceHeader, AddGuIdentityHeaders, CheckCacheHeadersFilter}
@@ -13,7 +13,6 @@ import play.api.libs.ws.ahc.AhcWSComponents
 import play.api.mvc.EssentialFilter
 import play.filters.csrf.CSRFComponents
 import router.Routes
-import services.AttributesFromZuora
 
 class AppLoader extends ApplicationLoader {
   def load(context: Context) = {
@@ -35,13 +34,13 @@ class MyComponents(context: Context)
   val commonActions = new CommonActions(touchPointBackends, defaultBodyParser)
   override lazy val httpErrorHandler: ErrorHandler =
     new ErrorHandler(environment, configuration, sourceMapper, Some(router))
-  val attributesFromZuora = new AttributesFromZuora()
+
   lazy val router: Routes = new Routes(
     httpErrorHandler,
-    new HealthCheckController(touchPointBackends, controllerComponents),
-    new AttributeController(attributesFromZuora, commonActions, controllerComponents),
-    new AccountController(commonActions, controllerComponents),
-    new BehaviourController(commonActions, controllerComponents)
+    new HealthCheckController(touchPointBackends),
+    new AttributeController(commonActions),
+    new AccountController(commonActions),
+    new BehaviourController(commonActions)
   )
 
   override lazy val httpFilters: Seq[EssentialFilter] = Seq(

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -9,12 +9,13 @@ import models.Attributes
 import org.joda.time.LocalDate
 import org.specs2.mutable.Specification
 import org.specs2.specification.AfterAll
+import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.Json
 import play.api.mvc._
 import play.api.test._
 import play.api.test.Helpers._
-import services.{AttributesFromZuora, AuthenticationService}
-import scala.concurrent.ExecutionContext.Implicits.global
+import services.AuthenticationService
+
 import scala.concurrent.Future
 
 class AttributeControllerTest extends Specification with AfterAll {
@@ -59,9 +60,8 @@ class AttributeControllerTest extends Specification with AfterAll {
   private val actorSystem = ActorSystem()
   private val touchpointBackends = new TouchpointBackends(actorSystem)
   private val stubParser = Helpers.stubBodyParser(AnyContent("test"))
-  private val ex = scala.concurrent.ExecutionContext.global
-  private val commonActions = new CommonActions(touchpointBackends, stubParser)(ex, ActorMaterializer())
-  private val controller = new AttributeController(new AttributesFromZuora(), commonActions, Helpers.stubControllerComponents()) {
+  private val commonActions = new CommonActions(touchpointBackends, stubParser)(scala.concurrent.ExecutionContext.global, ActorMaterializer())
+  private val controller = new AttributeController(commonActions) {
 
     override lazy val authenticationService = fakeAuthService
     override lazy val backendAction = Action andThen FakeWithBackendAction

--- a/membership-attribute-service/test/services/AttributesFromZuoraTest.scala
+++ b/membership-attribute-service/test/services/AttributesFromZuoraTest.scala
@@ -11,15 +11,15 @@ import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import org.specs2.specification.{BeforeEach, Scope}
+import services.AttributesFromZuora._
 import testdata.SubscriptionTestData
-import scala.concurrent.ExecutionContext.Implicits.global
+
 import scala.concurrent.Future
 import scalaz.\/
 
 
-class attributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification with SubscriptionTestData with Mockito with BeforeEach {
+class AttributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification with SubscriptionTestData with Mockito with BeforeEach {
 
-  val attributesFromZuora = new AttributesFromZuora()
   override def referenceDate = new LocalDate(2016, 9, 20)
   val referenceDateInSeconds = referenceDate.toDateTimeAtStartOfDay.getMillis / 1000
   def twoWeeksFromReferenceDate = referenceDate.toDateTimeAtStartOfDay.plusWeeks(2)
@@ -76,7 +76,7 @@ class attributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
       "return attributes for a user who has many subscriptions" in new contributorDigitalPack {
         mockDynamoAttributesService.get(testId) returns Future.successful(Some(dynamoContributorDigitalPackAttributes))
 
-        val attributes: Future[(String, Option[Attributes])] = attributesFromZuora.getAttributes(testId, identityIdToAccountIds, subscriptionFromAccountId, mockDynamoAttributesService, referenceDate)
+        val attributes: Future[(String, Option[Attributes])] = AttributesFromZuora.getAttributes(testId, identityIdToAccountIds, subscriptionFromAccountId, mockDynamoAttributesService, referenceDate)
         attributes must be_==("Zuora", Some(contributorDigitalPackAttributes)).await
 
         there was no(mockDynamoAttributesService).delete(anyString)
@@ -89,7 +89,7 @@ class attributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
         mockDynamoAttributesService.get(testId) returns Future.successful(Some(outdatedAttributesButWithAdFree))
         mockDynamoAttributesService.update(contributorDigitalPackAdfreeAttributes) returns Future.successful(Right(contributorDigitalPackAdfreeAttributes))
 
-        val attributes: Future[(String, Option[Attributes])] = attributesFromZuora.getAttributes(testId, identityIdToAccountIds, subscriptionFromAccountId, mockDynamoAttributesService, referenceDate)
+        val attributes: Future[(String, Option[Attributes])] = AttributesFromZuora.getAttributes(testId, identityIdToAccountIds, subscriptionFromAccountId, mockDynamoAttributesService, referenceDate)
         val expected: Option[Attributes] = Some(contributorDigitalPackAttributes.copy(AdFree = Some(true)))
         attributes must be_==("Zuora", expected).await
 
@@ -97,12 +97,12 @@ class attributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
       }
 
       "return None if the user has no account ids" in new noAccounts {
-        val attributes: Future[(String, Option[Attributes])] = attributesFromZuora.getAttributes(testId, identityIdToAccountIds, subscriptionFromAccountId, mockDynamoAttributesService, referenceDate)
+        val attributes: Future[(String, Option[Attributes])] = AttributesFromZuora.getAttributes(testId, identityIdToAccountIds, subscriptionFromAccountId, mockDynamoAttributesService, referenceDate)
         attributes must be_==("Zuora", None).await
       }
 
       "return the attributes from Dynamo if Zuora query for account ids fails" in new errorWhenGettingAccounts {
-        val attributes: Future[(String, Option[Attributes])] = attributesFromZuora.getAttributes(testId, identityIdToAccountIds, subscriptionFromAccountId, mockDynamoAttributesService, referenceDate)
+        val attributes: Future[(String, Option[Attributes])] = AttributesFromZuora.getAttributes(testId, identityIdToAccountIds, subscriptionFromAccountId, mockDynamoAttributesService, referenceDate)
         attributes must be_==("Dynamo", Some(supporterAttributes)).await
 
         there was no(mockDynamoAttributesService).delete(anyString)
@@ -111,7 +111,7 @@ class attributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
       "return the attributes from Dynamo if Zuora call to get subscriptions fails" in new errorWhenGettingSubs {
         mockDynamoAttributesService.get(testId) returns Future.successful(Some(supporterDynamoAttributes))
 
-        val attributes: Future[(String, Option[Attributes])] = attributesFromZuora.getAttributes(testId, identityIdToAccountIds, subscriptionFromAccountId, mockDynamoAttributesService, referenceDate)
+        val attributes: Future[(String, Option[Attributes])] = AttributesFromZuora.getAttributes(testId, identityIdToAccountIds, subscriptionFromAccountId, mockDynamoAttributesService, referenceDate)
         attributes must be_==("Dynamo", Some(supporterAttributes)).await
 
         there was no(mockDynamoAttributesService).delete(anyString)
@@ -119,7 +119,7 @@ class attributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
 
       "return None if there are no attributes from Dynamo and the Zuora call to get subscriptions fails" in new errorWhenGettingSubs {
         mockDynamoAttributesService.get(testId) returns Future.successful(None)
-        val attributes: Future[(String, Option[Attributes])] = attributesFromZuora.getAttributes(testId, identityIdToAccountIds, subscriptionFromAccountId, mockDynamoAttributesService, referenceDate)
+        val attributes: Future[(String, Option[Attributes])] = AttributesFromZuora.getAttributes(testId, identityIdToAccountIds, subscriptionFromAccountId, mockDynamoAttributesService, referenceDate)
         attributes must be_==("Dynamo", None).await
 
         there was no(mockDynamoAttributesService).delete(anyString)
@@ -136,7 +136,7 @@ class attributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
 
           val expected = attributesFromCache flatMap {attr => Some(DynamoAttributes.asAttributes(attr))}
 
-          val attributes: Future[(String, Option[Attributes])] = attributesFromZuora.getAttributes(testId, identityIdToAccountIds, subscriptionFromAccountId, mockDynamoAttributesService, referenceDate)
+          val attributes: Future[(String, Option[Attributes])] = AttributesFromZuora.getAttributes(testId, identityIdToAccountIds, subscriptionFromAccountId, mockDynamoAttributesService, referenceDate)
           attributes must be_==("Dynamo", expected).await
         }
 
@@ -151,7 +151,7 @@ class attributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
         def identityIdToAccountIds(identityId: String): Future[\/[String, QueryResponse]] = Future.successful(\/.right(oneAccountQueryResponse))
         def subscriptionFromAccountId(accountId: AccountId)(reads: SubPlanReads[AnyPlan]) = Future.successful(\/.right(List(contributor)))
 
-        val attributes: Future[(String, Option[Attributes])] = attributesFromZuora.getAttributes(testId, identityIdToAccountIds, subscriptionFromAccountId, mockDynamoAttributesService, referenceDate)
+        val attributes: Future[(String, Option[Attributes])] = AttributesFromZuora.getAttributes(testId, identityIdToAccountIds, subscriptionFromAccountId, mockDynamoAttributesService, referenceDate)
         attributes must be_==("Zuora", Some(contributorAttributes)).await
 
         there was one(mockDynamoAttributesService).update(contributorAttributesWithTtl)
@@ -165,7 +165,7 @@ class attributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
         def identityIdToAccountIds(identityId: String): Future[\/[String, QueryResponse]] = Future.successful(\/.right(oneAccountQueryResponse))
         def subscriptionFromAccountId(accountId: AccountId)(reads: SubPlanReads[AnyPlan]) = Future.successful(\/.right(Nil))
 
-        val attributes: Future[(String, Option[Attributes])] = attributesFromZuora.getAttributes(testId, identityIdToAccountIds, subscriptionFromAccountId, mockDynamoAttributesService, referenceDate)
+        val attributes: Future[(String, Option[Attributes])] = AttributesFromZuora.getAttributes(testId, identityIdToAccountIds, subscriptionFromAccountId, mockDynamoAttributesService, referenceDate)
 
         attributes must be_==("Zuora", None).await
 
@@ -184,7 +184,7 @@ class attributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
         def subscriptionFromAccountId(accountId: AccountId)(reads: SubPlanReads[AnyPlan]) = Future.successful(\/.right(List(membership)))
         def identityIdToAccountIds(identityId: String): Future[\/[String, QueryResponse]] = Future.successful(\/.right(oneAccountQueryResponse))
 
-        val attributes: Future[(String, Option[Attributes])] = attributesFromZuora.getAttributes(testId, identityIdToAccountIds, subscriptionFromAccountId, mockDynamoAttributesService, referenceDate)
+        val attributes: Future[(String, Option[Attributes])] = AttributesFromZuora.getAttributes(testId, identityIdToAccountIds, subscriptionFromAccountId, mockDynamoAttributesService, referenceDate)
         attributes must be_==("Zuora", Some(supporterAttributes)).await
 
         there was one(mockDynamoAttributesService).update(expectedAttributesWithTtl)
@@ -202,7 +202,7 @@ class attributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
         def subscriptionFromAccountId(accountId: AccountId)(reads: SubPlanReads[AnyPlan]) = Future.successful(\/.right(List(membership)))
         def identityIdToAccountIds(identityId: String): Future[\/[String, QueryResponse]] = Future.successful(\/.right(oneAccountQueryResponse))
 
-        val attributes: Future[(String, Option[Attributes])] = attributesFromZuora.getAttributes(testId, identityIdToAccountIds, subscriptionFromAccountId, mockDynamoAttributesService, referenceDate)
+        val attributes: Future[(String, Option[Attributes])] = AttributesFromZuora.getAttributes(testId, identityIdToAccountIds, subscriptionFromAccountId, mockDynamoAttributesService, referenceDate)
         attributes must be_==("Zuora", Some(supporterAttributes)).await
 
         there was one(mockDynamoAttributesService).update(expectedAttributesWithTtl)
@@ -219,7 +219,7 @@ class attributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
         def subscriptionFromAccountId(accountId: AccountId)(reads: SubPlanReads[AnyPlan]) = Future.successful(\/.right(List(membership)))
         def identityIdToAccountIds(identityId: String): Future[\/[String, QueryResponse]] = Future.successful(\/.right(oneAccountQueryResponse))
 
-        val attributes: Future[(String, Option[Attributes])] = attributesFromZuora.getAttributes(testId, identityIdToAccountIds, subscriptionFromAccountId, mockDynamoAttributesService, referenceDate)
+        val attributes: Future[(String, Option[Attributes])] = AttributesFromZuora.getAttributes(testId, identityIdToAccountIds, subscriptionFromAccountId, mockDynamoAttributesService, referenceDate)
         attributes must be_==("Zuora", Some(supporterAttributes)).await
 
         there was one(mockDynamoAttributesService).update(expectedAttributesWithUpdatedTtl)
@@ -231,19 +231,19 @@ class attributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
     "getSubscriptions" should {
       "get all subscriptions if a user has multiple" in new contributorDigitalPack {
         mockDynamoAttributesService.get(testId) returns Future.successful(Some(dynamoContributorDigitalPackAttributes))
-        val subscriptions = attributesFromZuora.getSubscriptions(List(testAccountId, anotherTestAccountId), testId, subscriptionFromAccountId)
+        val subscriptions = AttributesFromZuora.getSubscriptions(List(testAccountId, anotherTestAccountId), testId, subscriptionFromAccountId)
 
         subscriptions must be_==(\/.right(List(contributor, digipack))).await
       }
 
       "get an empty list of subscriptions for a user who doesn't have any " in new accountButNoSubscriptions {
-        val subscriptions = attributesFromZuora.getSubscriptions(List(testAccountId), testId, subscriptionFromAccountId)
+        val subscriptions = AttributesFromZuora.getSubscriptions(List(testAccountId), testId, subscriptionFromAccountId)
 
         subscriptions must be_==(\/.right(Nil)).await
       }
 
       "return a left with error message if the subscription service returns a left" in new errorWhenGettingSubs {
-        val subscriptions = attributesFromZuora.getSubscriptions(List(testAccountId), testId, subscriptionFromAccountId)
+        val subscriptions = AttributesFromZuora.getSubscriptions(List(testAccountId), testId, subscriptionFromAccountId)
 
         subscriptions must be_==(\/.left(s"We called Zuora to get subscriptions for a user with identityId $testId but the call failed because $testErrorMessage")).await
       }
@@ -251,13 +251,13 @@ class attributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
 
     "queryToAccountIds" should {
       "extract an AccountId from a query response" in new contributor {
-        val accountIds: List[AccountId] = attributesFromZuora.queryToAccountIds(oneAccountQueryResponse)
+        val accountIds: List[AccountId] = AttributesFromZuora.queryToAccountIds(oneAccountQueryResponse)
         accountIds === List(testAccountId)
       }
 
       "return an empty list when no account ids" in new contributor {
         val emptyResponse = QueryResponse(records = Nil, size = 0)
-        val accountIds: List[AccountId] = attributesFromZuora.queryToAccountIds(emptyResponse)
+        val accountIds: List[AccountId] = AttributesFromZuora.queryToAccountIds(emptyResponse)
         accountIds === Nil
       }
     }
@@ -267,47 +267,47 @@ class attributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
         val fromDynamo = Some(supporterDynamoAttributes)
         val fromZuora = Some(asZuoraAttributes(supporterDynamoAttributes))
 
-        attributesFromZuora.dynamoAndZuoraAgree(fromDynamo, fromZuora, testId) must be_==(true)
+        AttributesFromZuora.dynamoAndZuoraAgree(fromDynamo, fromZuora, testId) must be_==(true)
       }
 
       "ignore the fields not obtainable from zuora" in {
         val fromDynamo = Some(supporterDynamoAttributes.copy(AdFree = Some(true), TTLTimestamp = toDynamoTtl(twoWeeksFromReferenceDate)))
         val fromZuora = Some(asZuoraAttributes(supporterDynamoAttributes))
 
-        attributesFromZuora.dynamoAndZuoraAgree(fromDynamo, fromZuora, testId) must be_==(true)
+        AttributesFromZuora.dynamoAndZuoraAgree(fromDynamo, fromZuora, testId) must be_==(true)
       }
 
       "return false when dynamo is outdated and does not match zuora" in {
         val fromDynamo = Some(supporterDynamoAttributes)
         val fromZuora = Some(asZuoraAttributes(friendAttributes))
 
-        attributesFromZuora.dynamoAndZuoraAgree(fromDynamo, fromZuora, testId) must be_==(false)
+        AttributesFromZuora.dynamoAndZuoraAgree(fromDynamo, fromZuora, testId) must be_==(false)
       }
 
       "return false if dynamo is none and zuora has attributes" in {
         val fromDynamo = None
         val fromZuora = Some(asZuoraAttributes(supporterDynamoAttributes))
 
-        attributesFromZuora.dynamoAndZuoraAgree(fromDynamo, fromZuora, testId) must be_==(false)
+        AttributesFromZuora.dynamoAndZuoraAgree(fromDynamo, fromZuora, testId) must be_==(false)
       }
 
       "return true if dynamo is none and attributes from zuora is also none" in {
         val fromDynamo = None
         val fromZuora = None
 
-        attributesFromZuora.dynamoAndZuoraAgree(fromDynamo, fromZuora, testId) must be_==(true)
+        AttributesFromZuora.dynamoAndZuoraAgree(fromDynamo, fromZuora, testId) must be_==(true)
       }
     }
 
     "dynamoUpdateRequired" should {
       "return true if there is no existing timestamp in the Dynamo attributes" in {
-        val updateRequired = attributesFromZuora.dynamoUpdateRequired(Some(supporterDynamoAttributes), Some(asZuoraAttributes(supporterDynamoAttributes)), supporterDynamoAttributes.UserId, twoWeeksFromReferenceDate)
+        val updateRequired = dynamoUpdateRequired(Some(supporterDynamoAttributes), Some(asZuoraAttributes(supporterDynamoAttributes)), supporterDynamoAttributes.UserId, twoWeeksFromReferenceDate)
         updateRequired must be_==(true)
       }
 
       "return true if the timestamp is old" in {
         val tooOld = toDynamoTtl(twoWeeksFromReferenceDate.minusDays(14))
-        val updateRequired = attributesFromZuora.dynamoUpdateRequired(dynamoAttributes = Some(supporterDynamoAttributes.copy(TTLTimestamp = tooOld)), Some(asZuoraAttributes(supporterDynamoAttributes)), supporterDynamoAttributes.UserId, twoWeeksFromReferenceDate)
+        val updateRequired = dynamoUpdateRequired(dynamoAttributes = Some(supporterDynamoAttributes.copy(TTLTimestamp = tooOld)), Some(asZuoraAttributes(supporterDynamoAttributes)), supporterDynamoAttributes.UserId, twoWeeksFromReferenceDate)
 
         updateRequired must be_==(true)
       }
@@ -317,20 +317,20 @@ class attributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
         val dynamoAttributes = Some(supporterDynamoAttributes.copy(TTLTimestamp = recentEnough))
         val zuoraAttributes = Some(asZuoraAttributes(friendAttributes))
 
-        val updateRequired = attributesFromZuora.dynamoUpdateRequired(dynamoAttributes, zuoraAttributes, "123", twoWeeksFromReferenceDate)
+        val updateRequired = dynamoUpdateRequired(dynamoAttributes, zuoraAttributes, "123", twoWeeksFromReferenceDate)
 
         updateRequired must be_==(true)
       }
 
       "return false if zuora and dynamo agree and the timestamp is recent enough" in {
         val recentEnough = toDynamoTtl(twoWeeksFromReferenceDate.minusHours(14))
-        val updateRequired = attributesFromZuora.dynamoUpdateRequired(dynamoAttributes = Some(supporterDynamoAttributes.copy(TTLTimestamp = recentEnough)), Some(asZuoraAttributes(supporterDynamoAttributes)), supporterDynamoAttributes.UserId, twoWeeksFromReferenceDate)
+        val updateRequired = dynamoUpdateRequired(dynamoAttributes = Some(supporterDynamoAttributes.copy(TTLTimestamp = recentEnough)), Some(asZuoraAttributes(supporterDynamoAttributes)), supporterDynamoAttributes.UserId, twoWeeksFromReferenceDate)
 
         updateRequired must be_==(false)
       }
 
       "return false if there are no attributes in Zuora or Dynamo" in {
-        val updateRequired = attributesFromZuora.dynamoUpdateRequired(None, None, supporterDynamoAttributes.UserId, twoWeeksFromReferenceDate)
+        val updateRequired = dynamoUpdateRequired(None, None, supporterDynamoAttributes.UserId, twoWeeksFromReferenceDate)
         updateRequired must be_==(false)
       }
 


### PR DESCRIPTION
Reverts guardian/members-data-api#292
we are seeing some issues in the log with the update card functionality so we are going back to play 2.5 while we investigate
