### PR TITLE
Revert "Fresh Sentry project"

### DIFF
--- a/membership-attribute-service/app/monitoring/SentryLogging.scala
+++ b/membership-attribute-service/app/monitoring/SentryLogging.scala
@@ -1,7 +1,5 @@
 package monitoring
 
-import com.gu.monitoring.SafeLogger
-import com.gu.monitoring.SafeLogger._
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.filter.Filter
 import ch.qos.logback.core.spi.FilterReply
@@ -10,24 +8,18 @@ import io.sentry.Sentry
 import configuration.Config
 
 import scala.collection.JavaConversions._
-import scala.util.{Failure, Try}
 
 object SentryLogging {
   def init() {
-      Config.sentryDsn match {
-        case None => SafeLogger.warn("No Sentry logging configured (OK for dev)")
-        case Some(sentryDSN) =>
-          SafeLogger.info(s"Initialising Sentry logging")
-          Try {
-            val sentryClient = Sentry.init(sentryDSN)
-            val buildInfo: Map[String, String] = app.BuildInfo.toMap.mapValues(_.toString)
-            val tags = Map("stage" -> Config.stage) ++ buildInfo
-            sentryClient.setTags(tags)
-          } match {
-            case Failure(e) => SafeLogger.error(scrub"Something went wrong when setting up Sentry logging ${e.getStackTrace}")
-          }
-      }
-
+    Config.sentryDsn match {
+      case None => play.api.Logger.warn("No Sentry logging configured (OK for dev)")
+      case Some(sentryDSN) =>
+        play.api.Logger.info(s"Initialising Sentry logging")
+        val sentryClient = Sentry.init(sentryDSN)
+        val buildInfo: Map[String, String] = app.BuildInfo.toMap.mapValues(_.toString)
+        val tags = Map("stage" -> Config.stage) ++ buildInfo
+        sentryClient.setTags(tags)
+    }
   }
 }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   //versions
   val awsClientVersion = "1.11.286"
   //libraries
-  val sentryLogback = "io.sentry" % "sentry-logback" % "1.7.5"
+  val sentryLogback = "io.sentry" % "sentry-logback" % "1.7.0"
   val identityCookie = "com.gu.identity" %% "identity-cookie" % "3.99"
   val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "2.1"
   val identityTestUsers =  "com.gu" %% "identity-test-users" % "0.7"


### PR DESCRIPTION
Reverts guardian/members-data-api#327

The deploy failed when I merged this change, so we shall revert this change while looking into the issue. 