### PR TITLE
Use shared bucket for encrypted config

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add the following line to the hosts file:
 `127.0.0.1   members-data-api.thegulocal.com`
 
 Download the config (you may need to `brew install awscli` to get the command.
-`aws s3 cp s3://members-data-api-private/DEV/members-data-api.private.conf /etc/gu/ --profile membership`
+`aws s3 cp s3://gu-reader-revenue-private/membership/members-data-api/DEV/members-data-api.private.conf /etc/gu/ --profile membership`
 
 ## Running Locally
 

--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -284,7 +284,7 @@ Resources:
               aws s3 cp s3://gu-membership-attribute-service-dist/membership/${Stage}/membership-attribute-service/membership-attribute-service_1.0-SNAPSHOT_all.deb /tmp
               dpkg -i /tmp/membership-attribute-service_1.0-SNAPSHOT_all.deb
               mkdir -p /etc/gu
-              aws --region ${AWS::Region} s3 cp s3://gu-reader-revenue-private/${Stack}/members-data-api/${Stage}/members-data-api.private.conf /etc/gu
+              aws --region ${AWS::Region} s3 cp s3://gu-reader-revenue-private/membership/members-data-api/${Stage}/members-data-api.private.conf /etc/gu
               chown membership-attribute-service /etc/gu/members-data-api.private.conf
               chmod 0600 /etc/gu/members-data-api.private.conf
 

--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -112,7 +112,7 @@ Resources:
             Resource: arn:aws:s3:::gu-membership-*/*
             Effect: Allow
           - Action: s3:GetObject
-            Resource: arn:aws:s3:::members-data-api-private/*
+            Resource: arn:aws:s3:::gu-reader-revenue-private/${Stack}/members-data-api/${Stage}/*
             Effect: Allow
           - Action: ec2:DescribeTags
             Resource: "*"
@@ -284,7 +284,7 @@ Resources:
               aws s3 cp s3://gu-membership-attribute-service-dist/membership/${Stage}/membership-attribute-service/membership-attribute-service_1.0-SNAPSHOT_all.deb /tmp
               dpkg -i /tmp/membership-attribute-service_1.0-SNAPSHOT_all.deb
               mkdir -p /etc/gu
-              aws --region ${AWS::Region} s3 cp s3://members-data-api-private/${Stage}/members-data-api.private.conf /etc/gu
+              aws --region ${AWS::Region} s3 cp s3://gu-reader-revenue-private/${Stack}/members-data-api/${Stage}/members-data-api.private.conf /etc/gu
               chown membership-attribute-service /etc/gu/members-data-api.private.conf
               chmod 0600 /etc/gu/members-data-api.private.conf
 


### PR DESCRIPTION
### Why do we need this?

We're moving all private conf to a single bucket as part of the GDPR work. This simplifies our AWS resources and means that any files added automatically derive the correct storage policies for private configuration / secrets.

The members-data-api-private bucket will be deleted once this PR has been merged.

### The changes
* Update README with new bukcet
* Update CFN with new bucket

### trello card/screenshot/json/related PRs etc
Part of https://trello.com/c/mJdMZoYo/254-gdpr-sprint-goal-mostly-finish-encrypted-config

This has been tested in CODE.