### PR TITLE
More accurately identify users who would see a payment failure banner

### DIFF
--- a/membership-attribute-service/test/testdata/AccountObjectTestData.scala
+++ b/membership-attribute-service/test/testdata/AccountObjectTestData.scala
@@ -4,7 +4,8 @@ import com.gu.i18n.Country
 import com.gu.i18n.Currency.GBP
 import com.gu.zuora.api.StripeUKMembershipGateway
 import com.gu.memsub.Subscription.AccountId
-import com.gu.zuora.rest.ZuoraRestService.{AccountObject, AccountSummary, BillToContact, DefaultPaymentMethod, PaymentMethodId, SoldToContact}
+import com.gu.zuora.rest.ZuoraRestService._
+import org.joda.time.DateTime
 
 
 object AccountObjectTestData {
@@ -12,8 +13,9 @@ object AccountObjectTestData {
   private val testPaymentMethodId = PaymentMethodId("testme")
   private val testIdentityId = "123"
   private val currency = GBP
-  val accountObjectWithBalance = AccountObject(testAccountId, 20.0, Some(currency), Some(testPaymentMethodId), Some(StripeUKMembershipGateway))
-  val accountObjectWithZeroBalance = AccountObject(testAccountId, 0, Some(currency), Some(testPaymentMethodId))
+  val accountObjectWithBalanceAndOldInvoice = AccountObject(testAccountId, 20.0, Some(currency), Some(testPaymentMethodId), Some(StripeUKMembershipGateway), Some(DateTime.now().minusDays(30)))
+  val accountObjectWithBalance = AccountObject(testAccountId, 20.0, Some(currency), Some(testPaymentMethodId), Some(StripeUKMembershipGateway), Some(DateTime.now().minusDays(3)))
+  val accountObjectWithZeroBalance = AccountObject(testAccountId, 0, Some(currency), Some(testPaymentMethodId), None, None)
 }
 
 object AccountSummaryTestData {
@@ -32,6 +34,12 @@ object AccountSummaryTestData {
         lastName = "Bloggs",
         None, None, None, None, None, None
       ),
+      invoices = List(Invoice(
+        id = InvoiceId("someid"),
+        invoiceDate = DateTime.now().minusDays(14),
+        dueDate = DateTime.now().minusDays(7),
+        balance = balance
+      )),
       currency = None,
       balance = balance,
       defaultPaymentMethod = Some(DefaultPaymentMethod(paymentMethodId))

--- a/membership-attribute-service/test/testdata/SubscriptionTestData.scala
+++ b/membership-attribute-service/test/testdata/SubscriptionTestData.scala
@@ -56,6 +56,7 @@ trait SubscriptionTestData {
   val sunday = toSubscription(false)(NonEmptyList(paperPlan(referenceDate, referenceDate + 1.year)))
   val sundayPlus = toSubscription(false)(NonEmptyList(paperPlusPlan(referenceDate, referenceDate + 1.year)))
   val membership = toSubscription(false)(NonEmptyList(supporterPlan(referenceDate, referenceDate + 1.year)))
+  val cancelledMembership = toSubscription(true)(NonEmptyList(supporterPlan(referenceDate, referenceDate + 1.year)))
   val expiredMembership = toSubscription(false)(NonEmptyList(supporterPlan(referenceDate - 2.year, referenceDate - 1.year)))
   val friend = toSubscription(false)(NonEmptyList(friendPlan))
   val contributor = toSubscription(false)(NonEmptyList(contributorPlan(referenceDate, referenceDate + 1.month)))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.506"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.507"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.9"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.2"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
We started logging who we wanted to show a payment failure banner to in https://github.com/guardian/members-data-api/pull/302. ~10% of these members were not actually in payment failure and this appears to primarily a case of cancelled memberships or that it the last payment date was within 27 days but the last invoice date was not. This PR is to address this discrepancy, and then we can see if using the LastInvoiceDate on calls to /me is correct often enough. 

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->

1. Changing how we determine if a payment failure is recent enough to show the user a banner. 

- **On /me** We will use the latest invoice date (This may not be exactly correct in some cases, but saves adding an extra call to zuora). 

- **On /me/mma-membership** We will use the date of the latest unpaid invoice

2. For a user to be shown the banner/the message on the mma manage page, now their membership cannot be cancelled. 

### trello card/screenshot/json/related PRs etc
https://trello.com/c/5n3GqOPd/231-goal-implement-payment-failure-banner-across-the-site

https://github.com/guardian/membership-common/pull/571 - keep invoices and invoice dates 
https://github.com/guardian/members-data-api/pull/302 - identify and log if a member has an action on calls to /me
https://github.com/guardian/members-data-api/pull/309 - identify and log if a member has an alert for the membership manage page

cc @paulbrown1982 @AWare @jacobwinch @johnduffell @pvighi 