### PR TITLE
Add some custom fields to the logging for the payment failure banner

### DIFF
--- a/membership-attribute-service/app/services/AttributesFromZuora.scala
+++ b/membership-attribute-service/app/services/AttributesFromZuora.scala
@@ -192,7 +192,7 @@ class AttributesFromZuora(implicit val executionContext: ExecutionContext) exten
         case \/-(_) =>
           val latency = stopWatch.elapsed
           val zuoraConcurrencyCount = ZuoraRequestCounter.get
-          val customFields: List[LogField] = List("zuora_latency_millis" -> latency.toInt, "zuora_call" -> whichCall, "identityId" -> identityId, "zuora_concurrency_count" -> zuoraConcurrencyCount)
+          val customFields: List[LogField] = List("zuora_latency_millis" -> latency.toInt, "zuora_call" -> whichCall, "identity_id" -> identityId, "zuora_concurrency_count" -> zuoraConcurrencyCount)
           logInfoWithCustomFields(s"$whichCall took ${latency}ms.", customFields)
       }
     }.onFailure {

--- a/membership-attribute-service/app/services/AttributesMaker.scala
+++ b/membership-attribute-service/app/services/AttributesMaker.scala
@@ -58,7 +58,7 @@ class AttributesMaker extends LoggingWithLogstashFields{
     maybeAlertAvailable.getOrElse(Future.successful(None)) map { maybeAlert =>
       def customFields(identityId: String, alertAvailableFor: String) = List(LogFieldString("identity_id", identityId), LogFieldString("alert_available_for", alertAvailableFor))
 
-      maybeAlert map { alert => logInfoWithCustomFields(s"User $identityId has an alert available: $alert", customFields(identityId, alert)) }
+      maybeAlert foreach { alert => logInfoWithCustomFields(s"User $identityId has an alert available: $alert", customFields(identityId, alert)) }
 
       hasAttributableProduct.option {
         val tier: Option[String] = membershipSub.flatMap(getCurrentPlans(_).headOption.map(_.charges.benefits.head.id))

--- a/membership-attribute-service/app/services/AttributesMaker.scala
+++ b/membership-attribute-service/app/services/AttributesMaker.scala
@@ -4,16 +4,17 @@ import com.github.nscala_time.time.OrderingImplicits._
 import com.gu.memsub.subsv2.SubscriptionPlan.AnyPlan
 import com.gu.memsub.subsv2.{GetCurrentPlans, Subscription}
 import com.gu.memsub.{Benefit, Product}
-import com.gu.monitoring.SafeLogger
 import com.gu.zuora.rest.ZuoraRestService.{AccountSummary, PaymentMethodId, PaymentMethodResponse}
-import models.{Attributes, AccountWithSubscription, DynamoAttributes, ZuoraAttributes}
+import loghandling.LoggingField.LogFieldString
+import loghandling.LoggingWithLogstashFields
+import models.{AccountWithSubscription, Attributes, DynamoAttributes, ZuoraAttributes}
 import org.joda.time.{DateTime, LocalDate}
 
 import scala.concurrent.{ExecutionContext, Future}
-import scalaz.{EitherT, \/, \/-}
+import scalaz.\/
 import scalaz.syntax.std.boolean._
 
-class AttributesMaker {
+class AttributesMaker extends LoggingWithLogstashFields{
 
   def zuoraAttributes(
     identityId: String,
@@ -55,7 +56,9 @@ class AttributesMaker {
     }
 
     maybeAlertAvailable.getOrElse(Future.successful(None)) map { maybeAlert =>
-      maybeAlert map { alert => SafeLogger.info(s"User $identityId has an alert available: $alert") }
+      def customFields(identityId: String, alertAvailableFor: String) = List(LogFieldString("identity_id", identityId), LogFieldString("alert_available_for", alertAvailableFor))
+
+      maybeAlert map { alert => logInfoWithCustomFields(s"User $identityId has an alert available: $alert", customFields(identityId, alert)) }
 
       hasAttributableProduct.option {
         val tier: Option[String] = membershipSub.flatMap(getCurrentPlans(_).headOption.map(_.charges.benefits.head.id))


### PR DESCRIPTION
https://github.com/guardian/members-data-api/pull/302 adds a log when we would have shown a member a banner asking them to take an action on their account. 

This PR adds some custom fields to the logging so that it's easier to query these logs. 

<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
We would like to be able to compare the users we would have shown the banner to and see if we consider them to be in payment failure. These custom fields will make that easier. 

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
- Add some custom fields to the logging of when we would have shown the member a banner 

### trello card/screenshot/json/related PRs etc
https://github.com/guardian/members-data-api/pull/302
https://trello.com/c/5n3GqOPd/231-goal-implement-payment-failure-banner-across-the-site

cc @paulbrown1982 @johnduffell @pvighi 