### PR TITLE
When finding the latest unpaid invoice, ignore any invoices that aren't posted.

### DIFF
--- a/membership-attribute-service/app/services/PaymentFailureAlerter.scala
+++ b/membership-attribute-service/app/services/PaymentFailureAlerter.scala
@@ -31,7 +31,7 @@ object PaymentFailureAlerter extends LoggingWithLogstashFields {
   def latestUnpaidInvoiceDate(invoices: List[Invoice]): Option[DateTime] = {
     implicit def latestFirstDateTimeOrdering: Ordering[DateTime] = Ordering.fromLessThan(_ isAfter  _)
 
-    val unpaidInvoices = invoices.filter(invoice => invoice.balance > 0)
+    val unpaidInvoices = invoices.filter(invoice => invoice.balance > 0 && invoice.status == "Posted")
     val latestUnpaidInvoice = unpaidInvoices.sortBy(invoice => invoice.invoiceDate).headOption
 
     latestUnpaidInvoice.map (_.invoiceDate)

--- a/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
+++ b/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
@@ -108,7 +108,8 @@ class PaymentFailureAlerterTest(implicit ee: ExecutionEnv)  extends Specificatio
           InvoiceId("someId"),
           DateTime.now().minusDays(14),
           DateTime.now().minusDays(7),
-          balance = 0
+          balance = 0,
+          status = "Posted"
         )
 
         val lastUnpaidInvoiceDate = PaymentFailureAlerter.latestUnpaidInvoiceDate(invoices = List(freshNoBalanceInvoice))
@@ -123,7 +124,8 @@ class PaymentFailureAlerterTest(implicit ee: ExecutionEnv)  extends Specificatio
           InvoiceId("someId"),
           invoiceDate,
           DateTime.now().minusDays(7),
-          balance = 12.34
+          balance = 12.34,
+          status = "Posted"
         )
         val lastUnpaidInvoiceDate = PaymentFailureAlerter.latestUnpaidInvoiceDate(invoices = List(freshInvoiceWithABalance))
 
@@ -138,14 +140,16 @@ class PaymentFailureAlerterTest(implicit ee: ExecutionEnv)  extends Specificatio
           InvoiceId("someId"),
           invoiceDateLatest,
           DateTime.now().minusDays(7),
-          balance = 12.34
+          balance = 12.34,
+          status = "Posted"
         )
 
         val oldInvoiceWithABalance = Invoice(
           InvoiceId("someId2"),
           invoiceDateOlder,
           DateTime.now().minusDays(14),
-          balance = 12.34
+          balance = 12.34,
+          status = "Posted"
         )
         val lastUnpaidInvoiceDate = PaymentFailureAlerter.latestUnpaidInvoiceDate(invoices = List(latestInvoiceWithABalance, oldInvoiceWithABalance))
 
@@ -161,18 +165,35 @@ class PaymentFailureAlerterTest(implicit ee: ExecutionEnv)  extends Specificatio
         InvoiceId("someId"),
         invoiceDateLatest,
         DateTime.now().minusDays(7),
-        balance = 0
+        balance = 0,
+        status = "Posted"
       )
 
       val oldInvoiceWithABalance = Invoice(
         InvoiceId("someId2"),
         invoiceDateOlder,
         DateTime.now().minusDays(14),
-        balance = 12.34
+        balance = 12.34,
+        status = "Posted"
       )
       val lastUnpaidInvoiceDate = PaymentFailureAlerter.latestUnpaidInvoiceDate(invoices = List(latestInvoiceWithNoBalance, oldInvoiceWithABalance))
 
       lastUnpaidInvoiceDate === Some(invoiceDateOlder)
+    }
+
+    "ignore an invoice that isn't posted" in {
+      val invoiceDate = DateTime.now().minusDays(14).withTimeAtStartOfDay()
+
+      val freshDraftInvoiceWithABalance = Invoice(
+        InvoiceId("someId"),
+        invoiceDate,
+        DateTime.now().minusDays(7),
+        balance = 12.34,
+        status = "Draft"
+      )
+      val lastUnpaidInvoiceDate = PaymentFailureAlerter.latestUnpaidInvoiceDate(invoices = List(freshDraftInvoiceWithABalance))
+
+      lastUnpaidInvoiceDate === None
     }
   }
 }

--- a/membership-attribute-service/test/testdata/AccountObjectTestData.scala
+++ b/membership-attribute-service/test/testdata/AccountObjectTestData.scala
@@ -38,7 +38,8 @@ object AccountSummaryTestData {
         id = InvoiceId("someid"),
         invoiceDate = DateTime.now().minusDays(14),
         dueDate = DateTime.now().minusDays(7),
-        balance = balance
+        balance = balance,
+        status = "Posted"
       )),
       currency = None,
       balance = balance,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.507"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.508"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.9"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.2"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
When finding the latest unpaid invoice to determine who should see a payment failure banner, the only invoices that are relevant are posted, so let's ignore the others. 

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
- On calls to /me/mma-membership, we make a zuora account summary call and from the invoices returned, determine the invoice date for the latest unpaid invoice. Here we ignore any invoices that don't have status "Posted" when finding this date. 

### trello card/screenshot/json/related PRs etc
https://github.com/guardian/membership-common/pull/571 - keep invoices and invoice dates 
https://github.com/guardian/members-data-api/pull/302 - identify and log if a member has an action on calls to /me
https://github.com/guardian/members-data-api/pull/309 - identify and log if a member has an alert for the membership manage page
https://github.com/guardian/members-data-api/pull/312 - more accurately identify if membership should see the payment failure banner based on the latest invoice date + they should have an active membership

cc @paulbrown1982 @AWare @jacobwinch @johnduffell @pvighi 