### PR TITLE
Fix recognition of Paper+ and Voucher+ subscribers

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.505"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.506"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.9"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.2"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"


### PR DESCRIPTION
Previously Paper+ and Voucher+ users were:

"digitalPack":false

Now they are:

"digitalPack":true

I will also re-factor the code to make it more obvious when things are going wrong at the membership-common level, but I don't have much time today and I want to get this fix out first.

### The changes 
* Use the [latest membership-common](https://github.com/guardian/membership-common/pull/570), which includes the fix.