### PR TITLE
Fresh Sentry project

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -26,7 +26,6 @@ class AttributeController(attributesFromZuora: AttributesFromZuora, commonAction
   lazy val metrics = Metrics("AttributesController")
 
   def pickAttributes(identityId: String) (implicit request: BackendRequest[AnyContent]): Future[(String, Option[Attributes])] = {
-    SafeLogger.error(scrub"*TEST* more spam from Leigh-Anne: Don't tell, reader, but you are my favourite colleague. ")
     val dynamoService = request.touchpoint.attrService
     val featureToggleData = request.touchpoint.featureToggleData.getZuoraLookupFeatureDataTask.get()
     val concurrentCallThreshold = featureToggleData.ConcurrentZuoraCallThreshold

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -2,6 +2,8 @@ package controllers
 
 import actions._
 import com.gu.memsub.subsv2.SubscriptionPlan.AnyPlan
+import com.gu.monitoring.SafeLogger._
+import com.gu.monitoring.SafeLogger
 import configuration.Config
 import loghandling.LoggingField.{LogField, LogFieldString}
 import loghandling.{LoggingWithLogstashFields, ZuoraRequestCounter}
@@ -24,6 +26,7 @@ class AttributeController(attributesFromZuora: AttributesFromZuora, commonAction
   lazy val metrics = Metrics("AttributesController")
 
   def pickAttributes(identityId: String) (implicit request: BackendRequest[AnyContent]): Future[(String, Option[Attributes])] = {
+    SafeLogger.error(scrub"*TEST* more spam from Leigh-Anne: Don't tell, reader, but you are my favourite colleague. ")
     val dynamoService = request.touchpoint.attrService
     val featureToggleData = request.touchpoint.featureToggleData.getZuoraLookupFeatureDataTask.get()
     val concurrentCallThreshold = featureToggleData.ConcurrentZuoraCallThreshold

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -2,8 +2,6 @@ package controllers
 
 import actions._
 import com.gu.memsub.subsv2.SubscriptionPlan.AnyPlan
-import com.gu.monitoring.SafeLogger._
-import com.gu.monitoring.SafeLogger
 import configuration.Config
 import loghandling.LoggingField.{LogField, LogFieldString}
 import loghandling.{LoggingWithLogstashFields, ZuoraRequestCounter}

--- a/membership-attribute-service/app/monitoring/SentryLogging.scala
+++ b/membership-attribute-service/app/monitoring/SentryLogging.scala
@@ -1,23 +1,26 @@
 package monitoring
 
+import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.SafeLogger._
 import io.sentry.Sentry
 import configuration.Config
+
 import scala.collection.JavaConversions._
 import scala.util.{Failure, Try}
 
 object SentryLogging {
   def init() {
       Config.sentryDsn match {
-        case None => play.api.Logger.warn("No Sentry logging configured (OK for dev)")
+        case None => SafeLogger.warn("No Sentry logging configured (OK for dev)")
         case Some(sentryDSN) =>
-          play.api.Logger.info(s"Initialising Sentry logging")
+          SafeLogger.info(s"Initialising Sentry logging")
           Try {
             val sentryClient = Sentry.init(sentryDSN)
             val buildInfo: Map[String, String] = app.BuildInfo.toMap.mapValues(_.toString)
             val tags = Map("stage" -> Config.stage) ++ buildInfo
             sentryClient.setTags(tags)
           } match {
-            case Failure(e) => play.api.Logger.warn(s"Something went wrong when setting up Sentry logging ${e.getStackTrace}")
+            case Failure(e) => SafeLogger.error(scrub"Something went wrong when setting up Sentry logging ${e.getStackTrace}")
           }
       }
 

--- a/membership-attribute-service/app/monitoring/SentryLogging.scala
+++ b/membership-attribute-service/app/monitoring/SentryLogging.scala
@@ -2,18 +2,25 @@ package monitoring
 
 import io.sentry.Sentry
 import configuration.Config
+
 import scala.collection.JavaConversions._
+import scala.util.{Failure, Try}
 
 object SentryLogging {
   def init() {
-    Config.sentryDsn match {
-      case None => play.api.Logger.warn("No Sentry logging configured (OK for dev)")
-      case Some(sentryDSN) =>
-        play.api.Logger.info(s"Initialising Sentry logging")
-        val sentryClient = Sentry.init(sentryDSN)
-        val buildInfo: Map[String, String] = app.BuildInfo.toMap.mapValues(_.toString)
-        val tags = Map("stage" -> Config.stage) ++ buildInfo
-        sentryClient.setTags(tags)
-    }
+      Config.sentryDsn match {
+        case None => play.api.Logger.warn("No Sentry logging configured (OK for dev)")
+        case Some(sentryDSN) =>
+          play.api.Logger.info(s"Initialising Sentry logging")
+          Try {
+            val sentryClient = Sentry.init(sentryDSN)
+            val buildInfo: Map[String, String] = app.BuildInfo.toMap.mapValues(_.toString)
+            val tags = Map("stage" -> Config.stage) ++ buildInfo
+            sentryClient.setTags(tags)
+          } match {
+            case Failure(e) => play.api.Logger.warn(s"Something went wrong when setting up Sentry logging ${e.getStackTrace}")
+          }
+      }
+
   }
 }

--- a/membership-attribute-service/app/monitoring/SentryLogging.scala
+++ b/membership-attribute-service/app/monitoring/SentryLogging.scala
@@ -2,7 +2,6 @@ package monitoring
 
 import io.sentry.Sentry
 import configuration.Config
-
 import scala.collection.JavaConversions._
 import scala.util.{Failure, Try}
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   //versions
   val awsClientVersion = "1.11.286"
   //libraries
-  val sentryLogback = "io.sentry" % "sentry-logback" % "1.7.0"
+  val sentryLogback = "io.sentry" % "sentry-logback" % "1.7.5"
   val identityCookie = "com.gu.identity" %% "identity-cookie" % "3.99"
   val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "2.1"
   val identityTestUsers =  "com.gu" %% "identity-test-users" % "0.7"


### PR DESCRIPTION
### Why do we need this? 
We scrubbed PII here:  https://github.com/guardian/members-data-api/pull/324

Once  https://github.com/guardian/members-data-api/pull/324 is merged, we will point to a new sentry project, and delete the old to start anew. 

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
* Pointing to the DSN of the new project
* New version of sentry-logback
* Wrap Sentry.init in a try 

TODO:
Pre-merge
- [x] Test in CODE that error logs go to the new project
- [x] Add the DSN for the new sentry project to the PROD config 
- [x] Remove the DSN from the CODE config

Post-merge
- [ ] Delete the existing sentry project
- [ ] Rename the new sentry project back to members-data-api as before


### trello card/screenshot/json/related PRs etc
[**Trello Card**](https://trello.com/c/LiojyKYR/1555-delete-all-projects-which-contain-pii-from-sentry-and-replace-with-a-clean-project)
[Scrub PII from logs sent to sentry]( https://github.com/guardian/members-data-api/pull/324)