### PR TITLE
Revert "update to Play 2 6"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,9 +43,10 @@ lazy val dynamoDBLocalSettings = Seq(
   testOptions in Test += (dynamoDBLocalTestCleanup).value
 )
 
-import com.typesafe.sbt.packager.archetypes.systemloader.ServerLoader.Systemd
+import com.typesafe.sbt.packager.archetypes.ServerLoader.Systemd
+
 val buildDebSettings = Seq(
-  serverLoading in Debian := Some(Systemd),
+  serverLoading in Debian := Systemd,
   debianPackageDependencies := Seq("openjdk-8-jre-headless"),
   maintainer := "Membership Dev <membership.dev@theguardian.com>",
   packageSummary := "Members Data API",
@@ -65,7 +66,7 @@ val buildDebSettings = Seq(
 )
 
 def lib(name: String) = Project(name, file(name))
-  .enablePlugins(SystemdPlugin, PlayScala, BuildInfoPlugin, RiffRaffArtifact, JDebPackaging).settings(commonSettings)
+  .enablePlugins(PlayScala, BuildInfoPlugin, RiffRaffArtifact, JDebPackaging).settings(commonSettings)
 
 def app(name: String) = lib(name)
   .settings(dynamoDBLocalSettings)

--- a/membership-attribute-service/app/actions/CommonActions.scala
+++ b/membership-attribute-service/app/actions/CommonActions.scala
@@ -1,27 +1,21 @@
 package actions
-import akka.stream.Materializer
 import components.{TouchpointBackends, TouchpointComponents}
 import controllers.NoCache
-import play.api.http.{DefaultHttpErrorHandler, ParserConfiguration}
-import play.api.libs.Files.SingletonTemporaryFileCreator
 import play.api.mvc._
-import scala.concurrent.{ExecutionContext, Future}
-import play.filters.cors.{CORSActionBuilder, CORSConfig}
+import scala.concurrent.Future
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
-class CommonActions(touchpointBackends: TouchpointBackends, bodyParser: BodyParser[AnyContent])(implicit ex: ExecutionContext, mat:Materializer) {
+class CommonActions(touchpointBackends: TouchpointBackends) {
   def noCache(result: Result): Result = NoCache(result)
 
   val NoCacheAction = resultModifier(noCache)
-  val BackendFromCookieAction = NoCacheAction andThen new WithBackendFromCookieAction(touchpointBackends, ex)
 
-  private def resultModifier(f: Result => Result) = new ActionBuilder[Request, AnyContent] {
-    override val parser = bodyParser
-    override val executionContext = ex
+  val BackendFromCookieAction = NoCacheAction andThen new WithBackendFromCookieAction(touchpointBackends)
+
+  private def resultModifier(f: Result => Result) = new ActionBuilder[Request] {
     def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) = block(request).map(f)
   }
-
-  def CORSFilter(corsConfig:CORSConfig) = CORSActionBuilder(corsConfig, DefaultHttpErrorHandler, ParserConfiguration() , SingletonTemporaryFileCreator)
-
 }
 
 class BackendRequest[A](val touchpoint: TouchpointComponents, request: Request[A]) extends WrappedRequest[A](request)
+

--- a/membership-attribute-service/app/actions/WithBackendFromCookieAction.scala
+++ b/membership-attribute-service/app/actions/WithBackendFromCookieAction.scala
@@ -4,13 +4,11 @@ import components.TouchpointBackends
 import configuration.Config
 import play.api.mvc.{ActionRefiner, Request, Result}
 import services.IdentityAuthService
-
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
 
-class WithBackendFromCookieAction(touchpointBackends: TouchpointBackends, ex: ExecutionContext) extends ActionRefiner[Request, BackendRequest] {
-  override val executionContext = ex
+class WithBackendFromCookieAction(touchpointBackends: TouchpointBackends) extends ActionRefiner[Request, BackendRequest] {
   override protected def refine[A](request: Request[A]): Future[Either[Result, BackendRequest[A]]] = Future {
     val firstName = IdentityAuthService.username(request).flatMap(_.split(' ').headOption) //Identity checks for test users by first name
     val exists = firstName.exists(Config.testUsernames.isValid)

--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -76,7 +76,7 @@ class TouchpointComponents(stage: String)(implicit system: ActorSystem) {
   implicit lazy val simpleClient: SimpleClient[Future] = new SimpleClient[Future](tpConfig.zuoraRest, ZuoraRequestCounter.withZuoraRequestCounter(RequestRunners.futureRunner))
   lazy val zuoraRestService = new ZuoraRestService[Future]()
   lazy val catalogService = new CatalogService[Future](productIds, simpleClient, Await.result(_, 10.seconds), stage)
-  lazy val futureCatalog: Future[CatalogMap] = catalogService.catalog.map(_.fold[CatalogMap](error => {println(s"error: ${error.list.toList.mkString}"); Map()}, _.map))
+  lazy val futureCatalog: Future[CatalogMap] = catalogService.catalog.map(_.fold[CatalogMap](error => {println(s"error: ${error.list.mkString}"); Map()}, _.map))
 
   lazy val subService = new SubscriptionService[Future](productIds, futureCatalog, simpleClient, zuoraService.getAccountIds)
   lazy val paymentService = new PaymentService(zuoraService, catalogService.unsafeCatalog.productMap)

--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -10,8 +10,9 @@ import com.gu.memsub.subsv2.reads.SubPlanReads._
 import com.gu.services.model.PaymentDetails
 import com.gu.stripe.{Stripe, StripeService}
 import com.gu.zuora.api.RegionalStripeGateways
+import com.gu.zuora.rest.ZuoraResponse
 import com.typesafe.scalalogging.LazyLogging
-import components.TouchpointComponents
+import components.{TouchpointBackends, TouchpointComponents}
 import configuration.Config
 import json.PaymentCardUpdateResultWriters._
 import models.AccountDetails._
@@ -20,7 +21,12 @@ import models.ApiErrors._
 import play.api.mvc.Controller
 import play.api.data.Form
 import play.api.data.Forms._
+import play.api.http.DefaultHttpErrorHandler
 import play.api.libs.json.Json
+import play.api.mvc.Result
+import play.api.mvc.Results._
+import play.filters.cors.CORSActionBuilder
+
 import scala.concurrent.Future
 import scalaz.std.option._
 import scalaz.std.scalaFuture._
@@ -32,8 +38,8 @@ import scalaz.{-\/, EitherT, OptionT, \/, \/-, _}
 class AccountController(commonActions: CommonActions) extends Controller with LazyLogging {
   import commonActions._
   lazy val authenticationService: AuthenticationService = IdentityAuthService
-  lazy val corsMmaUpdateFilter = CORSFilter(Config.mmaUpdateCorsConfig)
-  lazy val mmaCorsFilter = CORSFilter(Config.mmaCorsConfig)
+  lazy val corsMmaUpdateFilter = CORSActionBuilder(Config.mmaUpdateCorsConfig, DefaultHttpErrorHandler)
+  lazy val mmaCorsFilter = CORSActionBuilder(Config.mmaCorsConfig, DefaultHttpErrorHandler)
   lazy val mmaAction = NoCacheAction andThen mmaCorsFilter andThen BackendFromCookieAction
   lazy val mmaUpdateAction = NoCacheAction andThen corsMmaUpdateFilter andThen BackendFromCookieAction
 

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -2,6 +2,7 @@ package controllers
 
 import actions._
 import com.gu.memsub.subsv2.SubscriptionPlan.AnyPlan
+import components.TouchpointBackends
 import configuration.Config
 import loghandling.LoggingField.{LogField, LogFieldString}
 import loghandling.{LoggingWithLogstashFields, ZuoraRequestCounter}
@@ -10,9 +11,11 @@ import models.ApiErrors._
 import models.Features._
 import models._
 import monitoring.Metrics
+import play.api.http.DefaultHttpErrorHandler
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.Json
 import play.api.mvc._
+import play.filters.cors.CORSActionBuilder
 import services.{AuthenticationService, IdentityAuthService}
 
 import scala.concurrent.Future
@@ -21,7 +24,7 @@ import services.AttributesFromZuora._
 class AttributeController(commonActions: CommonActions) extends Controller with LoggingWithLogstashFields {
 
   import commonActions._
-  lazy val corsFilter = CORSFilter(Config.corsConfig)
+  lazy val corsFilter = CORSActionBuilder(Config.corsConfig, DefaultHttpErrorHandler)
   lazy val backendAction = NoCacheAction andThen corsFilter andThen BackendFromCookieAction
   lazy val authenticationService: AuthenticationService = IdentityAuthService
   lazy val metrics = Metrics("AttributesController")

--- a/membership-attribute-service/app/controllers/BehaviourController.scala
+++ b/membership-attribute-service/app/controllers/BehaviourController.scala
@@ -2,20 +2,25 @@ package controllers
 import actions._
 import actions.CommonActions
 import com.typesafe.scalalogging.LazyLogging
+import components.{TouchpointBackends, TouchpointComponents}
 import configuration.Config
 import models.Behaviour
 import monitoring.Metrics
+import play.api.http.DefaultHttpErrorHandler
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.{AnyContent, Controller}
+import play.filters.cors.CORSActionBuilder
 import services.IdentityService.IdentityId
 import services.{AuthenticationService, IdentityAuthService, SQSAbandonedCartEmailService}
+
 import scala.concurrent.Future
 
 class BehaviourController(commonActions: CommonActions) extends Controller with LazyLogging {
 
   import commonActions._
-  lazy val corsFilter = CORSFilter(Config.corsConfig)
+
+  lazy val corsFilter = CORSActionBuilder(Config.corsConfig, DefaultHttpErrorHandler)
   lazy val backendAction = corsFilter andThen BackendFromCookieAction
   lazy val authenticationService: AuthenticationService = IdentityAuthService
   lazy val metrics = Metrics("BehaviourController")

--- a/membership-attribute-service/app/controllers/HealthCheckController.scala
+++ b/membership-attribute-service/app/controllers/HealthCheckController.scala
@@ -1,5 +1,6 @@
 package controllers
 
+
 import play.api.libs.json.Json
 import play.api.mvc.{Action, Results}
 import components.TouchpointBackends

--- a/membership-attribute-service/app/filters/AddEC2InstanceHeader.scala
+++ b/membership-attribute-service/app/filters/AddEC2InstanceHeader.scala
@@ -1,8 +1,11 @@
 package filters
 
+import javax.inject.Inject
+
 import akka.stream.Materializer
+import play.api.Play.current
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
-import play.api.libs.ws.{WSClient}
+import play.api.libs.ws.{WS, WSClient}
 import play.api.mvc._
 
 import scala.concurrent.Future

--- a/membership-attribute-service/app/json/package.scala
+++ b/membership-attribute-service/app/json/package.scala
@@ -1,25 +1,19 @@
-import org.joda.time.LocalDate
 import play.api.libs.functional.syntax._
 import play.api.libs.json.{OWrites, Writes, _}
 
 
 package object json {
-
   // Adapted from http://kailuowang.blogspot.co.uk/2013/11/addremove-fields-to-plays-default-case.html
   implicit class RichOWrites[A](writes: OWrites[A]) {
     def addField[T: Writes](fieldName: String, field: A => T): OWrites[A] =
-      (writes ~ (__ \ fieldName).write[T]) ((a: A) => (a, field(a)))
+      (writes ~ (__ \ fieldName).write[T])((a: A) => (a, field(a)))
 
     def addNullableField[T: Writes](fieldName: String, field: A => Option[T]): OWrites[A] =
-      (writes ~ (__ \ fieldName).writeNullable[T]) ((a: A) => (a, field(a)))
+      (writes ~ (__ \ fieldName).writeNullable[T])((a: A) => (a, field(a)))
 
     def removeField(fieldName: String): OWrites[A] = OWrites { a: A =>
       val transformer = (__ \ fieldName).json.prune
       Json.toJson(a)(writes).validate(transformer).get
     }
-  }
-
-  implicit val localDateWrites = new Writes[LocalDate] {
-    override def writes(d: LocalDate) = JsString(d.toString("yyyy-MM-dd"))
   }
 }

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -2,12 +2,10 @@ package models
 import com.gu.memsub.{GoCardless, PayPalMethod, PaymentCard}
 import com.gu.salesforce._
 import com.gu.services.model._
-import json.localDateWrites
 import play.api.libs.json._
 import play.api.mvc.Results.Ok
 
 object AccountDetails {
-
   implicit class ResultLike(details: (Contact, PaymentDetails, String)) {
 
     def toResult = {

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -7,7 +7,7 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import play.api.mvc.Result
 import play.api.mvc.Results.Ok
-import json.localDateWrites
+
 import scala.language.implicitConversions
 import scalaz.syntax.std.boolean._
 import json._
@@ -15,7 +15,6 @@ import json._
 case class ContentAccess(member: Boolean, paidMember: Boolean, recurringContributor: Boolean, digitalPack: Boolean)
 
 object ContentAccess {
-
   implicit val jsWrite = Json.writes[ContentAccess]
 }
 

--- a/membership-attribute-service/app/models/Features.scala
+++ b/membership-attribute-service/app/models/Features.scala
@@ -1,10 +1,10 @@
 package models
 
 import org.joda.time.LocalDate
-import play.api.libs.json.{Json}
+import play.api.libs.json.Json
 import play.api.mvc.Result
 import play.api.mvc.Results.Ok
-import json.localDateWrites
+
 import scala.language.implicitConversions
 
 object Features {

--- a/membership-attribute-service/app/services/AttributesMaker.scala
+++ b/membership-attribute-service/app/services/AttributesMaker.scala
@@ -15,7 +15,7 @@ class AttributesMaker extends LazyLogging {
   def zuoraAttributes(identityId: String, subs: List[Subscription[AnyPlan]], forDate: LocalDate): Option[ZuoraAttributes] = {
 
     def getCurrentPlans(subscription: Subscription[AnyPlan]): List[AnyPlan] = {
-      GetCurrentPlans(subscription, forDate).map(_.list.toList).toList.flatten  // it's expected that users may not have any current plans
+      GetCurrentPlans(subscription, forDate).map(_.list).toList.flatten  // it's expected that users may not have any current plans
     }
     def getTopProduct(subscription: Subscription[AnyPlan]): Option[Product] = {
       getCurrentPlans(subscription).headOption.map(_.product)
@@ -24,7 +24,7 @@ class AttributesMaker extends LazyLogging {
       getCurrentPlans(subscription).headOption.map(_.name)
     }
     def getAllBenefits(subscription: Subscription[AnyPlan]): Set[Benefit] = {
-      getCurrentPlans(subscription).flatMap(_.charges.benefits.list.toList).toSet
+      getCurrentPlans(subscription).flatMap(_.charges.benefits.list).toSet
     }
 
     val groupedSubs: Map[Option[Product], List[Subscription[AnyPlan]]] = subs.groupBy(getTopProduct)

--- a/membership-attribute-service/app/wiring/AppLoader.scala
+++ b/membership-attribute-service/app/wiring/AppLoader.scala
@@ -31,7 +31,7 @@ class MyComponents(context: Context)
     with CSRFComponents {
 
   val touchPointBackends = new TouchpointBackends(actorSystem)
-  val commonActions = new CommonActions(touchPointBackends, defaultBodyParser)
+  val commonActions = new CommonActions(touchPointBackends)
   override lazy val httpErrorHandler: ErrorHandler =
     new ErrorHandler(environment, configuration, sourceMapper, Some(router))
 

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -2,7 +2,6 @@ package controllers
 
 import actions.{BackendRequest, CommonActions}
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import components.{TouchpointBackends, TouchpointComponents}
 import configuration.Config
 import models.Attributes
@@ -12,7 +11,7 @@ import org.specs2.specification.AfterAll
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.Json
 import play.api.mvc._
-import play.api.test._
+import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import services.AuthenticationService
 
@@ -48,7 +47,6 @@ class AttributeControllerTest extends Specification with AfterAll {
 
   // Succeeds for the valid user id
   private object FakeWithBackendAction extends ActionRefiner[Request, BackendRequest] {
-    override val executionContext = scala.concurrent.ExecutionContext.global
     override protected def refine[A](request: Request[A]): Future[Either[Result, BackendRequest[A]]] = {
 
       object components extends TouchpointComponents(Config.defaultTouchpointBackendStage)
@@ -59,8 +57,7 @@ class AttributeControllerTest extends Specification with AfterAll {
 
   private val actorSystem = ActorSystem()
   private val touchpointBackends = new TouchpointBackends(actorSystem)
-  private val stubParser = Helpers.stubBodyParser(AnyContent("test"))
-  private val commonActions = new CommonActions(touchpointBackends, stubParser)(scala.concurrent.ExecutionContext.global, ActorMaterializer())
+  private val commonActions = new CommonActions(touchpointBackends)
   private val controller = new AttributeController(commonActions) {
 
     override lazy val authenticationService = fakeAuthService

--- a/membership-attribute-service/test/testdata/SubscriptionTestData.scala
+++ b/membership-attribute-service/test/testdata/SubscriptionTestData.scala
@@ -46,7 +46,7 @@ trait SubscriptionTestData {
       promoCode = None,
       isCancelled = isCancelled,
       hasPendingFreePlan = false,
-      plans = CovariantNonEmptyList(plans.head, plans.tail.toList),
+      plans = plans,
       readerType = ReaderType.Direct,
       autoRenew = true
     )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,8 +7,8 @@ object Dependencies {
   val awsClientVersion = "1.11.226"
   //libraries
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "8.0.3"
-  val identityCookie = "com.gu.identity" %% "identity-cookie" % "3.80"
-  val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "2.1"
+  val identityCookie = "com.gu.identity" %% "identity-cookie" % "3.51"
+  val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "0.18"
   val identityTestUsers =  "com.gu" %% "identity-test-users" % "0.6"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.13"
   val playWS = PlayImport.ws
@@ -19,8 +19,8 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.497"
-  val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.7"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.492"
+  val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.0"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"
   val jacksonCbor = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % "2.8.7"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,13 +3,13 @@ logLevel := Level.Warn
 
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.11")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.18")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
 
 addSbtPlugin("com.localytics" % "sbt-dynamodb" % "1.5.3")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.2")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.6")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.7")
 


### PR DESCRIPTION
Reverts guardian/members-data-api#291
We are seeing some issues in the log with the update card functionality so we are going back to play 2.5 while we investigate