### PR TITLE
Scrub personally identifiable information before logging to Sentry

### DIFF
--- a/membership-attribute-service/app/loghandling/LoggingWithLogstashFields.scala
+++ b/membership-attribute-service/app/loghandling/LoggingWithLogstashFields.scala
@@ -19,9 +19,6 @@ trait LoggingWithLogstashFields {
     log.logger.warn(customFieldMarkers(customFields), message)
   }
 
-  def logErrorWithCustomFields(message: String, customFields: List[LogField]): Unit = {
-    log.logger.error(customFieldMarkers(customFields), message)
-  }
 }
 
 object LoggingField {

--- a/membership-attribute-service/app/monitoring/ErrorHandling.scala
+++ b/membership-attribute-service/app/monitoring/ErrorHandling.scala
@@ -1,4 +1,6 @@
 package monitoring
+import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.SafeLogger._
 import com.typesafe.scalalogging.LazyLogging
 import controllers.{Cached, NoCache}
 import filters.AddGuIdentityHeaders
@@ -8,8 +10,9 @@ import play.api.mvc.Results._
 import play.api.mvc._
 import play.api.routing.Router
 import play.core.SourceMapper
-import models.ApiErrors.{notFound, internalError, badRequest}
+import models.ApiErrors.{badRequest, internalError, notFound}
 import play.api.libs.json.Json
+
 import scala.concurrent._
 
 class ErrorHandler(
@@ -32,7 +35,7 @@ class ErrorHandler(
   }
 
   override protected def onProdServerError(request: RequestHeader, ex: UsefulException): Future[Result] = {
-       logger.error(s"Error handling request request: $request", ex)
+       SafeLogger.error(scrub"Error handling request request: $request", ex)
        Future { AddGuIdentityHeaders.headersFor(request, internalError) }
   }
   override protected def onBadRequest(request: RequestHeader, message: String): Future[Result] = {

--- a/membership-attribute-service/app/monitoring/SentryLogging.scala
+++ b/membership-attribute-service/app/monitoring/SentryLogging.scala
@@ -1,7 +1,12 @@
 package monitoring
 
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.filter.Filter
+import ch.qos.logback.core.spi.FilterReply
+import com.gu.monitoring.SafeLogger
 import io.sentry.Sentry
 import configuration.Config
+
 import scala.collection.JavaConversions._
 
 object SentryLogging {
@@ -16,4 +21,9 @@ object SentryLogging {
         sentryClient.setTags(tags)
     }
   }
+}
+
+class PiiFilter extends Filter[ILoggingEvent] {
+  override def decide(event: ILoggingEvent): FilterReply = if (event.getMarker.contains(SafeLogger.sanitizedLogMessage)) FilterReply.ACCEPT
+  else FilterReply.DENY
 }

--- a/membership-attribute-service/app/services/ScanamoAttributeService.scala
+++ b/membership-attribute-service/app/services/ScanamoAttributeService.scala
@@ -2,6 +2,8 @@ package services
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
 import com.amazonaws.services.dynamodbv2.model.{DeleteItemResult, PutItemResult}
+import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.SafeLogger._
 import com.gu.scanamo._
 import com.gu.scanamo.error.{DynamoReadError, MissingProperty}
 import com.gu.scanamo.syntax.{set => scanamoSet, _}
@@ -83,7 +85,7 @@ class ScanamoAttributeService(client: AmazonDynamoDBAsync, table: String)(implic
       attributes <- dynamoAttributes
     } yield TtlConversions.secondsToDateTime(attributes.TTLTimestamp).isBefore(oldestAcceptedAge)
     if (tooOld.contains(true)) {
-      logger.error(s"Dynamo Attributes for $identityId have an old TTL. The oldest accepted age is: $oldestAcceptedAge - are we still cleaning the table correctly?")
+      SafeLogger.error(scrub"Dynamo Attributes for $identityId have an old TTL. The oldest accepted age is: $oldestAcceptedAge - are we still cleaning the table correctly?")
       metrics.put("Old Dynamo Item", 1) //referenced in CloudFormation
     }
   }

--- a/membership-attribute-service/conf/logback.xml
+++ b/membership-attribute-service/conf/logback.xml
@@ -23,11 +23,14 @@
         </encoder>
     </appender>
 
-        <appender name="Sentry" class="io.sentry.logback.SentryAppender">
-            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-                <level>ERROR</level>
-            </filter>
-        </appender>
+    <appender name="Sentry" class="io.sentry.logback.SentryAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+        <filter class="monitoring.PiiFilter">
+            <level>ERROR</level>
+        </filter>
+    </appender>
 
     <logger name="com.google.api.client.http" level="WARN" />
 


### PR DESCRIPTION
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
This PR makes sure that we don't send any personally identifiable information to Sentry while still allowing us to log it elsewhere for diagnostic purposes

[This PR](https://github.com/guardian/support-frontend/pull/494) has more discussion of the approach taken