### PR TITLE
Remove the Qualys Vulnerability Scanner security group as we now use AWS Inspector

### DIFF
--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -37,9 +37,6 @@ Parameters:
   AmiId:
     Description: Custom AMI to use for instances
     Type: String
-  VulnerabilityScanningSecurityGroup:
-    Description: Security group that grants access to the account's Vulnerability Scanner
-    Type: AWS::EC2::SecurityGroup::Id
   ELBSSLCertificate:
     Description: ELB SSL Certificate ARN
     Type: String
@@ -217,7 +214,6 @@ Resources:
         Ref: AmiId
       SecurityGroups:
       - Ref: InstanceSecurityGroup
-      - Ref: VulnerabilityScanningSecurityGroup
       InstanceType:
         Ref: InstanceType
       AssociatePublicIpAddress: 'True'


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
Save costs.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
Remove security group from instance, so I can deprovision the cloudformation stack for the Vulnerability Scanner.

### trello card/screenshot/json/related PRs etc
