### PR TITLE
Revert "Start returning alertAvailableFor on calls to /me"

### DIFF
--- a/membership-attribute-service/app/services/AttributesMaker.scala
+++ b/membership-attribute-service/app/services/AttributesMaker.scala
@@ -72,7 +72,10 @@ class AttributesMaker extends LoggingWithLogstashFields{
           RecurringContributionPaymentPlan = recurringContributionPaymentPlan,
           MembershipJoinDate = membershipJoinDate,
           DigitalSubscriptionExpiryDate = latestDigitalPackExpiryDate,
-          AlertAvailableFor = maybeAlert
+          //First we will just log if we have determined we have a membership alert for the user. Once we assess the logs,
+          //we can start returning the value we've calculated
+          //AlertAvailableFor = maybeAlert
+          AlertAvailableFor = None
         )
       }
     }

--- a/membership-attribute-service/test/services/AttributesMakerTest.scala
+++ b/membership-attribute-service/test/services/AttributesMakerTest.scala
@@ -118,17 +118,22 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
       result must be_==(expected).await
     }
 
+    // We are currently returning alertAvailableFor = None always in AttributesMaker and just logging the value we've calculated
+    //This test should be un-ignored once we resume returning the calculated value
+
     "return alertAvailableFor=membership for an active membership in payment failure" in {
-      val expected = Some(ZuoraAttributes(
-        UserId = identityId,
-        Tier = Some("Supporter"),
-        RecurringContributionPaymentPlan = None,
-        MembershipJoinDate = Some(referenceDate),
-        AlertAvailableFor = Some("membership")
-      )
-      )
-      val result = AttributesMaker.zuoraAttributes(identityId, List(AccountWithSubscription(accountObjectWithBalance, Some(membership))), paymentMethodResponseRecentFailure, referenceDate)
-      result must be_==(expected).await
+      skipped {
+        val expected = Some(ZuoraAttributes(
+          UserId = identityId,
+          Tier = Some("Supporter"),
+          RecurringContributionPaymentPlan = None,
+          MembershipJoinDate = Some(referenceDate),
+          AlertAvailableFor = Some("membership")
+        )
+        )
+        val result = AttributesMaker.zuoraAttributes(identityId, List(AccountWithSubscription(accountObjectWithBalance, Some(membership))), paymentMethodResponseRecentFailure, referenceDate)
+        result must be_==(expected).await
+      }
     }
   }
 


### PR DESCRIPTION
Reverts guardian/members-data-api#314

This is not causing an issue, but we need to fix the actual issue before trying this one again.  Hence reverting so we have a clear run.