### PR TITLE
Turn off logstash while we decommission the existing ELK stack

### DIFF
--- a/membership-attribute-service/conf/CODE.public.conf
+++ b/membership-attribute-service/conf/CODE.public.conf
@@ -1,3 +1,3 @@
 include "DEV.public"
 
-logstash.enabled=true
+logstash.enabled=false

--- a/membership-attribute-service/conf/PROD.public.conf
+++ b/membership-attribute-service/conf/PROD.public.conf
@@ -31,4 +31,4 @@ ft.cors.allowedOrigins = [
   "https://interactive.guim.co.uk"
 ]
 
-logstash.enabled=true
+logstash.enabled=false


### PR DESCRIPTION
### Why do we need this?
We're going to remove the ELK stack that we're shipping logs to as part of GDPR changes. This PR stops the application from attempting to communicate with the Kinesis stream that will disappear when the stack is deleted.

Later on, we'll have created a new Kinesis stream that sends fully GDPR-compliant data to a new backend. Then we can re-enable (or revert this PR) when the new stream is available and configured for this application.

### The changes
PROD and CODE configuration files changed to set `logstash.enabled` to `false`.

### trello card/screenshot/json/related PRs etc
[delete-elk-stack-for-supporter-experience](https://trello.com/c/BPgeI0BP/1553-delete-elk-stack-for-supporter-experience)

### Screenshots
![screen shot 2018-05-23 at 11 22 29](https://user-images.githubusercontent.com/690395/40419254-a2f2c72e-5e7c-11e8-9a43-01ae70ff8a85.png)
