### PR TITLE
Enable alerts for contributions

### DIFF
--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -183,7 +183,7 @@ class AccountController(commonActions: CommonActions, override val controllerCom
       upToDatePaymentDetails <- OptionEither.liftOption(getUpToDatePaymentDetailsFromStripe(sub.accountId, paymentDetails).map(\/.right).recover { case x => \/.left(s"error getting up-to-date card details for payment method of account: ${sub.accountId}. Reason: $x") })
       accountSummary <- OptionEither.liftOption(tp.zuoraRestService.getAccount(sub.accountId).recover { case x => \/.left(s"error receiving account summary for subscription: ${sub.name} with account id ${sub.accountId}. Reason: $x") })
       stripeService = accountSummary.billToContact.country.map(RegionalStripeGateways.getGatewayForCountry).flatMap(tp.stripeServicesByPaymentGateway.get).getOrElse(tp.ukStripeService)
-      alertText <- OptionEither.liftEitherOption(membershipAlertText(accountSummary, sub, getPaymentMethod))
+      alertText <- OptionEither.liftEitherOption(alertText(accountSummary, sub, getPaymentMethod))
     } yield AccountDetails(contact, upToDatePaymentDetails, stripeService.publicKey, alertText).toResult).run.run.map {
       case \/-(Some(result)) =>
         logger.info(s"Successfully retrieved payment details result for identity user: ${maybeUserId.mkString}")

--- a/membership-attribute-service/app/services/AttributesMaker.scala
+++ b/membership-attribute-service/app/services/AttributesMaker.scala
@@ -53,7 +53,7 @@ class AttributesMaker extends LoggingWithLogstashFields{
 
       val justAlertableProducts = firstSubPerProduct.filterKeys(product => alertableProducts.contains(product))
 
-      justAlertableProducts.map { case (product, (account, subscription)) => ProductData(product, account, subscription) }.toList.sortWith(_.product.name > _.product.name)
+      justAlertableProducts.map { case (product, (account, subscription)) => ProductData(product, account, subscription) }.toList.sortWith(_.product.name < _.product.name)
     }
 
     def findFirstAlert(productData: List[ProductData]): Future[Option[String]] = productData match {

--- a/membership-attribute-service/app/services/AttributesMaker.scala
+++ b/membership-attribute-service/app/services/AttributesMaker.scala
@@ -19,7 +19,6 @@ case class ProductData(product:Product, account: ZuoraRestService.AccountObject,
 
 class AttributesMaker extends LoggingWithLogstashFields{
 
-  val alertableProducts = List(Product.Membership, Product.Contribution)
 
   def zuoraAttributes(
     identityId: String,
@@ -51,9 +50,7 @@ class AttributesMaker extends LoggingWithLogstashFields{
 
       val firstSubPerProduct = groupedByProduct.collect { case (Some(k), sub :: _) => (k, sub) }
 
-      val justAlertableProducts = firstSubPerProduct.filterKeys(product => alertableProducts.contains(product))
-
-      justAlertableProducts.map { case (product, (account, subscription)) => ProductData(product, account, subscription) }.toList.sortWith(_.product.name < _.product.name)
+      firstSubPerProduct.map { case (product, (account, subscription)) => ProductData(product, account, subscription) }.toList.sortWith(_.product.name < _.product.name)
     }
 
     def findFirstAlert(productData: List[ProductData]): Future[Option[String]] = productData match {

--- a/membership-attribute-service/app/services/PaymentFailureAlerter.scala
+++ b/membership-attribute-service/app/services/PaymentFailureAlerter.scala
@@ -2,7 +2,7 @@ package services
 
 import java.util.Locale
 
-import com.gu.memsub.subsv2.Subscription
+import com.gu.memsub.subsv2.{Subscription, SubscriptionPlan}
 import com.gu.memsub.subsv2.SubscriptionPlan.AnyPlan
 import com.gu.zuora.api.{RegionalStripeGateways, StripeAUMembershipGateway, StripeUKMembershipGateway}
 import com.gu.zuora.rest.ZuoraRestService.{AccountObject, AccountSummary, Invoice, PaymentMethodId, PaymentMethodResponse}
@@ -37,8 +37,7 @@ object PaymentFailureAlerter extends LoggingWithLogstashFields {
     latestUnpaidInvoice.map (_.invoiceDate)
   }
 
-
-  def membershipAlertText(
+  def alertText(
     accountSummary: AccountSummary, subscription: Subscription[AnyPlan],
     paymentMethodGetter: PaymentMethodId => Future[String \/ PaymentMethodResponse])(implicit ec: ExecutionContext) : Future[Option[String]] = {
 
@@ -52,6 +51,14 @@ object PaymentFailureAlerter extends LoggingWithLogstashFields {
         case None => Future.successful(None)
       }
 
+      def getProductDescription(subscription: Subscription[SubscriptionPlan.AnyPlan]) = if (subscription.asMembership.isDefined) {
+        s"${subscription.plan.productName} membership"
+      } else if (subscription.asContribution.isDefined) {
+        "contribution"
+      } else { //TODO SEE WHAT GENERIC TEXT WE SHOULD RETURN HERE
+        subscription.plan.productName
+      }
+
       def customFields(identityId: Option[String], paymentFailedDate: String, productName: String): List[LogFieldString] = {
         val logFields = List(LogFieldString("payment_failed_date", paymentFailedDate), LogFieldString("product_name", productName))
         identityId match {
@@ -61,11 +68,13 @@ object PaymentFailureAlerter extends LoggingWithLogstashFields {
       }
       maybePaymentMethodLatestDate map { maybeDate: Option[DateTime] =>
         maybeDate map { latestDate: DateTime =>
+          val productDescription = getProductDescription(subscription)
           val productName = subscription.plan.productName
-          val membershipAlertText = s"Our attempt to take payment for your $productName membership failed on ${latestDate.toString(formatter)}. Please check below that your card details are up to date."
+
           val fields = customFields(accountSummary.identityId, latestDate.toString(formatter), productName)
           logInfoWithCustomFields(s"Logging an alert for identityId: ${accountSummary.identityId} accountId: ${accountSummary.id}. Payment failed on ${latestDate.toString(formatter)}", fields)
-          membershipAlertText
+
+          s"Our attempt to take payment for your $productDescription failed on ${latestDate.toString(formatter)}. Please check below that your card details are up to date."
         }
       }
     }

--- a/membership-attribute-service/app/services/PaymentFailureAlerter.scala
+++ b/membership-attribute-service/app/services/PaymentFailureAlerter.scala
@@ -39,7 +39,8 @@ object PaymentFailureAlerter extends LoggingWithLogstashFields {
   }
 
   def alertText(
-    accountSummary: AccountSummary, subscription: Subscription[AnyPlan],
+    accountSummary: AccountSummary,
+    subscription: Subscription[AnyPlan],
     paymentMethodGetter: PaymentMethodId => Future[String \/ PaymentMethodResponse])(implicit ec: ExecutionContext) : Future[Option[String]] = {
 
     def expectedAlertText: Future[Option[String]] = {

--- a/membership-attribute-service/test/services/AttributesMakerTest.scala
+++ b/membership-attribute-service/test/services/AttributesMakerTest.scala
@@ -130,6 +130,45 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
       val result = AttributesMaker.zuoraAttributes(identityId, List(AccountWithSubscription(accountObjectWithBalance, Some(membership))), paymentMethodResponseRecentFailure, referenceDate)
       result must be_==(expected).await
     }
+    "return alertAvailableFor=contribution for an active recurring contribution in payment failure" in {
+      val expected = Some(ZuoraAttributes(
+        UserId = identityId,
+        Tier = None,
+        RecurringContributionPaymentPlan = Some("Monthly Contribution"),
+        MembershipJoinDate = None,
+        AlertAvailableFor = Some("contribution")
+      )
+      )
+      val result = AttributesMaker.zuoraAttributes(identityId, List(AccountWithSubscription(accountObjectWithBalance, Some(contributor))), paymentMethodResponseRecentFailure, referenceDate)
+      result must be_==(expected).await
+    }
+
+    "return alertAvailableFor=contribution when there is an active contribution and membership, both in payment failure" in {
+      val expected = Some(ZuoraAttributes(
+        UserId = identityId,
+        Tier = Some("Supporter"),
+        RecurringContributionPaymentPlan = Some("Monthly Contribution"),
+        MembershipJoinDate = Some(referenceDate),
+        AlertAvailableFor = Some("contribution")
+      )
+      )
+      val result = AttributesMaker.zuoraAttributes(identityId, List(AccountWithSubscription(accountObjectWithBalance, Some(membership)), AccountWithSubscription(accountObjectWithBalance, Some(contributor))), paymentMethodResponseRecentFailure, referenceDate)
+      result must be_==(expected).await
+    }
+
+    "still return alertAvailableFor=contribution when there is an active contribution and paper sub, both in payment failure" in {
+      val expected = Some(ZuoraAttributes(
+        UserId = identityId,
+        Tier = None,
+        RecurringContributionPaymentPlan = Some("Monthly Contribution"),
+        MembershipJoinDate = None,
+        AlertAvailableFor = Some("contribution")
+      )
+      )
+      val result = AttributesMaker.zuoraAttributes(identityId, List(AccountWithSubscription(accountObjectWithBalance, Some(sunday)), AccountWithSubscription(accountObjectWithBalance, Some(contributor))), paymentMethodResponseRecentFailure, referenceDate)
+      result must be_==(expected).await
+    }
+
   }
 
 

--- a/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
+++ b/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
@@ -47,6 +47,16 @@ class PaymentFailureAlerterTest(implicit ee: ExecutionEnv)  extends Specificatio
         result must be_==(Some(expectedActionText)).await
       }
 
+      "return a message for a contributor who is in payment failure" in {
+        val result: Future[Option[String]] = PaymentFailureAlerter.alertText(accountSummaryWithBalance, contributor, paymentMethodResponseRecentFailure)
+
+        val attemptDateTime = DateTime.now().minusDays(1)
+        val formatter = DateTimeFormat.forPattern("d MMMM yyyy").withLocale(Locale.ENGLISH)
+        val expectedActionText = s"Our attempt to take payment for your contribution failed on ${attemptDateTime.toString(formatter)}. Please check below that your card details are up to date."
+
+        result must be_==(Some(expectedActionText)).await
+      }
+
     }
 
     "alertAvailableFor" should {
@@ -77,19 +87,19 @@ class PaymentFailureAlerterTest(implicit ee: ExecutionEnv)  extends Specificatio
         result must be_==(false).await
       }
 
-      "return true for for a member with a failed payment and an invoice in the last 27 days" in {
+      "return true for a member with a failed payment and an invoice in the last 27 days" in {
         val result = PaymentFailureAlerter.alertAvailableFor(accountObjectWithBalance, membership, paymentMethodResponseRecentFailure)
 
         result must be_==(true).await
       }
 
-      "return true for for a non-membership sub with a failed payment in the last 27 days too" in {
-        val result = PaymentFailureAlerter.alertAvailableFor(accountObjectWithBalance, digipack, paymentMethodResponseRecentFailure)
+      "return true for a contributor with a failed payment and an invoice in the last 27 days" in {
+        val result = PaymentFailureAlerter.alertAvailableFor(accountObjectWithBalance, contributor, paymentMethodResponseRecentFailure)
 
         result must be_==(true).await
       }
 
-      "return false for for a cancelled membership with a failed payment in the last 27 days" in {
+      "return false for a cancelled membership with a failed payment in the last 27 days" in {
         val result = PaymentFailureAlerter.alertAvailableFor(accountObjectWithBalance, cancelledMembership, paymentMethodResponseRecentFailure)
 
         result must be_==(false).await

--- a/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
+++ b/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
@@ -26,19 +26,19 @@ class PaymentFailureAlerterTest(implicit ee: ExecutionEnv)  extends Specificatio
   "PaymentFailureAlerterTest" should {
     "membershipAlertText" should {
       "not return any for a user with no balance" in {
-        val result: Future[Option[String]] = PaymentFailureAlerter.membershipAlertText(accountSummaryWithZeroBalance, membership, paymentMethodResponseNoFailures)
+        val result: Future[Option[String]] = PaymentFailureAlerter.alertText(accountSummaryWithZeroBalance, membership, paymentMethodResponseNoFailures)
 
         result must be_==(None).await
       }
 
       "return none if one of the zuora calls returns a left" in {
-        val result: Future[Option[String]] = PaymentFailureAlerter.membershipAlertText(accountSummaryWithBalance, membership, paymentMethodLeftResponse)
+        val result: Future[Option[String]] = PaymentFailureAlerter.alertText(accountSummaryWithBalance, membership, paymentMethodLeftResponse)
 
         result must be_==(None).await
       }
 
       "return a message for a member who is in payment failure" in {
-        val result: Future[Option[String]] = PaymentFailureAlerter.membershipAlertText(accountSummaryWithBalance, membership, paymentMethodResponseRecentFailure)
+        val result: Future[Option[String]] = PaymentFailureAlerter.alertText(accountSummaryWithBalance, membership, paymentMethodResponseRecentFailure)
 
         val attemptDateTime = DateTime.now().minusDays(1)
         val formatter = DateTimeFormat.forPattern("d MMMM yyyy").withLocale(Locale.ENGLISH)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.1-SNAPSHOT"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.515"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.9"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.2"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.509"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.1-SNAPSHOT"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.9"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.2"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"


### PR DESCRIPTION
We need to add support for contributions in members data api responses related to the payment failure banner in order to alert users about their failed monthly contribution payments.

Before merging this we need to merge the [frontend PR](https://github.com/guardian/frontend/pull/19579) that adds support for contribution messages. 

trello card:
https://trello.com/c/4oLsE7a0/308-roll-out-banner-to-contributions-e-6