### PR TITLE
Enable returning alertText on calls to mma-membership

### DIFF
--- a/membership-attribute-service/app/services/PaymentFailureAlerter.scala
+++ b/membership-attribute-service/app/services/PaymentFailureAlerter.scala
@@ -58,9 +58,6 @@ object PaymentFailureAlerter extends LoggingWithLogstashFields {
           membershipAlertText
         }
       }
-      // For now, we want to just log and don't ever return the alertText
-      // Line below is very temporary and will be removed once we want alertText on calls to /mma-membership
-      Future.successful(None)
     }
 
     alertAvailableFor(accountObject(accountSummary), subscription, paymentMethodGetter) flatMap { shouldShowAlert: Boolean =>

--- a/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
+++ b/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
@@ -37,29 +37,15 @@ class PaymentFailureAlerterTest(implicit ee: ExecutionEnv)  extends Specificatio
         result must be_==(None).await
       }
 
-      // We are currently never returning alertText on calls to /mma-membership
-      //This test should be un-ignored once we resume returning the alertText, if relevant.
       "return a message for a member who is in payment failure" in {
-        skipped {
-          val result: Future[Option[String]] = PaymentFailureAlerter.membershipAlertText(accountSummaryWithBalance, membership, paymentMethodResponseRecentFailure)
-
-          val attemptDateTime = DateTime.now().minusDays(1)
-          val formatter = DateTimeFormat.forPattern("d MMMM yyyy").withLocale(Locale.ENGLISH)
-          val expectedActionText = s"Our attempt to take payment for your Supporter membership failed on ${attemptDateTime.toString(formatter)}. Please check below that your card details are up to date."
-
-          result must be_==(Some(expectedActionText)).await
-        }
-      }
-
-      // Temporarily the expected behaviour - delete once we start returning alertText
-      "TEMPORARY - still not return alertText even if a member is payment failure" in {
         val result: Future[Option[String]] = PaymentFailureAlerter.membershipAlertText(accountSummaryWithBalance, membership, paymentMethodResponseRecentFailure)
 
         val attemptDateTime = DateTime.now().minusDays(1)
         val formatter = DateTimeFormat.forPattern("d MMMM yyyy").withLocale(Locale.ENGLISH)
+        val expectedActionText = s"Our attempt to take payment for your Supporter membership failed on ${attemptDateTime.toString(formatter)}. Please check below that your card details are up to date."
 
-        result must be_==(None).await
-        }
+        result must be_==(Some(expectedActionText)).await
+      }
 
     }
 


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
We would like to encourage members in payment failure to update their card details. Once they reach the membership manage page, we would like to show a message asking them to update their card details, if relevant. https://github.com/guardian/members-data-api/pull/309 computed this text, but just logged it. This returns the alertText in the response so that it will appear on the manage page. 

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
Switches on returning a message for the membership manage page. 

### trello card/screenshot/json/related PRs etc
https://github.com/guardian/members-data-api/pull/309

cc @paulbrown1982 @AWare @jacobwinch @johnduffell @pvighi 