### PR TITLE
enable encrypted ami

### DIFF
--- a/membership-attribute-service/conf/riff-raff.yaml
+++ b/membership-attribute-service/conf/riff-raff.yaml
@@ -8,6 +8,7 @@ deployments:
       amiTags:
         Recipe: xenial-membership
         AmigoStage: PROD
+      amiEncrypted: true
       amiParameter: AmiId
   membership-attribute-service:
     type: autoscaling


### PR DESCRIPTION
now that everything is setup in the membership account for xenial-membership AMIs we can just enable it in the deployment descriptor.

Tested it in CODE and it seems to work fine. 

@jacobwinch, do you think we should test it in a less important app first ?