### PR TITLE
Start returning alertAvailableFor on calls to /me

### DIFF
--- a/membership-attribute-service/app/services/AttributesMaker.scala
+++ b/membership-attribute-service/app/services/AttributesMaker.scala
@@ -72,10 +72,7 @@ class AttributesMaker extends LoggingWithLogstashFields{
           RecurringContributionPaymentPlan = recurringContributionPaymentPlan,
           MembershipJoinDate = membershipJoinDate,
           DigitalSubscriptionExpiryDate = latestDigitalPackExpiryDate,
-          //First we will just log if we have determined we have a membership alert for the user. Once we assess the logs,
-          //we can start returning the value we've calculated
-          //AlertAvailableFor = maybeAlert
-          AlertAvailableFor = None
+          AlertAvailableFor = maybeAlert
         )
       }
     }

--- a/membership-attribute-service/test/services/AttributesMakerTest.scala
+++ b/membership-attribute-service/test/services/AttributesMakerTest.scala
@@ -118,22 +118,17 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
       result must be_==(expected).await
     }
 
-    // We are currently returning alertAvailableFor = None always in AttributesMaker and just logging the value we've calculated
-    //This test should be un-ignored once we resume returning the calculated value
-
     "return alertAvailableFor=membership for an active membership in payment failure" in {
-      skipped {
-        val expected = Some(ZuoraAttributes(
-          UserId = identityId,
-          Tier = Some("Supporter"),
-          RecurringContributionPaymentPlan = None,
-          MembershipJoinDate = Some(referenceDate),
-          AlertAvailableFor = Some("membership")
-        )
-        )
-        val result = AttributesMaker.zuoraAttributes(identityId, List(AccountWithSubscription(accountObjectWithBalance, Some(membership))), paymentMethodResponseRecentFailure, referenceDate)
-        result must be_==(expected).await
-      }
+      val expected = Some(ZuoraAttributes(
+        UserId = identityId,
+        Tier = Some("Supporter"),
+        RecurringContributionPaymentPlan = None,
+        MembershipJoinDate = Some(referenceDate),
+        AlertAvailableFor = Some("membership")
+      )
+      )
+      val result = AttributesMaker.zuoraAttributes(identityId, List(AccountWithSubscription(accountObjectWithBalance, Some(membership))), paymentMethodResponseRecentFailure, referenceDate)
+      result must be_==(expected).await
     }
   }
 


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
We would like to be able to notify a user that there is an action they may need to take to do with their membership (primarily, updating their card details).

https://github.com/guardian/members-data-api/pull/302 started to identify and log when we wished to provide a member with a banner because they needed to update their card details.

Here we actually return what product a member has an alert for, if any. This provides information needed to show a banner to the user added in https://github.com/guardian/frontend/pull/19176.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->

- Actually return alertAvailableFor = membership when there is a member who should update their card details, and alertAvailableFor still doesn't appear otherwise. This will enable the banner to appear once https://github.com/guardian/frontend/pull/19381 is merged. 

### trello card/screenshot/json/related PRs etc
This frontend PR will translate actionAvailableFor to the link to the manage page, and so we will merge this PR after:
https://github.com/guardian/frontend/pull/19381

https://github.com/guardian/members-data-api/pull/302 - identify and log if a member has an action on calls to /me
https://github.com/guardian/frontend/pull/19176 - add messaging for account errors

https://trello.com/c/5n3GqOPd/231-goal-implement-payment-failure-banner-across-the-site

cc @paulbrown1982 @AWare @jacobwinch @johnduffell 