### PR TITLE
Removed the security group giving us SSH access to the box, using instance group instead

### DIFF
--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -190,17 +190,6 @@ Resources:
       Path: "/"
       Roles:
       - Ref: MembershipRole
-  GuardianAccessSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: SSH access from Guardian network
-      VpcId:
-        Ref: VpcId
-      SecurityGroupIngress:
-      - IpProtocol: tcp
-        FromPort: '22'
-        ToPort: '22'
-        CidrIp: 77.91.248.0/21
   LoadBalancer:
     Type: AWS::ElasticLoadBalancing::LoadBalancer
     Properties:
@@ -268,7 +257,6 @@ Resources:
         Ref: AmiId
       SecurityGroups:
       - Ref: InstanceSecurityGroup
-      - Ref: GuardianAccessSecurityGroup
       - Ref: VulnerabilityScanningSecurityGroup
       InstanceType:
         Ref: InstanceType
@@ -322,8 +310,12 @@ Resources:
     Properties:
       VpcId:
         Ref: VpcId
-      GroupDescription: Open up HTTP access to load balancer
+      GroupDescription: Open up HTTP access to load balancer, SSH to office
       SecurityGroupIngress:
+      - IpProtocol: tcp
+        FromPort: '22'
+        ToPort: '22'
+        CidrIp: 77.91.248.0/21
       - IpProtocol: tcp
         FromPort: '9000'
         ToPort: '9000'


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
GDPR / CyberEssentials mandates that only ports through which a service needs to communicate should be open. We only want outbound HTTPS to be opened for most instances.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->

Removed the security group giving us SSH access to the box and instead attached the ingress rule to the instance's security group. This was because the default if no egress rule is selected is to open up a rule allowing outbound access to all ports and IP protocols to any location. See 'Remove Default Rule': https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html

<img width="818" alt="picture 409" src="https://user-images.githubusercontent.com/1515970/38030147-bb09c8bc-328f-11e8-8470-98a87edb7794.png">

cc @davidfurey @jacobwinch 

### trello card/screenshot/json/related PRs etc
