### PR TITLE
On calls to /me, determine if there is an action available for a user with a membership 

### DIFF
--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -17,8 +17,9 @@ import com.gu.stripe.StripeService
 import com.gu.touchpoint.TouchpointBackendConfig
 import com.gu.zuora.api.{InvoiceTemplate, InvoiceTemplates, PaymentGateway}
 import com.gu.zuora.rest.SimpleClient
+import com.gu.zuora.rest.ZuoraRestService
 import com.gu.zuora.soap.ClientWithFeatureSupplier
-import com.gu.zuora.{ZuoraRestService, ZuoraService}
+import com.gu.zuora.ZuoraSoapService
 import configuration.Config
 import loghandling.ZuoraRequestCounter
 import prodtest.FeatureToggleDataUpdatedOnSchedule
@@ -72,7 +73,7 @@ class TouchpointComponents(stage: String)(implicit system: ActorSystem) {
   lazy val attrService: AttributeService = new ScanamoAttributeService(dynamoClientBuilder.build(), dynamoAttributesTable)
   lazy val behaviourService: BehaviourService = new ScanamoBehaviourService(dynamoClientBuilder.build(), dynamoBehaviourTable)
   lazy val featureToggleService: FeatureToggleService = new ScanamoFeatureToggleService(dynamoClientBuilder.build(), dynamoFeatureToggleTable)
-  lazy val zuoraService = new ZuoraService(soapClient)
+  lazy val zuoraService = new ZuoraSoapService(soapClient)
   implicit lazy val simpleClient: SimpleClient[Future] = new SimpleClient[Future](tpConfig.zuoraRest, ZuoraRequestCounter.withZuoraRequestCounter(RequestRunners.futureRunner))
   lazy val zuoraRestService = new ZuoraRestService[Future]()
   lazy val catalogService = new CatalogService[Future](productIds, simpleClient, Await.result(_, 10.seconds), stage)

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -34,6 +34,7 @@ class AttributeController(commonActions: CommonActions) extends Controller with 
         identityIdToAccountIds = request.touchpoint.zuoraRestService.getAccounts,
         subscriptionsForAccountId = accountId => reads => request.touchpoint.subService.subscriptionsForAccountId[AnyPlan](accountId)(reads),
         dynamoAttributeService = dynamoService,
+        paymentMethodForPaymentMethodId = paymentMethodId => request.touchpoint.zuoraRestService.getPaymentMethod(paymentMethodId.get),
         accountSummaryForAccountId = request.touchpoint.zuoraRestService.getAccount
       )
     } else {

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -33,7 +33,8 @@ class AttributeController(commonActions: CommonActions) extends Controller with 
         identityId = identityId,
         identityIdToAccountIds = request.touchpoint.zuoraRestService.getAccounts,
         subscriptionsForAccountId = accountId => reads => request.touchpoint.subService.subscriptionsForAccountId[AnyPlan](accountId)(reads),
-        dynamoAttributeService = dynamoService
+        dynamoAttributeService = dynamoService,
+        accountSummaryForAccountId = request.touchpoint.zuoraRestService.getAccount
       )
     } else {
       val attributes: Future[Option[Attributes]] = dynamoService.get(identityId) map { maybeDynamoAttributes => maybeDynamoAttributes.map(DynamoAttributes.asAttributes(_))}

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -52,7 +52,7 @@ class AttributeController(commonActions: CommonActions) extends Controller with 
             def customFields(supporterType: String): List[LogField] = List(LogFieldString("lookup-endpoint-description", endpointDescription), LogFieldString("supporter-type", supporterType), LogFieldString("data-source", fromWhere))
 
             attributes match {
-              case Some(attrs @ Attributes(_, Some(tier), _, _, _, _, _)) =>
+              case Some(attrs @ Attributes(_, Some(tier), _, _, _, _, _, _)) =>
                 logInfoWithCustomFields(s"$identityId is a $tier member - $endpointDescription - $attrs found via $fromWhere", customFields("member"))
                 onSuccessMember(attrs).withHeaders(
                   "X-Gu-Membership-Tier" -> tier,

--- a/membership-attribute-service/app/models/AccountWithSubscription.scala
+++ b/membership-attribute-service/app/models/AccountWithSubscription.scala
@@ -4,4 +4,4 @@ import com.gu.memsub.subsv2.Subscription
 import com.gu.memsub.subsv2.SubscriptionPlan.AnyPlan
 import com.gu.zuora.rest.ZuoraRestService.AccountSummary
 
-case class CustomerAccount(account: AccountSummary, subscription: Option[Subscription[AnyPlan]])
+case class AccountWithSubscription(account: AccountSummary, subscription: Option[Subscription[AnyPlan]])

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -27,7 +27,7 @@ case class Attributes(
   DigitalSubscriptionExpiryDate: Option[LocalDate] = None,
   MembershipNumber: Option[String] = None,
   AdFree: Option[Boolean] = None,
-  actionAvailableFor: Option[String] = None) {
+  ActionAvailableFor: Option[String] = None) {
   lazy val isFriendTier = Tier.exists(_.equalsIgnoreCase("friend"))
   lazy val isSupporterTier = Tier.exists(_.equalsIgnoreCase("supporter"))
   lazy val isPartnerTier = Tier.exists(_.equalsIgnoreCase("partner"))
@@ -50,7 +50,7 @@ case class ZuoraAttributes(
   RecurringContributionPaymentPlan: Option[String] = None,
   MembershipJoinDate: Option[LocalDate] = None,
   DigitalSubscriptionExpiryDate: Option[LocalDate] = None,
-  actionAvailableFor: Option[String] = None)
+  ActionAvailableFor: Option[String] = None)
 
 case class DynamoAttributes(
   UserId: String,

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -27,7 +27,7 @@ case class Attributes(
   DigitalSubscriptionExpiryDate: Option[LocalDate] = None,
   MembershipNumber: Option[String] = None,
   AdFree: Option[Boolean] = None,
-  ActionAvailableFor: Option[String] = None) {
+  AlertAvailableFor: Option[String] = None) {
   lazy val isFriendTier = Tier.exists(_.equalsIgnoreCase("friend"))
   lazy val isSupporterTier = Tier.exists(_.equalsIgnoreCase("supporter"))
   lazy val isPartnerTier = Tier.exists(_.equalsIgnoreCase("partner"))
@@ -50,7 +50,7 @@ case class ZuoraAttributes(
   RecurringContributionPaymentPlan: Option[String] = None,
   MembershipJoinDate: Option[LocalDate] = None,
   DigitalSubscriptionExpiryDate: Option[LocalDate] = None,
-  ActionAvailableFor: Option[String] = None)
+  AlertAvailableFor: Option[String] = None)
 
 case class DynamoAttributes(
   UserId: String,
@@ -91,7 +91,7 @@ object Attributes {
       (__ \ "digitalSubscriptionExpiryDate").writeNullable[LocalDate] and
       (__ \ "membershipNumber").writeNullable[String] and
       (__ \ "adFree").writeNullable[Boolean] and
-      (__ \ "actionAvailableFor").writeNullable[String]
+      (__ \ "alertAvailableFor").writeNullable[String]
   )(unlift(Attributes.unapply))
     .addNullableField("digitalSubscriptionExpiryDate", _.latestDigitalSubscriptionExpiryDate)
     .addField("contentAccess", _.contentAccess)

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -26,7 +26,8 @@ case class Attributes(
   MembershipJoinDate: Option[LocalDate] = None,
   DigitalSubscriptionExpiryDate: Option[LocalDate] = None,
   MembershipNumber: Option[String] = None,
-  AdFree: Option[Boolean] = None) {
+  AdFree: Option[Boolean] = None,
+  actionAvailableFor: Option[String] = None) {
   lazy val isFriendTier = Tier.exists(_.equalsIgnoreCase("friend"))
   lazy val isSupporterTier = Tier.exists(_.equalsIgnoreCase("supporter"))
   lazy val isPartnerTier = Tier.exists(_.equalsIgnoreCase("partner"))
@@ -48,7 +49,8 @@ case class ZuoraAttributes(
   Tier: Option[String] = None,
   RecurringContributionPaymentPlan: Option[String] = None,
   MembershipJoinDate: Option[LocalDate] = None,
-  DigitalSubscriptionExpiryDate: Option[LocalDate] = None)
+  DigitalSubscriptionExpiryDate: Option[LocalDate] = None,
+  actionAvailableFor: Option[String] = None)
 
 case class DynamoAttributes(
   UserId: String,
@@ -88,7 +90,8 @@ object Attributes {
       (__ \ "membershipJoinDate").writeNullable[LocalDate] and
       (__ \ "digitalSubscriptionExpiryDate").writeNullable[LocalDate] and
       (__ \ "membershipNumber").writeNullable[String] and
-      (__ \ "adFree").writeNullable[Boolean]
+      (__ \ "adFree").writeNullable[Boolean] and
+      (__ \ "actionAvailableFor").writeNullable[String]
   )(unlift(Attributes.unapply))
     .addNullableField("digitalSubscriptionExpiryDate", _.latestDigitalSubscriptionExpiryDate)
     .addField("contentAccess", _.contentAccess)

--- a/membership-attribute-service/app/models/CustomerAccount.scala
+++ b/membership-attribute-service/app/models/CustomerAccount.scala
@@ -1,0 +1,7 @@
+package models
+
+import com.gu.memsub.subsv2.Subscription
+import com.gu.memsub.subsv2.SubscriptionPlan.AnyPlan
+import com.gu.zuora.rest.ZuoraRestService.AccountSummary
+
+case class CustomerAccount(account: AccountSummary, subscription: Option[Subscription[AnyPlan]])

--- a/membership-attribute-service/app/services/AttributesFromZuora.scala
+++ b/membership-attribute-service/app/services/AttributesFromZuora.scala
@@ -18,14 +18,14 @@ import scalaz.{-\/, Disjunction, EitherT, \/, \/-, _}
 
 class AttributesFromZuora(implicit val executionContext: ExecutionContext) extends LoggingWithLogstashFields {
 
-  def getAttributes(identityId: String,
-                    identityIdToAccountIds: String => Future[String \/ QueryResponse],
-                    subscriptionsForAccountId: AccountId => SubPlanReads[AnyPlan] => Future[Disjunction[String, List[Subscription[AnyPlan]]]],
-                    accountSummaryForAccountId: AccountId => Future[\/[String, AccountSummary]],
-                    paymentMethodForPaymentMethodId: PaymentMethodId => Future[\/[String, PaymentMethodResponse]],
-                    dynamoAttributeService: AttributeService,
-                    forDate: LocalDate = LocalDate.now()): Future[(String, Option[Attributes])] = {
-
+  def getAttributes(
+     identityId: String,
+     identityIdToAccountIds: String => Future[String \/ QueryResponse],
+     subscriptionsForAccountId: AccountId => SubPlanReads[AnyPlan] => Future[Disjunction[String, List[Subscription[AnyPlan]]]],
+     accountSummaryForAccountId: AccountId => Future[\/[String, AccountSummary]],
+     paymentMethodForPaymentMethodId: PaymentMethodId => Future[\/[String, PaymentMethodResponse]],
+     dynamoAttributeService: AttributeService,
+     forDate: LocalDate = LocalDate.now()): Future[(String, Option[Attributes])] = {
 
     def twoWeekExpiry = forDate.toDateTimeAtStartOfDay.plusDays(14)
 
@@ -143,9 +143,10 @@ class AttributesFromZuora(implicit val executionContext: ExecutionContext) exten
     }
   }
 
-  def getSubscriptions(accountSummaries: List[AccountSummary],
-                       identityId: String,
-                       subscriptionsForAccountId: AccountId => SubPlanReads[AnyPlan] => Future[Disjunction[String, List[Subscription[AnyPlan]]]]): Future[Disjunction[String, List[CustomerAccount]]] = {
+  def getSubscriptions(
+    accountSummaries: List[AccountSummary],
+    identityId: String,
+    subscriptionsForAccountId: AccountId => SubPlanReads[AnyPlan] => Future[Disjunction[String, List[Subscription[AnyPlan]]]]): Future[Disjunction[String, List[CustomerAccount]]] = {
 
     def subWithAccount(accountSummary: AccountSummary)(implicit reads: SubPlanReads[AnyPlan]): Future[Disjunction[String, CustomerAccount]] = subscriptionsForAccountId(accountSummary.id)(anyPlanReads) map { maybeSub =>
        maybeSub map {subList => CustomerAccount(accountSummary, subList.headOption)}

--- a/membership-attribute-service/app/services/AttributesFromZuora.scala
+++ b/membership-attribute-service/app/services/AttributesFromZuora.scala
@@ -5,7 +5,7 @@ import com.gu.memsub.subsv2.SubscriptionPlan.AnyPlan
 import com.gu.memsub.subsv2.reads.SubPlanReads
 import com.gu.memsub.subsv2.reads.SubPlanReads.anyPlanReads
 import com.gu.scanamo.error.DynamoReadError
-import com.gu.zuora.ZuoraRestService.QueryResponse
+import com.gu.zuora.rest.ZuoraRestService.QueryResponse
 import loghandling.LoggingField.LogField
 import loghandling.{LoggingWithLogstashFields, ZuoraRequestCounter}
 import models.{Attributes, DynamoAttributes, ZuoraAttributes}

--- a/membership-attribute-service/app/services/AttributesMaker.scala
+++ b/membership-attribute-service/app/services/AttributesMaker.scala
@@ -17,7 +17,9 @@ import scalaz.syntax.std.boolean._
 
 class AttributesMaker extends LazyLogging {
 
-  def zuoraAttributes(identityId: String, subs: List[Subscription[AnyPlan]], forDate: LocalDate): Option[ZuoraAttributes] = {
+  def zuoraAttributes(identityId: String, subsWithAccounts: List[(Option[Subscription[AnyPlan]], AccountSummary)], forDate: LocalDate): Option[ZuoraAttributes] = {
+
+    val subs: List[Subscription[AnyPlan]] = subsWithAccounts.map(subAccount => subAccount._1).flatten
 
     def getCurrentPlans(subscription: Subscription[AnyPlan]): List[AnyPlan] = {
       GetCurrentPlans(subscription, forDate).map(_.list.toList).toList.flatten  // it's expected that users may not have any current plans

--- a/membership-attribute-service/app/services/AttributesMaker.scala
+++ b/membership-attribute-service/app/services/AttributesMaker.scala
@@ -1,13 +1,18 @@
 package services
 
 import com.github.nscala_time.time.OrderingImplicits._
+import com.gu.memsub.Subscription.AccountId
 import com.gu.memsub.subsv2.SubscriptionPlan.AnyPlan
+import com.gu.memsub.subsv2.SubscriptionPlan.Member
 import com.gu.memsub.subsv2.{GetCurrentPlans, Subscription}
-import com.gu.memsub.{Benefit, Product}
+import com.gu.memsub.{Benefit, PaymentMethod, Product}
+import com.gu.zuora.rest.ZuoraRestService.{AccountSummary, PaymentMethodId, PaymentMethodResponse}
 import com.typesafe.scalalogging.LazyLogging
 import models.{Attributes, DynamoAttributes, ZuoraAttributes}
 import org.joda.time.LocalDate
 
+import scala.concurrent.{ExecutionContext, Future}
+import scalaz.{\/, \/-}
 import scalaz.syntax.std.boolean._
 
 class AttributesMaker extends LazyLogging {
@@ -73,6 +78,43 @@ class AttributesMaker extends LazyLogging {
           AdFree = None
         ))
       case (None, _) => None
+    }
+  }
+
+  def actionAvailableFor(accountsAndSubs: List[(AccountSummary, Subscription[AnyPlan])],
+                         paymentMethodGetter: PaymentMethodId => Future[String \/ PaymentMethodResponse])(implicit ec: ExecutionContext): Future[Option[String]] = {
+
+    def creditCard(paymentMethodResponse: PaymentMethodResponse) = paymentMethodResponse.paymentMethodType == "CreditCardReferenceTransaction" || paymentMethodResponse.paymentMethodType == "CreditCard"
+
+    def actionForSub(accountSummary: AccountSummary, sub: Subscription[AnyPlan]): Future[String \/ Option[String]] = {
+      (accountSummary, sub) match {
+        case (account, member: Subscription[Member]) => {
+          if(account.balance > 0 && account.defaultPaymentMethod.isDefined) {
+              val eventualPaymentMethod: Future[\/[String, PaymentMethodResponse]] = paymentMethodGetter(account.defaultPaymentMethod.get.id) //todo get
+              eventualPaymentMethod map { maybePaymentMethod: \/[String, PaymentMethodResponse] =>
+                maybePaymentMethod.map { pm: PaymentMethodResponse =>
+                  if(creditCard(pm) && pm.numConsecutiveFailures > 0)
+                    Some("membership")
+                  else None
+                }
+              }
+          } else Future.successful(\/.right(None))
+        }
+        case _ => Future.successful(\/.right(None))
+      }
+    }
+
+    val maybeAccountAndMembership: Option[(AccountSummary, Subscription[AnyPlan])] = accountsAndSubs.find { accountAndSub =>
+      val sub = accountAndSub._2
+      sub match {
+        case member: Subscription[Member] => true
+        case _ => false
+      }
+    }
+
+    maybeAccountAndMembership match {
+      case Some((accountSummary, membershipSub)) => actionForSub(accountSummary, membershipSub) map {(_.getOrElse(None))}
+      case None => Future.successful(None)
     }
   }
 

--- a/membership-attribute-service/app/services/AttributesMaker.scala
+++ b/membership-attribute-service/app/services/AttributesMaker.scala
@@ -54,8 +54,8 @@ class AttributesMaker {
       }
     }
 
-    maybeAlertAvailable.getOrElse(Future.successful(None)) map { maybeAction =>
-      maybeAction map { action => SafeLogger.info(s"User $identityId has an action available: $action") }
+    maybeAlertAvailable.getOrElse(Future.successful(None)) map { maybeAlert =>
+      maybeAlert map { alert => SafeLogger.info(s"User $identityId has an alert available: $alert") }
 
       hasAttributableProduct.option {
         val tier: Option[String] = membershipSub.flatMap(getCurrentPlans(_).headOption.map(_.charges.benefits.head.id))
@@ -68,7 +68,7 @@ class AttributesMaker {
           RecurringContributionPaymentPlan = recurringContributionPaymentPlan,
           MembershipJoinDate = membershipJoinDate,
           DigitalSubscriptionExpiryDate = latestDigitalPackExpiryDate,
-          //First we will just log if we have determined we have a membership action for the user. Once we assess the logs,
+          //First we will just log if we have determined we have a membership alert for the user. Once we assess the logs,
           //we can start returning the value we've calculated
           //AlertAvailableFor = maybeAlert
           AlertAvailableFor = None

--- a/membership-attribute-service/conf/logback.xml
+++ b/membership-attribute-service/conf/logback.xml
@@ -3,6 +3,14 @@
     <contextName>membership-attribute-service</contextName>
 
     <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+
+        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+            <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
+                <marker>SENTRY</marker>
+            </evaluator>
+            <onMatch>DENY</onMatch>
+        </filter>
+
         <file>logs/membership-attribute-service.log</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">

--- a/membership-attribute-service/test/services/AttributesFromZuoraTest.scala
+++ b/membership-attribute-service/test/services/AttributesFromZuoraTest.scala
@@ -5,7 +5,7 @@ import com.gu.memsub.Subscription.AccountId
 import com.gu.memsub.subsv2.SubscriptionPlan.AnyPlan
 import com.gu.memsub.subsv2.reads.SubPlanReads
 import com.gu.zuora.rest.ZuoraRestService.{AccountIdRecord, PaymentMethodId, PaymentMethodResponse, QueryResponse}
-import models.{Attributes, DynamoAttributes, ZuoraAttributes}
+import models.{Attributes, CustomerAccount, DynamoAttributes, ZuoraAttributes}
 import org.joda.time.{DateTime, LocalDate}
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mock.Mockito
@@ -241,14 +241,14 @@ class AttributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
         val anotherAccountSummary = accountSummaryWithZeroBalance.copy(id = anotherTestAccountId)
         val subscriptions = AttributesFromZuora.getSubscriptions(List(accountSummaryWithZeroBalance, anotherAccountSummary), testId, subscriptionFromAccountId)
 
-        val expected = List((Some(contributor), accountSummaryWithZeroBalance), (Some(digipack), anotherAccountSummary))
+        val expected = List(CustomerAccount(accountSummaryWithZeroBalance, Some(contributor)), CustomerAccount(anotherAccountSummary, Some(digipack)))
         subscriptions must be_==(\/.right(expected)).await
       }
 
       "get an empty list of subscriptions for a user who doesn't have any " in new accountButNoSubscriptions {
         val subscriptions = AttributesFromZuora.getSubscriptions(List(accountSummaryWithZeroBalance), testId, subscriptionFromAccountId)
 
-        subscriptions must be_==(\/.right(List((None, accountSummaryWithZeroBalance)))).await
+        subscriptions must be_==(\/.right(List(CustomerAccount(accountSummaryWithZeroBalance, None)))).await
       }
 
       "return a left with error message if the subscription service returns a left" in new errorWhenGettingSubs {

--- a/membership-attribute-service/test/services/AttributesFromZuoraTest.scala
+++ b/membership-attribute-service/test/services/AttributesFromZuoraTest.scala
@@ -5,7 +5,7 @@ import com.gu.memsub.Subscription.AccountId
 import com.gu.memsub.subsv2.SubscriptionPlan.AnyPlan
 import com.gu.memsub.subsv2.reads.SubPlanReads
 import com.gu.zuora.rest.ZuoraRestService.{AccountIdRecord, PaymentMethodId, PaymentMethodResponse, QueryResponse}
-import models.{Attributes, CustomerAccount, DynamoAttributes, ZuoraAttributes}
+import models.{Attributes, AccountWithSubscription, DynamoAttributes, ZuoraAttributes}
 import org.joda.time.{DateTime, LocalDate}
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mock.Mockito
@@ -242,14 +242,14 @@ class AttributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
         val anotherAccountSummary = accountSummaryWithZeroBalance.copy(id = anotherTestAccountId)
         val subscriptions = attributesFromZuora.getSubscriptions(List(accountSummaryWithZeroBalance, anotherAccountSummary), testId, subscriptionFromAccountId)
 
-        val expected = List(CustomerAccount(accountSummaryWithZeroBalance, Some(contributor)), CustomerAccount(anotherAccountSummary, Some(digipack)))
+        val expected = List(AccountWithSubscription(accountSummaryWithZeroBalance, Some(contributor)), AccountWithSubscription(anotherAccountSummary, Some(digipack)))
         subscriptions must be_==(\/.right(expected)).await
       }
 
       "get an empty list of subscriptions for a user who doesn't have any " in new accountButNoSubscriptions {
         val subscriptions = attributesFromZuora.getSubscriptions(List(accountSummaryWithZeroBalance), testId, subscriptionFromAccountId)
 
-        subscriptions must be_==(\/.right(List(CustomerAccount(accountSummaryWithZeroBalance, None)))).await
+        subscriptions must be_==(\/.right(List(AccountWithSubscription(accountSummaryWithZeroBalance, None)))).await
       }
 
       "return a left with error message if the subscription service returns a left" in new errorWhenGettingSubs {

--- a/membership-attribute-service/test/services/AttributesFromZuoraTest.scala
+++ b/membership-attribute-service/test/services/AttributesFromZuoraTest.scala
@@ -4,7 +4,7 @@ import com.amazonaws.services.dynamodbv2.model.DeleteItemResult
 import com.gu.memsub.Subscription.AccountId
 import com.gu.memsub.subsv2.SubscriptionPlan.AnyPlan
 import com.gu.memsub.subsv2.reads.SubPlanReads
-import com.gu.zuora.ZuoraRestService.{AccountIdRecord, QueryResponse}
+import com.gu.zuora.rest.ZuoraRestService.{AccountIdRecord, QueryResponse}
 import models.{Attributes, DynamoAttributes, ZuoraAttributes}
 import org.joda.time.{DateTime, LocalDate}
 import org.specs2.concurrent.ExecutionEnv

--- a/membership-attribute-service/test/services/AttributesMakerTest.scala
+++ b/membership-attribute-service/test/services/AttributesMakerTest.scala
@@ -119,20 +119,22 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
     }
 
     // We are currently returning actionAvailableFor = None always in AttributesMaker and just logging the value we've calculated
-    //This test should be uncommented once we resume returning the calculated value
+    //This test should be un-ignored once we resume returning the calculated value
 
-//    "return actionAvailableFor=membership for an active membership in payment failure" in {
-//      val expected = Some(ZuoraAttributes(
-//        UserId = identityId,
-//        Tier = Some("Supporter"),
-//        RecurringContributionPaymentPlan = None,
-//        MembershipJoinDate = Some(referenceDate),
-//        ActionAvailableFor = Some("membership")
-//      )
-//      )
-//      val result = AttributesMaker.zuoraAttributes(identityId, List(CustomerAccount(accountSummaryWithBalance, Some(membership))), paymentMethodResponseRecentFailure, referenceDate)
-//      result must be_==(expected).await
-//    }
+    "return actionAvailableFor=membership for an active membership in payment failure" in {
+      skipped {
+        val expected = Some(ZuoraAttributes(
+          UserId = identityId,
+          Tier = Some("Supporter"),
+          RecurringContributionPaymentPlan = None,
+          MembershipJoinDate = Some(referenceDate),
+          ActionAvailableFor = Some("membership")
+        )
+        )
+        val result = AttributesMaker.zuoraAttributes(identityId, List(CustomerAccount(accountSummaryWithBalance, Some(membership))), paymentMethodResponseRecentFailure, referenceDate)
+        result must be_==(expected).await
+      }
+    }
   }
 
 
@@ -218,6 +220,14 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
 
     "return false for a member with a balance but no failed payments" in {
       val result = AttributesMaker.actionAvailableFor(accountSummaryWithBalance, membership, paymentMethodResponseNoFailures)
+
+      result must be_==(false).await
+    }
+
+    "return false for a member who pays via paypal" in {
+      def paymentMethodResponsePaypal(paymentMethodId: PaymentMethodId) = Future.successful(\/.right(PaymentMethodResponse(1, "PayPal", DateTime.now().minusDays(1))))
+
+      val result = AttributesMaker.actionAvailableFor(accountSummaryWithBalance, membership, paymentMethodResponsePaypal)
 
       result must be_==(false).await
     }

--- a/membership-attribute-service/test/services/AttributesMakerTest.scala
+++ b/membership-attribute-service/test/services/AttributesMakerTest.scala
@@ -1,165 +1,219 @@
 package services
 
-import com.github.nscala_time.time.Implicits._
-import models.{Attributes, DynamoAttributes, ZuoraAttributes}
-import org.joda.time.LocalDate
+import com.gu.memsub.Subscription.AccountId
+import com.gu.zuora.rest.ZuoraRestService.{AccountSummary, BillToContact, DefaultPaymentMethod, PaymentMethodId, PaymentMethodResponse, SoldToContact}
+import org.joda.time.{DateTime, LocalDate}
+import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mutable.Specification
 import testdata.SubscriptionTestData
 
-class AttributesMakerTest extends Specification with SubscriptionTestData {
+import scala.concurrent.Future
+import scalaz.\/
+
+class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with SubscriptionTestData {
   override def referenceDate = new LocalDate(2016, 10, 26)
+
   val referenceDateAsDynamoTimestamp = referenceDate.toDateTimeAtStartOfDay.getMillis / 1000
+  val identityId = "123"
 
+//  "zuoraAttributes" should {
+//
+//    "return attributes when digipack sub" in {
+//      val expected = Some(ZuoraAttributes(
+//        UserId = identityId,
+//        Tier = None,
+//        RecurringContributionPaymentPlan = None,
+//        MembershipJoinDate = None,
+//        DigitalSubscriptionExpiryDate = Some(referenceDate + 1.year)
+//      ))
+//      AttributesMaker.zuoraAttributes(identityId, List(digipack), referenceDate) === expected
+//    }
+//
+//    "return attributes when one of the subs has a digital benefit" in {
+//      val expected = Some(ZuoraAttributes(
+//        UserId = identityId,
+//        Tier = None,
+//        RecurringContributionPaymentPlan = None,
+//        MembershipJoinDate = None,
+//        DigitalSubscriptionExpiryDate = Some(referenceDate + 1.year)
+//      ))
+//      AttributesMaker.zuoraAttributes(identityId, List(sunday, sundayPlus), referenceDate) === expected
+//    }
+//
+//    "return none when only sub is expired" in {
+//      AttributesMaker.zuoraAttributes(identityId, List(expiredMembership), referenceDate) === None
+//    }
+//
+//    "return attributes when there is one membership sub" in {
+//      val expected = Some(ZuoraAttributes(
+//        UserId = identityId,
+//        Tier = Some("Supporter"),
+//        RecurringContributionPaymentPlan = None,
+//        MembershipJoinDate = Some(referenceDate)
+//      )
+//      )
+//      AttributesMaker.zuoraAttributes(identityId, List(membership), referenceDate) === expected
+//    }
+//
+//    "return attributes when one sub is expired and one is not" in {
+//      val expected = Some(ZuoraAttributes(
+//        UserId = identityId,
+//        Tier = None,
+//        RecurringContributionPaymentPlan = Some("Monthly Contribution"),
+//        MembershipJoinDate = None
+//      )
+//      )
+//
+//      AttributesMaker.zuoraAttributes(identityId, List(expiredMembership, contributor), referenceDate) === expected
+//    }
+//
+//    "return attributes when one sub is a recurring contribution" in {
+//      val expected = Some(ZuoraAttributes(
+//        UserId = identityId,
+//        Tier = None,
+//        RecurringContributionPaymentPlan = Some("Monthly Contribution"),
+//        MembershipJoinDate = None
+//      )
+//      )
+//      AttributesMaker.zuoraAttributes(identityId, List(contributor), referenceDate) === expected
+//    }
+//
+//    "return attributes relevant to both when one sub is a contribution and the other a membership" in {
+//      val expected = Some(ZuoraAttributes(
+//        UserId = identityId,
+//        Tier = Some("Supporter"),
+//        RecurringContributionPaymentPlan = Some("Monthly Contribution"),
+//        MembershipJoinDate = Some(referenceDate)
+//      )
+//      )
+//      AttributesMaker.zuoraAttributes(identityId, List(contributor, membership), referenceDate) === expected
+//    }
+//
+//    "return attributes when the membership is a friend tier" in {
+//      val expected = Some(ZuoraAttributes(
+//        UserId = identityId,
+//        Tier = Some("Friend"),
+//        RecurringContributionPaymentPlan = None,
+//        MembershipJoinDate = Some(referenceDate)
+//      )
+//      )
+//      AttributesMaker.zuoraAttributes(identityId, List(friend), referenceDate) === expected
+//    }
+//  }
+//
+//
+//  "attributes" should {
+//    "return up to date Zuora attributes when they match the dynamo attributes" in {
+//      val zuoraAttributes = ZuoraAttributes(
+//        UserId = identityId,
+//        Tier = None,
+//        RecurringContributionPaymentPlan = Some("Monthly Contribution"),
+//        MembershipJoinDate = None,
+//        DigitalSubscriptionExpiryDate = None
+//      )
+//
+//      val dynamoAttributes = DynamoAttributes(
+//        UserId = identityId,
+//        Tier = None,
+//        RecurringContributionPaymentPlan = Some("Monthly Contribution"),
+//        MembershipJoinDate = None,
+//        DigitalSubscriptionExpiryDate = None,
+//        MembershipNumber = None,
+//        AdFree = None,
+//        TTLTimestamp = referenceDateAsDynamoTimestamp
+//      )
+//
+//      val expected = Some(
+//        Attributes(
+//          UserId = identityId,
+//          Tier = None,
+//          RecurringContributionPaymentPlan = Some("Monthly Contribution"),
+//          MembershipJoinDate = None,
+//          DigitalSubscriptionExpiryDate = None
+//        )
+//      )
+//
+//      val attributes = AttributesMaker.zuoraAttributesWithAddedDynamoFields(Some(zuoraAttributes), Some(dynamoAttributes))
+//
+//      attributes === expected
+//    }
+//
+//    "still return Zuora attributes when the user is not in Dynamo" in {
+//      val zuoraAttributes = ZuoraAttributes(
+//        UserId = identityId,
+//        Tier = None,
+//        RecurringContributionPaymentPlan = Some("Monthly Contribution"),
+//        MembershipJoinDate = None,
+//        DigitalSubscriptionExpiryDate = None
+//      )
+//
+//      val expected = Some(
+//        Attributes(
+//          UserId = identityId,
+//          Tier = None,
+//          RecurringContributionPaymentPlan = Some("Monthly Contribution"),
+//          MembershipJoinDate = None,
+//          DigitalSubscriptionExpiryDate = None
+//        )
+//      )
+//
+//      val attributes = AttributesMaker.zuoraAttributesWithAddedDynamoFields(Some(zuoraAttributes), None)
+//
+//      attributes === expected
+//    }
+//
+//    "return none if both Dynamo and Zuora attributes are none" in {
+//      AttributesMaker.zuoraAttributesWithAddedDynamoFields(None, None) === None
+//    }
+//
+//  }
 
-  "zuoraAttributes" should {
-    val testId = "123"
+  "actionAvailableFor" should {
+    val testAccountId = AccountId("testme")
+    val testPaymentMethodId = PaymentMethodId("testme")
 
-    "return attributes when digipack sub" in {
-      val expected = Some(ZuoraAttributes(
-        UserId = testId,
-        Tier = None,
-        RecurringContributionPaymentPlan = None,
-        MembershipJoinDate = None,
-        DigitalSubscriptionExpiryDate = Some(referenceDate + 1.year)
-      ))
-      AttributesMaker.zuoraAttributes(testId, List(digipack), referenceDate) === expected
+    def accountSummaryWith(balance: Double, paymentMethodId: PaymentMethodId, accountId: AccountId) =
+      AccountSummary(
+        id = accountId,
+        identityId = Some(identityId),
+        billToContact = BillToContact(Some("email"), None),
+        soldToContact = SoldToContact(
+          title = None,
+          firstName = Some("Joe"),
+          lastName = "Bloggs",
+          None, None, None, None, None, None
+        ),
+        currency = None,
+        balance = balance,
+        defaultPaymentMethod = Some(DefaultPaymentMethod(paymentMethodId))
+      )
+
+    val accountSummaryWithBalance = accountSummaryWith(20.0, testPaymentMethodId, testAccountId)
+    val accountSummaryWithZeroBalance = accountSummaryWith(0, testPaymentMethodId, testAccountId)
+
+    def paymentMethodResponseNoFailures(id: PaymentMethodId) = Future.successful(\/.right(PaymentMethodResponse(0, "CreditCardReferenceTransaction", referenceDate.toDateTimeAtCurrentTime)))
+    def paymentMethodResponseRecentFailure(id: PaymentMethodId) = Future.successful(\/.right(PaymentMethodResponse(1, "CreditCardReferenceTransaction", DateTime.now().minusDays(1))))
+    def paymentMethodResponseStaleFailure(id: PaymentMethodId) = Future.successful(\/.right(PaymentMethodResponse(1, "CreditCardReferenceTransaction", DateTime.now().minusMonths(2))))
+
+    "return None when no subs are a membership" in {
+      val result = AttributesMaker.actionAvailableFor(List((accountSummaryWithBalance, sunday)), paymentMethodResponseNoFailures)
+
+      result must be_==(None).await
     }
 
-    "return attributes when one of the subs has a digital benefit" in {
-      val expected = Some(ZuoraAttributes(
-        UserId = testId,
-        Tier = None,
-        RecurringContributionPaymentPlan = None,
-        MembershipJoinDate = None,
-        DigitalSubscriptionExpiryDate = Some(referenceDate + 1.year)
-      ))
-      AttributesMaker.zuoraAttributes(testId, List(sunday, sundayPlus), referenceDate) === expected
+    "return Some('membership') for a member with a failed payment in the last 27 days" in {
+      val result = AttributesMaker.actionAvailableFor(List((accountSummaryWithBalance, membership)), paymentMethodResponseRecentFailure)
+      val expected = Some("membership")
+
+      result must be_==(expected).await
     }
 
-    "return none when only sub is expired" in {
-      AttributesMaker.zuoraAttributes(testId, List(expiredMembership), referenceDate) === None
-    }
+    "return None for a member with a failed payment more than 27 days ago" in {
+      val result = AttributesMaker.actionAvailableFor(List((accountSummaryWithBalance, membership)), paymentMethodResponseStaleFailure)
 
-    "return attributes when there is one membership sub" in {
-      val expected = Some(ZuoraAttributes(
-        UserId = testId,
-        Tier = Some("Supporter"),
-        RecurringContributionPaymentPlan = None,
-        MembershipJoinDate = Some(referenceDate)
-      )
-      )
-      AttributesMaker.zuoraAttributes(testId, List(membership), referenceDate) === expected
-    }
-
-    "return attributes when one sub is expired and one is not" in {
-      val expected = Some(ZuoraAttributes(
-        UserId = testId,
-        Tier = None,
-        RecurringContributionPaymentPlan = Some("Monthly Contribution"),
-        MembershipJoinDate = None
-      )
-      )
-
-      AttributesMaker.zuoraAttributes(testId, List(expiredMembership, contributor), referenceDate) === expected
-    }
-
-    "return attributes when one sub is a recurring contribution" in {
-      val expected = Some(ZuoraAttributes(
-        UserId = testId,
-        Tier = None,
-        RecurringContributionPaymentPlan = Some("Monthly Contribution"),
-        MembershipJoinDate = None
-      )
-      )
-      AttributesMaker.zuoraAttributes(testId, List(contributor), referenceDate) === expected
-    }
-
-    "return attributes relevant to both when one sub is a contribution and the other a membership" in {
-      val expected = Some(ZuoraAttributes(
-        UserId = testId,
-        Tier = Some("Supporter"),
-        RecurringContributionPaymentPlan = Some("Monthly Contribution"),
-        MembershipJoinDate = Some(referenceDate)
-      )
-      )
-      AttributesMaker.zuoraAttributes(testId, List(contributor, membership), referenceDate) === expected
-    }
-
-    "return attributes when the membership is a friend tier" in {
-      val expected = Some(ZuoraAttributes(
-        UserId = testId,
-        Tier = Some("Friend"),
-        RecurringContributionPaymentPlan = None,
-        MembershipJoinDate = Some(referenceDate)
-      )
-      )
-      AttributesMaker.zuoraAttributes(testId, List(friend), referenceDate) === expected
-    }
-
-    "attributes" should  {
-      "return up to date Zuora attributes when they match the dynamo attributes" in {
-        val zuoraAttributes = ZuoraAttributes(
-          UserId = testId,
-          Tier = None,
-          RecurringContributionPaymentPlan = Some("Monthly Contribution"),
-          MembershipJoinDate = None,
-          DigitalSubscriptionExpiryDate = None
-        )
-
-        val dynamoAttributes = DynamoAttributes(
-          UserId = testId,
-          Tier = None,
-          RecurringContributionPaymentPlan = Some("Monthly Contribution"),
-          MembershipJoinDate = None,
-          DigitalSubscriptionExpiryDate = None,
-          MembershipNumber = None,
-          AdFree = None,
-          TTLTimestamp = referenceDateAsDynamoTimestamp
-        )
-
-        val expected = Some(
-          Attributes(
-            UserId = testId,
-            Tier = None,
-            RecurringContributionPaymentPlan = Some("Monthly Contribution"),
-            MembershipJoinDate = None,
-            DigitalSubscriptionExpiryDate = None
-          )
-        )
-
-        val attributes = AttributesMaker.zuoraAttributesWithAddedDynamoFields(Some(zuoraAttributes), Some(dynamoAttributes))
-
-        attributes === expected
-      }
-
-      "still return Zuora attributes when the user is not in Dynamo" in {
-        val zuoraAttributes = ZuoraAttributes(
-          UserId = testId,
-          Tier = None,
-          RecurringContributionPaymentPlan = Some("Monthly Contribution"),
-          MembershipJoinDate = None,
-          DigitalSubscriptionExpiryDate = None
-        )
-
-        val expected = Some(
-          Attributes(
-            UserId = testId,
-            Tier = None,
-            RecurringContributionPaymentPlan = Some("Monthly Contribution"),
-            MembershipJoinDate = None,
-            DigitalSubscriptionExpiryDate = None
-          )
-        )
-
-        val attributes = AttributesMaker.zuoraAttributesWithAddedDynamoFields(Some(zuoraAttributes), None)
-
-        attributes === expected
-      }
-
-      "return none if both Dynamo and Zuora attributes are none" in {
-        AttributesMaker.zuoraAttributesWithAddedDynamoFields(None, None) === None
-      }
+      result must be_==(None).await
     }
   }
+
 }
 

--- a/membership-attribute-service/test/services/AttributesMakerTest.scala
+++ b/membership-attribute-service/test/services/AttributesMakerTest.scala
@@ -1,7 +1,9 @@
 package services
 
+import com.github.nscala_time.time.Implicits._
 import com.gu.memsub.Subscription.AccountId
 import com.gu.zuora.rest.ZuoraRestService.{AccountSummary, BillToContact, DefaultPaymentMethod, PaymentMethodId, PaymentMethodResponse, SoldToContact}
+import models.{Attributes, DynamoAttributes, ZuoraAttributes}
 import org.joda.time.{DateTime, LocalDate}
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mutable.Specification
@@ -11,162 +13,162 @@ import scala.concurrent.Future
 import scalaz.\/
 
 class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with SubscriptionTestData {
-  override def referenceDate = new LocalDate(2016, 10, 26)
+  override def referenceDate = new LocalDate()
 
   val referenceDateAsDynamoTimestamp = referenceDate.toDateTimeAtStartOfDay.getMillis / 1000
   val identityId = "123"
 
-//  "zuoraAttributes" should {
-//
-//    "return attributes when digipack sub" in {
-//      val expected = Some(ZuoraAttributes(
-//        UserId = identityId,
-//        Tier = None,
-//        RecurringContributionPaymentPlan = None,
-//        MembershipJoinDate = None,
-//        DigitalSubscriptionExpiryDate = Some(referenceDate + 1.year)
-//      ))
-//      AttributesMaker.zuoraAttributes(identityId, List(digipack), referenceDate) === expected
-//    }
-//
-//    "return attributes when one of the subs has a digital benefit" in {
-//      val expected = Some(ZuoraAttributes(
-//        UserId = identityId,
-//        Tier = None,
-//        RecurringContributionPaymentPlan = None,
-//        MembershipJoinDate = None,
-//        DigitalSubscriptionExpiryDate = Some(referenceDate + 1.year)
-//      ))
-//      AttributesMaker.zuoraAttributes(identityId, List(sunday, sundayPlus), referenceDate) === expected
-//    }
-//
-//    "return none when only sub is expired" in {
-//      AttributesMaker.zuoraAttributes(identityId, List(expiredMembership), referenceDate) === None
-//    }
-//
-//    "return attributes when there is one membership sub" in {
-//      val expected = Some(ZuoraAttributes(
-//        UserId = identityId,
-//        Tier = Some("Supporter"),
-//        RecurringContributionPaymentPlan = None,
-//        MembershipJoinDate = Some(referenceDate)
-//      )
-//      )
-//      AttributesMaker.zuoraAttributes(identityId, List(membership), referenceDate) === expected
-//    }
-//
-//    "return attributes when one sub is expired and one is not" in {
-//      val expected = Some(ZuoraAttributes(
-//        UserId = identityId,
-//        Tier = None,
-//        RecurringContributionPaymentPlan = Some("Monthly Contribution"),
-//        MembershipJoinDate = None
-//      )
-//      )
-//
-//      AttributesMaker.zuoraAttributes(identityId, List(expiredMembership, contributor), referenceDate) === expected
-//    }
-//
-//    "return attributes when one sub is a recurring contribution" in {
-//      val expected = Some(ZuoraAttributes(
-//        UserId = identityId,
-//        Tier = None,
-//        RecurringContributionPaymentPlan = Some("Monthly Contribution"),
-//        MembershipJoinDate = None
-//      )
-//      )
-//      AttributesMaker.zuoraAttributes(identityId, List(contributor), referenceDate) === expected
-//    }
-//
-//    "return attributes relevant to both when one sub is a contribution and the other a membership" in {
-//      val expected = Some(ZuoraAttributes(
-//        UserId = identityId,
-//        Tier = Some("Supporter"),
-//        RecurringContributionPaymentPlan = Some("Monthly Contribution"),
-//        MembershipJoinDate = Some(referenceDate)
-//      )
-//      )
-//      AttributesMaker.zuoraAttributes(identityId, List(contributor, membership), referenceDate) === expected
-//    }
-//
-//    "return attributes when the membership is a friend tier" in {
-//      val expected = Some(ZuoraAttributes(
-//        UserId = identityId,
-//        Tier = Some("Friend"),
-//        RecurringContributionPaymentPlan = None,
-//        MembershipJoinDate = Some(referenceDate)
-//      )
-//      )
-//      AttributesMaker.zuoraAttributes(identityId, List(friend), referenceDate) === expected
-//    }
-//  }
-//
-//
-//  "attributes" should {
-//    "return up to date Zuora attributes when they match the dynamo attributes" in {
-//      val zuoraAttributes = ZuoraAttributes(
-//        UserId = identityId,
-//        Tier = None,
-//        RecurringContributionPaymentPlan = Some("Monthly Contribution"),
-//        MembershipJoinDate = None,
-//        DigitalSubscriptionExpiryDate = None
-//      )
-//
-//      val dynamoAttributes = DynamoAttributes(
-//        UserId = identityId,
-//        Tier = None,
-//        RecurringContributionPaymentPlan = Some("Monthly Contribution"),
-//        MembershipJoinDate = None,
-//        DigitalSubscriptionExpiryDate = None,
-//        MembershipNumber = None,
-//        AdFree = None,
-//        TTLTimestamp = referenceDateAsDynamoTimestamp
-//      )
-//
-//      val expected = Some(
-//        Attributes(
-//          UserId = identityId,
-//          Tier = None,
-//          RecurringContributionPaymentPlan = Some("Monthly Contribution"),
-//          MembershipJoinDate = None,
-//          DigitalSubscriptionExpiryDate = None
-//        )
-//      )
-//
-//      val attributes = AttributesMaker.zuoraAttributesWithAddedDynamoFields(Some(zuoraAttributes), Some(dynamoAttributes))
-//
-//      attributes === expected
-//    }
-//
-//    "still return Zuora attributes when the user is not in Dynamo" in {
-//      val zuoraAttributes = ZuoraAttributes(
-//        UserId = identityId,
-//        Tier = None,
-//        RecurringContributionPaymentPlan = Some("Monthly Contribution"),
-//        MembershipJoinDate = None,
-//        DigitalSubscriptionExpiryDate = None
-//      )
-//
-//      val expected = Some(
-//        Attributes(
-//          UserId = identityId,
-//          Tier = None,
-//          RecurringContributionPaymentPlan = Some("Monthly Contribution"),
-//          MembershipJoinDate = None,
-//          DigitalSubscriptionExpiryDate = None
-//        )
-//      )
-//
-//      val attributes = AttributesMaker.zuoraAttributesWithAddedDynamoFields(Some(zuoraAttributes), None)
-//
-//      attributes === expected
-//    }
-//
-//    "return none if both Dynamo and Zuora attributes are none" in {
-//      AttributesMaker.zuoraAttributesWithAddedDynamoFields(None, None) === None
-//    }
-//
-//  }
+  "zuoraAttributes" should {
+
+    "return attributes when digipack sub" in {
+      val expected = Some(ZuoraAttributes(
+        UserId = identityId,
+        Tier = None,
+        RecurringContributionPaymentPlan = None,
+        MembershipJoinDate = None,
+        DigitalSubscriptionExpiryDate = Some(referenceDate + 1.year)
+      ))
+      AttributesMaker.zuoraAttributes(identityId, List(digipack), referenceDate) === expected
+    }
+
+    "return attributes when one of the subs has a digital benefit" in {
+      val expected = Some(ZuoraAttributes(
+        UserId = identityId,
+        Tier = None,
+        RecurringContributionPaymentPlan = None,
+        MembershipJoinDate = None,
+        DigitalSubscriptionExpiryDate = Some(referenceDate + 1.year)
+      ))
+      AttributesMaker.zuoraAttributes(identityId, List(sunday, sundayPlus), referenceDate) === expected
+    }
+
+    "return none when only sub is expired" in {
+      AttributesMaker.zuoraAttributes(identityId, List(expiredMembership), referenceDate) === None
+    }
+
+    "return attributes when there is one membership sub" in {
+      val expected = Some(ZuoraAttributes(
+        UserId = identityId,
+        Tier = Some("Supporter"),
+        RecurringContributionPaymentPlan = None,
+        MembershipJoinDate = Some(referenceDate)
+      )
+      )
+      AttributesMaker.zuoraAttributes(identityId, List(membership), referenceDate) === expected
+    }
+
+    "return attributes when one sub is expired and one is not" in {
+      val expected = Some(ZuoraAttributes(
+        UserId = identityId,
+        Tier = None,
+        RecurringContributionPaymentPlan = Some("Monthly Contribution"),
+        MembershipJoinDate = None
+      )
+      )
+
+      AttributesMaker.zuoraAttributes(identityId, List(expiredMembership, contributor), referenceDate) === expected
+    }
+
+    "return attributes when one sub is a recurring contribution" in {
+      val expected = Some(ZuoraAttributes(
+        UserId = identityId,
+        Tier = None,
+        RecurringContributionPaymentPlan = Some("Monthly Contribution"),
+        MembershipJoinDate = None
+      )
+      )
+      AttributesMaker.zuoraAttributes(identityId, List(contributor), referenceDate) === expected
+    }
+
+    "return attributes relevant to both when one sub is a contribution and the other a membership" in {
+      val expected = Some(ZuoraAttributes(
+        UserId = identityId,
+        Tier = Some("Supporter"),
+        RecurringContributionPaymentPlan = Some("Monthly Contribution"),
+        MembershipJoinDate = Some(referenceDate)
+      )
+      )
+      AttributesMaker.zuoraAttributes(identityId, List(contributor, membership), referenceDate) === expected
+    }
+
+    "return attributes when the membership is a friend tier" in {
+      val expected = Some(ZuoraAttributes(
+        UserId = identityId,
+        Tier = Some("Friend"),
+        RecurringContributionPaymentPlan = None,
+        MembershipJoinDate = Some(referenceDate)
+      )
+      )
+      AttributesMaker.zuoraAttributes(identityId, List(friend), referenceDate) === expected
+    }
+  }
+
+
+  "attributes" should {
+    "return up to date Zuora attributes when they match the dynamo attributes" in {
+      val zuoraAttributes = ZuoraAttributes(
+        UserId = identityId,
+        Tier = None,
+        RecurringContributionPaymentPlan = Some("Monthly Contribution"),
+        MembershipJoinDate = None,
+        DigitalSubscriptionExpiryDate = None
+      )
+
+      val dynamoAttributes = DynamoAttributes(
+        UserId = identityId,
+        Tier = None,
+        RecurringContributionPaymentPlan = Some("Monthly Contribution"),
+        MembershipJoinDate = None,
+        DigitalSubscriptionExpiryDate = None,
+        MembershipNumber = None,
+        AdFree = None,
+        TTLTimestamp = referenceDateAsDynamoTimestamp
+      )
+
+      val expected = Some(
+        Attributes(
+          UserId = identityId,
+          Tier = None,
+          RecurringContributionPaymentPlan = Some("Monthly Contribution"),
+          MembershipJoinDate = None,
+          DigitalSubscriptionExpiryDate = None
+        )
+      )
+
+      val attributes = AttributesMaker.zuoraAttributesWithAddedDynamoFields(Some(zuoraAttributes), Some(dynamoAttributes))
+
+      attributes === expected
+    }
+
+    "still return Zuora attributes when the user is not in Dynamo" in {
+      val zuoraAttributes = ZuoraAttributes(
+        UserId = identityId,
+        Tier = None,
+        RecurringContributionPaymentPlan = Some("Monthly Contribution"),
+        MembershipJoinDate = None,
+        DigitalSubscriptionExpiryDate = None
+      )
+
+      val expected = Some(
+        Attributes(
+          UserId = identityId,
+          Tier = None,
+          RecurringContributionPaymentPlan = Some("Monthly Contribution"),
+          MembershipJoinDate = None,
+          DigitalSubscriptionExpiryDate = None
+        )
+      )
+
+      val attributes = AttributesMaker.zuoraAttributesWithAddedDynamoFields(Some(zuoraAttributes), None)
+
+      attributes === expected
+    }
+
+    "return none if both Dynamo and Zuora attributes are none" in {
+      AttributesMaker.zuoraAttributesWithAddedDynamoFields(None, None) === None
+    }
+
+  }
 
   "actionAvailableFor" should {
     val testAccountId = AccountId("testme")
@@ -195,24 +197,30 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
     def paymentMethodResponseRecentFailure(id: PaymentMethodId) = Future.successful(\/.right(PaymentMethodResponse(1, "CreditCardReferenceTransaction", DateTime.now().minusDays(1))))
     def paymentMethodResponseStaleFailure(id: PaymentMethodId) = Future.successful(\/.right(PaymentMethodResponse(1, "CreditCardReferenceTransaction", DateTime.now().minusMonths(2))))
 
-    "return None when no subs are a membership" in {
-      val result = AttributesMaker.actionAvailableFor(List((accountSummaryWithBalance, sunday)), paymentMethodResponseNoFailures)
+    "return false for a member with a zero balance" in {
+      val result = AttributesMaker.actionAvailableFor(accountSummaryWithZeroBalance, membership, paymentMethodResponseNoFailures)
 
-      result must be_==(None).await
+      result must be_==(false).await
     }
 
-    "return Some('membership') for a member with a failed payment in the last 27 days" in {
-      val result = AttributesMaker.actionAvailableFor(List((accountSummaryWithBalance, membership)), paymentMethodResponseRecentFailure)
-      val expected = Some("membership")
+    "return false for a member with a failed payment more than 27 days ago" in {
+      val result = AttributesMaker.actionAvailableFor(accountSummaryWithBalance, membership, paymentMethodResponseStaleFailure)
 
-      result must be_==(expected).await
+      result must be_==(false).await
     }
 
-    "return None for a member with a failed payment more than 27 days ago" in {
-      val result = AttributesMaker.actionAvailableFor(List((accountSummaryWithBalance, membership)), paymentMethodResponseStaleFailure)
+    "return true for for a member with a failed payment in the last 27 days" in {
+      val result = AttributesMaker.actionAvailableFor(accountSummaryWithBalance, membership, paymentMethodResponseRecentFailure)
 
-      result must be_==(None).await
+      result must be_==(true).await
     }
+
+    "return true for for a non-membership sub with a failed payment in the last 27 days too" in {
+      val result = AttributesMaker.actionAvailableFor(accountSummaryWithBalance, digipack, paymentMethodResponseRecentFailure)
+
+      result must be_==(true).await
+    }
+
   }
 
 }

--- a/membership-attribute-service/test/services/AttributesMakerTest.scala
+++ b/membership-attribute-service/test/services/AttributesMakerTest.scala
@@ -2,7 +2,7 @@ package services
 
 import com.github.nscala_time.time.Implicits._
 import com.gu.memsub.Subscription.AccountId
-import com.gu.zuora.rest.ZuoraRestService.{AccountSummary, BillToContact, DefaultPaymentMethod, PaymentMethodId, PaymentMethodResponse, SoldToContact}
+import com.gu.zuora.rest.ZuoraRestService.{PaymentMethodId, PaymentMethodResponse}
 import models.{Attributes, CustomerAccount, DynamoAttributes, ZuoraAttributes}
 import org.joda.time.{DateTime, LocalDate}
 import org.specs2.concurrent.ExecutionEnv
@@ -118,18 +118,21 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
       result must be_==(expected).await
     }
 
-    "return actionAvailableFor=membership for an active membership in payment failure" in {
-      val expected = Some(ZuoraAttributes(
-        UserId = identityId,
-        Tier = Some("Supporter"),
-        RecurringContributionPaymentPlan = None,
-        MembershipJoinDate = Some(referenceDate),
-        ActionAvailableFor = Some("membership")
-      )
-      )
-      val result = AttributesMaker.zuoraAttributes(identityId, List(CustomerAccount(accountSummaryWithBalance, Some(membership))), paymentMethodResponseRecentFailure, referenceDate)
-      result must be_==(expected).await
-    }
+    // We are currently returning actionAvailableFor = None always in AttributesMaker and just logging the value we've calculated
+    //This test should be uncommented once we resume returning the calculated value
+
+//    "return actionAvailableFor=membership for an active membership in payment failure" in {
+//      val expected = Some(ZuoraAttributes(
+//        UserId = identityId,
+//        Tier = Some("Supporter"),
+//        RecurringContributionPaymentPlan = None,
+//        MembershipJoinDate = Some(referenceDate),
+//        ActionAvailableFor = Some("membership")
+//      )
+//      )
+//      val result = AttributesMaker.zuoraAttributes(identityId, List(CustomerAccount(accountSummaryWithBalance, Some(membership))), paymentMethodResponseRecentFailure, referenceDate)
+//      result must be_==(expected).await
+//    }
   }
 
 

--- a/membership-attribute-service/test/services/AttributesMakerTest.scala
+++ b/membership-attribute-service/test/services/AttributesMakerTest.scala
@@ -3,7 +3,7 @@ package services
 import com.github.nscala_time.time.Implicits._
 import com.gu.memsub.Subscription.AccountId
 import com.gu.zuora.rest.ZuoraRestService.{PaymentMethodId, PaymentMethodResponse}
-import models.{Attributes, CustomerAccount, DynamoAttributes, ZuoraAttributes}
+import models.{Attributes, AccountWithSubscription, DynamoAttributes, ZuoraAttributes}
 import org.joda.time.{DateTime, LocalDate}
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mutable.Specification
@@ -34,7 +34,7 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
         MembershipJoinDate = None,
         DigitalSubscriptionExpiryDate = Some(referenceDate + 1.year)
       ))
-      val result = AttributesMaker.zuoraAttributes(identityId, List(CustomerAccount(accountSummaryWithZeroBalance, Some(digipack))), paymentMethodResponseNoFailures, referenceDate)
+      val result = AttributesMaker.zuoraAttributes(identityId, List(AccountWithSubscription(accountSummaryWithZeroBalance, Some(digipack))), paymentMethodResponseNoFailures, referenceDate)
       result must be_==(expected).await
     }
 
@@ -46,12 +46,12 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
         MembershipJoinDate = None,
         DigitalSubscriptionExpiryDate = Some(referenceDate + 1.year)
       ))
-      val result = AttributesMaker.zuoraAttributes(identityId, List(CustomerAccount(accountSummaryWithZeroBalance, Some(sunday)), CustomerAccount(anotherAccountSummary, Some(sundayPlus))), paymentMethodResponseNoFailures, referenceDate)
+      val result = AttributesMaker.zuoraAttributes(identityId, List(AccountWithSubscription(accountSummaryWithZeroBalance, Some(sunday)), AccountWithSubscription(anotherAccountSummary, Some(sundayPlus))), paymentMethodResponseNoFailures, referenceDate)
       result must be_==(expected).await
     }
 
     "return none when only sub is expired" in {
-      val result = AttributesMaker.zuoraAttributes(identityId, List(CustomerAccount(accountSummaryWithZeroBalance, Some(expiredMembership))), paymentMethodResponseNoFailures, referenceDate)
+      val result = AttributesMaker.zuoraAttributes(identityId, List(AccountWithSubscription(accountSummaryWithZeroBalance, Some(expiredMembership))), paymentMethodResponseNoFailures, referenceDate)
       result must be_==(None).await
     }
 
@@ -63,7 +63,7 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
         MembershipJoinDate = Some(referenceDate)
       )
       )
-      val result = AttributesMaker.zuoraAttributes(identityId, List(CustomerAccount(accountSummaryWithZeroBalance, Some(membership))), paymentMethodResponseNoFailures, referenceDate)
+      val result = AttributesMaker.zuoraAttributes(identityId, List(AccountWithSubscription(accountSummaryWithZeroBalance, Some(membership))), paymentMethodResponseNoFailures, referenceDate)
       result must be_==(expected).await
     }
 
@@ -76,7 +76,7 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
       )
       )
 
-      val result = AttributesMaker.zuoraAttributes(identityId, List(CustomerAccount(accountSummaryWithZeroBalance, Some(expiredMembership)), CustomerAccount(accountSummaryWithZeroBalance, Some(contributor))), paymentMethodResponseNoFailures, referenceDate)
+      val result = AttributesMaker.zuoraAttributes(identityId, List(AccountWithSubscription(accountSummaryWithZeroBalance, Some(expiredMembership)), AccountWithSubscription(accountSummaryWithZeroBalance, Some(contributor))), paymentMethodResponseNoFailures, referenceDate)
       result must be_==(expected).await
 
     }
@@ -89,7 +89,7 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
         MembershipJoinDate = None
       )
       )
-      val result = AttributesMaker.zuoraAttributes(identityId, List(CustomerAccount(accountSummaryWithZeroBalance, Some(contributor))), paymentMethodResponseNoFailures, referenceDate)
+      val result = AttributesMaker.zuoraAttributes(identityId, List(AccountWithSubscription(accountSummaryWithZeroBalance, Some(contributor))), paymentMethodResponseNoFailures, referenceDate)
       result must be_==(expected).await
 
     }
@@ -102,7 +102,7 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
         MembershipJoinDate = Some(referenceDate)
       )
       )
-      val result = AttributesMaker.zuoraAttributes(identityId, List(CustomerAccount(accountSummaryWithZeroBalance, Some(contributor)), CustomerAccount(accountSummaryWithZeroBalance, Some(membership))),  paymentMethodResponseNoFailures, referenceDate)
+      val result = AttributesMaker.zuoraAttributes(identityId, List(AccountWithSubscription(accountSummaryWithZeroBalance, Some(contributor)), AccountWithSubscription(accountSummaryWithZeroBalance, Some(membership))),  paymentMethodResponseNoFailures, referenceDate)
       result must be_==(expected).await
     }
 
@@ -114,7 +114,7 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
         MembershipJoinDate = Some(referenceDate)
       )
       )
-      val result = AttributesMaker.zuoraAttributes(identityId, List(CustomerAccount(accountSummaryWithZeroBalance, Some(friend))), paymentMethodResponseNoFailures, referenceDate)
+      val result = AttributesMaker.zuoraAttributes(identityId, List(AccountWithSubscription(accountSummaryWithZeroBalance, Some(friend))), paymentMethodResponseNoFailures, referenceDate)
       result must be_==(expected).await
     }
 
@@ -131,7 +131,7 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
           AlertAvailableFor = Some("membership")
         )
         )
-        val result = AttributesMaker.zuoraAttributes(identityId, List(CustomerAccount(accountSummaryWithBalance, Some(membership))), paymentMethodResponseRecentFailure, referenceDate)
+        val result = AttributesMaker.zuoraAttributes(identityId, List(AccountWithSubscription(accountSummaryWithBalance, Some(membership))), paymentMethodResponseRecentFailure, referenceDate)
         result must be_==(expected).await
       }
     }

--- a/membership-attribute-service/test/services/AttributesMakerTest.scala
+++ b/membership-attribute-service/test/services/AttributesMakerTest.scala
@@ -3,7 +3,7 @@ package services
 import com.github.nscala_time.time.Implicits._
 import com.gu.memsub.Subscription.AccountId
 import com.gu.zuora.rest.ZuoraRestService.{AccountSummary, BillToContact, DefaultPaymentMethod, PaymentMethodId, PaymentMethodResponse, SoldToContact}
-import models.{Attributes, DynamoAttributes, ZuoraAttributes}
+import models.{Attributes, CustomerAccount, DynamoAttributes, ZuoraAttributes}
 import org.joda.time.{DateTime, LocalDate}
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mutable.Specification
@@ -34,7 +34,7 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
         MembershipJoinDate = None,
         DigitalSubscriptionExpiryDate = Some(referenceDate + 1.year)
       ))
-      val result = AttributesMaker.zuoraAttributes(identityId, List((Some(digipack), accountSummaryWithZeroBalance)), paymentMethodResponseNoFailures, referenceDate)
+      val result = AttributesMaker.zuoraAttributes(identityId, List(CustomerAccount(accountSummaryWithZeroBalance, Some(digipack))), paymentMethodResponseNoFailures, referenceDate)
       result must be_==(expected).await
     }
 
@@ -46,12 +46,12 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
         MembershipJoinDate = None,
         DigitalSubscriptionExpiryDate = Some(referenceDate + 1.year)
       ))
-      val result = AttributesMaker.zuoraAttributes(identityId, List((Some(sunday), accountSummaryWithZeroBalance), (Some(sundayPlus), anotherAccountSummary)), paymentMethodResponseNoFailures, referenceDate)
+      val result = AttributesMaker.zuoraAttributes(identityId, List(CustomerAccount(accountSummaryWithZeroBalance, Some(sunday)), CustomerAccount(anotherAccountSummary, Some(sundayPlus))), paymentMethodResponseNoFailures, referenceDate)
       result must be_==(expected).await
     }
 
     "return none when only sub is expired" in {
-      val result = AttributesMaker.zuoraAttributes(identityId, List((Some(expiredMembership), accountSummaryWithZeroBalance)), paymentMethodResponseNoFailures, referenceDate)
+      val result = AttributesMaker.zuoraAttributes(identityId, List(CustomerAccount(accountSummaryWithZeroBalance, Some(expiredMembership))), paymentMethodResponseNoFailures, referenceDate)
       result must be_==(None).await
     }
 
@@ -63,7 +63,7 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
         MembershipJoinDate = Some(referenceDate)
       )
       )
-      val result = AttributesMaker.zuoraAttributes(identityId, List((Some(membership), accountSummaryWithZeroBalance)), paymentMethodResponseNoFailures, referenceDate)
+      val result = AttributesMaker.zuoraAttributes(identityId, List(CustomerAccount(accountSummaryWithZeroBalance, Some(membership))), paymentMethodResponseNoFailures, referenceDate)
       result must be_==(expected).await
     }
 
@@ -76,7 +76,7 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
       )
       )
 
-      val result = AttributesMaker.zuoraAttributes(identityId, List((Some(expiredMembership), accountSummaryWithZeroBalance), (Some(contributor), accountSummaryWithZeroBalance)), paymentMethodResponseNoFailures, referenceDate)
+      val result = AttributesMaker.zuoraAttributes(identityId, List(CustomerAccount(accountSummaryWithZeroBalance, Some(expiredMembership)), CustomerAccount(accountSummaryWithZeroBalance, Some(contributor))), paymentMethodResponseNoFailures, referenceDate)
       result must be_==(expected).await
 
     }
@@ -89,7 +89,7 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
         MembershipJoinDate = None
       )
       )
-      val result = AttributesMaker.zuoraAttributes(identityId, List((Some(contributor), accountSummaryWithZeroBalance)), paymentMethodResponseNoFailures, referenceDate)
+      val result = AttributesMaker.zuoraAttributes(identityId, List(CustomerAccount(accountSummaryWithZeroBalance, Some(contributor))), paymentMethodResponseNoFailures, referenceDate)
       result must be_==(expected).await
 
     }
@@ -102,7 +102,7 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
         MembershipJoinDate = Some(referenceDate)
       )
       )
-      val result = AttributesMaker.zuoraAttributes(identityId, List((Some(contributor), accountSummaryWithZeroBalance), (Some(membership), accountSummaryWithZeroBalance)),  paymentMethodResponseNoFailures, referenceDate)
+      val result = AttributesMaker.zuoraAttributes(identityId, List(CustomerAccount(accountSummaryWithZeroBalance, Some(contributor)), CustomerAccount(accountSummaryWithZeroBalance, Some(membership))),  paymentMethodResponseNoFailures, referenceDate)
       result must be_==(expected).await
     }
 
@@ -114,7 +114,7 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
         MembershipJoinDate = Some(referenceDate)
       )
       )
-      val result = AttributesMaker.zuoraAttributes(identityId, List((Some(friend), accountSummaryWithZeroBalance)), paymentMethodResponseNoFailures, referenceDate)
+      val result = AttributesMaker.zuoraAttributes(identityId, List(CustomerAccount(accountSummaryWithZeroBalance, Some(friend))), paymentMethodResponseNoFailures, referenceDate)
       result must be_==(expected).await
     }
 
@@ -127,7 +127,7 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
         ActionAvailableFor = Some("membership")
       )
       )
-      val result = AttributesMaker.zuoraAttributes(identityId, List((Some(membership), accountSummaryWithBalance)), paymentMethodResponseRecentFailure, referenceDate)
+      val result = AttributesMaker.zuoraAttributes(identityId, List(CustomerAccount(accountSummaryWithBalance, Some(membership))), paymentMethodResponseRecentFailure, referenceDate)
       result must be_==(expected).await
     }
   }

--- a/membership-attribute-service/test/services/AttributesMakerTest.scala
+++ b/membership-attribute-service/test/services/AttributesMakerTest.scala
@@ -118,17 +118,17 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
       result must be_==(expected).await
     }
 
-    // We are currently returning actionAvailableFor = None always in AttributesMaker and just logging the value we've calculated
+    // We are currently returning alertAvailableFor = None always in AttributesMaker and just logging the value we've calculated
     //This test should be un-ignored once we resume returning the calculated value
 
-    "return actionAvailableFor=membership for an active membership in payment failure" in {
+    "return alertAvailableFor=membership for an active membership in payment failure" in {
       skipped {
         val expected = Some(ZuoraAttributes(
           UserId = identityId,
           Tier = Some("Supporter"),
           RecurringContributionPaymentPlan = None,
           MembershipJoinDate = Some(referenceDate),
-          ActionAvailableFor = Some("membership")
+          AlertAvailableFor = Some("membership")
         )
         )
         val result = AttributesMaker.zuoraAttributes(identityId, List(CustomerAccount(accountSummaryWithBalance, Some(membership))), paymentMethodResponseRecentFailure, referenceDate)
@@ -204,22 +204,22 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
 
   }
 
-  "actionAvailableFor" should {
+  "alertAvailableFor" should {
 
     "return false for a member with a zero balance" in {
-      val result = AttributesMaker.actionAvailableFor(accountSummaryWithZeroBalance, membership, paymentMethodResponseNoFailures)
+      val result = AttributesMaker.alertAvailableFor(accountSummaryWithZeroBalance, membership, paymentMethodResponseNoFailures)
 
       result must be_==(false).await
     }
 
     "return false for a member with a failed payment more than 27 days ago" in {
-      val result = AttributesMaker.actionAvailableFor(accountSummaryWithBalance, membership, paymentMethodResponseStaleFailure)
+      val result = AttributesMaker.alertAvailableFor(accountSummaryWithBalance, membership, paymentMethodResponseStaleFailure)
 
       result must be_==(false).await
     }
 
     "return false for a member with a balance but no failed payments" in {
-      val result = AttributesMaker.actionAvailableFor(accountSummaryWithBalance, membership, paymentMethodResponseNoFailures)
+      val result = AttributesMaker.alertAvailableFor(accountSummaryWithBalance, membership, paymentMethodResponseNoFailures)
 
       result must be_==(false).await
     }
@@ -227,19 +227,19 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
     "return false for a member who pays via paypal" in {
       def paymentMethodResponsePaypal(paymentMethodId: PaymentMethodId) = Future.successful(\/.right(PaymentMethodResponse(1, "PayPal", DateTime.now().minusDays(1))))
 
-      val result = AttributesMaker.actionAvailableFor(accountSummaryWithBalance, membership, paymentMethodResponsePaypal)
+      val result = AttributesMaker.alertAvailableFor(accountSummaryWithBalance, membership, paymentMethodResponsePaypal)
 
       result must be_==(false).await
     }
 
     "return true for for a member with a failed payment in the last 27 days" in {
-      val result = AttributesMaker.actionAvailableFor(accountSummaryWithBalance, membership, paymentMethodResponseRecentFailure)
+      val result = AttributesMaker.alertAvailableFor(accountSummaryWithBalance, membership, paymentMethodResponseRecentFailure)
 
       result must be_==(true).await
     }
 
     "return true for for a non-membership sub with a failed payment in the last 27 days too" in {
-      val result = AttributesMaker.actionAvailableFor(accountSummaryWithBalance, digipack, paymentMethodResponseRecentFailure)
+      val result = AttributesMaker.alertAvailableFor(accountSummaryWithBalance, digipack, paymentMethodResponseRecentFailure)
 
       result must be_==(true).await
     }

--- a/membership-attribute-service/test/testdata/AccountSummaryTestData.scala
+++ b/membership-attribute-service/test/testdata/AccountSummaryTestData.scala
@@ -3,7 +3,7 @@ package testdata
 import com.gu.memsub.Subscription.AccountId
 import com.gu.zuora.rest.ZuoraRestService.{AccountSummary, BillToContact, DefaultPaymentMethod, PaymentMethodId, SoldToContact}
 
-object AccountSummaryTestData { //todo should this be an object?
+object AccountSummaryTestData {
   val testAccountId = AccountId("accountId")
   val testPaymentMethodId = PaymentMethodId("testme")
   val testIdentityId = "123"

--- a/membership-attribute-service/test/testdata/AccountSummaryTestData.scala
+++ b/membership-attribute-service/test/testdata/AccountSummaryTestData.scala
@@ -1,0 +1,29 @@
+package testdata
+
+import com.gu.memsub.Subscription.AccountId
+import com.gu.zuora.rest.ZuoraRestService.{AccountSummary, BillToContact, DefaultPaymentMethod, PaymentMethodId, SoldToContact}
+
+object AccountSummaryTestData { //todo should this be an object?
+  val testAccountId = AccountId("accountId")
+  val testPaymentMethodId = PaymentMethodId("testme")
+  val testIdentityId = "123"
+
+  def accountSummaryWith(balance: Double, paymentMethodId: PaymentMethodId, accountId: AccountId) =
+    AccountSummary(
+      id = accountId,
+      identityId = Some(testIdentityId),
+      billToContact = BillToContact(Some("email"), None),
+      soldToContact = SoldToContact(
+        title = None,
+        firstName = Some("Joe"),
+        lastName = "Bloggs",
+        None, None, None, None, None, None
+      ),
+      currency = None,
+      balance = balance,
+      defaultPaymentMethod = Some(DefaultPaymentMethod(paymentMethodId))
+    )
+
+  val accountSummaryWithBalance = accountSummaryWith(20.0, testPaymentMethodId, testAccountId)
+  val accountSummaryWithZeroBalance = accountSummaryWith(0, testPaymentMethodId, testAccountId)
+}

--- a/membership-attribute-service/test/testdata/SubscriptionTestData.scala
+++ b/membership-attribute-service/test/testdata/SubscriptionTestData.scala
@@ -24,10 +24,10 @@ trait SubscriptionTestData {
     RatePlanId("idDigipack"), ProductRatePlanId("prpi"), "Digipack", "desc", "Digital Pack", Product.Digipack, List.empty, PaidCharge(Digipack, BillingPeriod.Year, PricingSummary(Map(GBP -> Price(119.90f, GBP))), ProductRatePlanChargeId("baz"), SubscriptionRatePlanChargeId("naz")), None, startDate, endDate
   )
   def paperPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan.Delivery = PaidSubscriptionPlan[Product.Delivery, PaperCharges](
-    RatePlanId("idDigipack"), ProductRatePlanId("prpi"), "Sunday", "desc", "Sunday", Product.Delivery, List.empty, PaperCharges(Seq((SundayPaper, PricingSummary(Map(GBP -> Price(5.07f, GBP))))).toMap, None), None, startDate, endDate
+    RatePlanId("idPaperPlan"), ProductRatePlanId("prpi"), "Sunday", "desc", "Sunday", Product.Delivery, List.empty, PaperCharges(Seq((SundayPaper, PricingSummary(Map(GBP -> Price(5.07f, GBP))))).toMap, None), None, startDate, endDate
   )
   def paperPlusPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan.Delivery = PaidSubscriptionPlan[Product.Delivery, PaperCharges](
-    RatePlanId("idDigipack"), ProductRatePlanId("prpi"), "Sunday+", "desc", "Sunday+", Product.Delivery, List.empty, PaperCharges(Seq((SundayPaper, PricingSummary(Map(GBP -> Price(5.07f, GBP))))).toMap, Some(PricingSummary(Map(GBP -> Price(119.90f, GBP))))), None, startDate, endDate
+    RatePlanId("idPaperPlusPlan"), ProductRatePlanId("prpi"), "Sunday+", "desc", "Sunday+", Product.Delivery, List.empty, PaperCharges(Seq((SundayPaper, PricingSummary(Map(GBP -> Price(5.07f, GBP))))).toMap, Some(PricingSummary(Map(GBP -> Price(119.90f, GBP))))), None, startDate, endDate
   )
   def contributorPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan.Contributor = PaidSubscriptionPlan[Product.Contribution, PaidCharge[Benefit.Contributor.type, BillingPeriod]](
     RatePlanId("idContributor"), ProductRatePlanId("prpi"), "Monthly Contribution", "desc", "Monthly Contribution", Product.Contribution, List.empty, PaidCharge(Contributor, BillingPeriod.Month, PricingSummary(Map(GBP -> Price(5.0f, GBP))), ProductRatePlanChargeId("bar"), SubscriptionRatePlanChargeId("nar")), None, startDate, endDate

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.497"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.502"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.7"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.0"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.502"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.503"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.7"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.0"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
We would like to be able to notify a user that there is an action they may need to take to do with their membership (primarily, updating their card details).

Part of https://github.com/guardian/frontend/pull/19176 ensures that calls to /user-attributes/me to update the user's cookies also update an action available cookie. This PR is to add a value `alertAvailableFor="membership"` on calls to /me if a user with a membership needs to update their card details. **Initially, we will just log when we would have returned `alertAvailableFor="membership"` for a user** and then we will later put the calculated value for alertAvailableFor in the response. 

PRs to follow:
- Since this PR just logs the calculated value, one will follow to actually add the value to the response. 
- Potentially we'll need to return the calculated value to test in CODE, so this would follow in another PR
- We still need a change to return the action for the user on calls to /mma-membership, if they have one

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
- On lookup calls /user-attributes/{me, features, membership}, we now need to make an additional Zuora REST call to get the user's account summary to determine if they have an action available
- Now within the AttributesMaker we calculate if there is an action available for the user based on a list of their zuora accounts and corresponding subscriptions (if any) 

### trello card/screenshot/json/related PRs etc
https://github.com/guardian/frontend/pull/19176
https://trello.com/c/5n3GqOPd/231-goal-implement-payment-failure-banner-across-the-site

cc @paulbrown1982 @jacobwinch @pvighi @johnduffell 