### PR TITLE
Remove CFN references to old Dynamo Tables

### DIFF
--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -71,8 +71,6 @@ Mappings:
     PROD:
       NotificationAlarmPeriod: 1200
       InstanceName: PROD:membership-attribute-service
-      DynamoDBUnencryptedTable: arn:aws:dynamodb:*:*:table/MembershipAttributes-PROD
-      DynamoDBUnencryptedTableTestUsers: arn:aws:dynamodb:*:*:table/MembershipAttributes-UAT
       DynamoDBTable: "Memb-Attributes-Tables-PROD-SupporterAttributesFallback"
       DynamoDBTableTestUsers: "Memb-Attributes-Tables-UAT-SupporterAttributesFallback"
       DynamoDBBehaviourTable: arn:aws:dynamodb:*:*:table/MembershipBehaviour-PROD
@@ -83,8 +81,6 @@ Mappings:
     CODE:
       NotificationAlarmPeriod: 1200
       InstanceName: CODE:membership-attribute-service
-      DynamoDBUnencryptedTable: arn:aws:dynamodb:*:*:table/MembershipAttributes-DEV
-      DynamoDBUnencryptedTableTestUsers: arn:aws:dynamodb:*:*:table/MembershipAttributes-UAT
       DynamoDBTable: "Memb-Attributes-Tables-DEV-SupporterAttributesFallback"
       DynamoDBTableTestUsers: "Memb-Attributes-Tables-UAT-SupporterAttributesFallback"
       DynamoDBBehaviourTable: arn:aws:dynamodb:*:*:table/MembershipBehaviour-DEV
@@ -120,26 +116,6 @@ Resources:
             Effect: Allow
           - Action: ec2:DescribeTags
             Resource: "*"
-            Effect: Allow
-          - Action:
-              - dynamodb:PutItem
-              - dynamodb:GetItem
-              - dynamodb:UpdateItem
-              - dynamodb:DeleteItem
-              - dynamodb:BatchGetItem
-              - dynamodb:DescribeTable
-            Resource:
-                Fn::FindInMap: [ StageVariables, { Ref: Stage }, DynamoDBUnencryptedTable ]
-            Effect: Allow
-          - Action:
-            - dynamodb:PutItem
-            - dynamodb:GetItem
-            - dynamodb:UpdateItem
-            - dynamodb:DeleteItem
-            - dynamodb:BatchGetItem
-            - dynamodb:DescribeTable
-            Resource:
-                Fn::FindInMap: [ StageVariables, { Ref: Stage }, DynamoDBUnencryptedTableTestUsers ]
             Effect: Allow
           - Action:
             - dynamodb:PutItem


### PR DESCRIPTION
### Why do we need this?
We started using a new Dynamo table as the fallback in https://github.com/guardian/members-data-api/pull/299, but we left the old policies in place so that we could roll back quickly in the event of a problem.

If we are still happy with this change on Monday morning then we should merge this PR and tidy up the Cloudformation template.

### The changes
* Delete unused mappings
* Delete unused policies

## To do
- [x] Delete MembershipAttributes-DEV table
- [x] Delete MembershipAttributes-UAT table
- [x] Delete MembershipAttributes-PROD table
- [x] Delete encrypted backup of MembershipAttributes table from S3