### PR TITLE
wait 60s for the catalog on startup

### DIFF
--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -77,7 +77,8 @@ class TouchpointComponents(stage: String)(implicit  system: ActorSystem, executi
   lazy val zuoraService = new ZuoraSoapService(soapClient)
   implicit lazy val simpleClient: SimpleClient[Future] = new SimpleClient[Future](tpConfig.zuoraRest, ZuoraRequestCounter.withZuoraRequestCounter(RequestRunners.futureRunner))
   lazy val zuoraRestService = new ZuoraRestService[Future]()
-  lazy val catalogService = new CatalogService[Future](productIds, simpleClient, Await.result(_, 10.seconds), stage)
+  val catalogRestClient: SimpleClient[Future] = new SimpleClient[Future](tpConfig.zuoraRest, RequestRunners.configurableFutureRunner(60.seconds))
+  lazy val catalogService = new CatalogService[Future](productIds, catalogRestClient, Await.result(_, 10.seconds), stage)
   lazy val futureCatalog: Future[CatalogMap] = catalogService.catalog.map(_.fold[CatalogMap](error => {println(s"error: ${error.list.toList.mkString}"); Map()}, _.map))
 
   lazy val subService = new SubscriptionService[Future](productIds, futureCatalog, simpleClient, zuoraService.getAccountIds)

--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -78,7 +78,7 @@ class TouchpointComponents(stage: String)(implicit  system: ActorSystem, executi
   implicit lazy val simpleClient: SimpleClient[Future] = new SimpleClient[Future](tpConfig.zuoraRest, ZuoraRequestCounter.withZuoraRequestCounter(RequestRunners.futureRunner))
   lazy val zuoraRestService = new ZuoraRestService[Future]()
   val catalogRestClient: SimpleClient[Future] = new SimpleClient[Future](tpConfig.zuoraRest, RequestRunners.configurableFutureRunner(60.seconds))
-  lazy val catalogService = new CatalogService[Future](productIds, catalogRestClient, Await.result(_, 10.seconds), stage)
+  lazy val catalogService = new CatalogService[Future](productIds, catalogRestClient, Await.result(_, 60.seconds), stage)
   lazy val futureCatalog: Future[CatalogMap] = catalogService.catalog.map(_.fold[CatalogMap](error => {println(s"error: ${error.list.toList.mkString}"); Map()}, _.map))
 
   lazy val subService = new SubscriptionService[Future](productIds, futureCatalog, simpleClient, zuoraService.getAccountIds)

--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -77,7 +77,7 @@ class TouchpointComponents(stage: String)(implicit  system: ActorSystem, executi
   lazy val zuoraService = new ZuoraSoapService(soapClient)
   implicit lazy val simpleClient: SimpleClient[Future] = new SimpleClient[Future](tpConfig.zuoraRest, ZuoraRequestCounter.withZuoraRequestCounter(RequestRunners.futureRunner))
   lazy val zuoraRestService = new ZuoraRestService[Future]()
-  val catalogRestClient: SimpleClient[Future] = new SimpleClient[Future](tpConfig.zuoraRest, RequestRunners.configurableFutureRunner(60.seconds))
+  lazy val catalogRestClient: SimpleClient[Future] = new SimpleClient[Future](tpConfig.zuoraRest, RequestRunners.configurableFutureRunner(60.seconds))
   lazy val catalogService = new CatalogService[Future](productIds, catalogRestClient, Await.result(_, 60.seconds), stage)
   lazy val futureCatalog: Future[CatalogMap] = catalogService.catalog.map(_.fold[CatalogMap](error => {println(s"error: ${error.list.toList.mkString}"); Map()}, _.map))
 


### PR DESCRIPTION
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
When members data api starts up, it only waits 10 seconds for the catalog.  Sometimes it can take 20+.
### The changes
I have stolen this from subs frontend to do the same.  It seems to be working locally.
https://github.com/guardian/subscriptions-frontend/blob/c40f283b78f972e32dacdc5753db2942f7c056cf/app/services/TouchpointBackends.scala#L89

@jacobwinch 
