### PR TITLE
routes for cancelling membership (paid & free)

### DIFF
--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -224,7 +224,7 @@ class AccountController(commonActions: CommonActions, override val controllerCom
   }
 
   def cancelRegularContribution = cancelSubscription[SubscriptionPlan.Contributor]
-  def cancelMembership = cancelSubscription[SubscriptionPlan.PaidMember]
+  def cancelPaidMembership = cancelSubscription[SubscriptionPlan.PaidMember]
   def cancelFreeMembership = cancelSubscription[SubscriptionPlan.FreeMember]
 
   def membershipUpdateCard = updateCard[SubscriptionPlan.PaidMember]

--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -224,6 +224,8 @@ class AccountController(commonActions: CommonActions, override val controllerCom
   }
 
   def cancelRegularContribution = cancelSubscription[SubscriptionPlan.Contributor]
+  def cancelMembership = cancelSubscription[SubscriptionPlan.PaidMember]
+  def cancelFreeMembership = cancelSubscription[SubscriptionPlan.FreeMember]
 
   def membershipUpdateCard = updateCard[SubscriptionPlan.PaidMember]
   def digitalPackUpdateCard = updateCard[SubscriptionPlan.Digipack]

--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -226,8 +226,7 @@ class AccountController(commonActions: CommonActions, override val controllerCom
   }
 
   def cancelRegularContribution = cancelSubscription[SubscriptionPlan.Contributor]
-  def cancelPaidMembership = cancelSubscription[SubscriptionPlan.PaidMember]
-  def cancelFreeMembership = cancelSubscription[SubscriptionPlan.FreeMember]
+  def cancelMembership = cancelSubscription[SubscriptionPlan.Member]
 
   def membershipUpdateCard = updateCard[SubscriptionPlan.PaidMember]
   def digitalPackUpdateCard = updateCard[SubscriptionPlan.Digipack]

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -24,6 +24,12 @@ OPTIONS    /user-attributes/me/contribution-update-card      controllers.Account
 POST       /user-attributes/me/cancel-regular-contribution   controllers.AccountController.cancelRegularContribution
 OPTIONS    /user-attributes/me/cancel-regular-contribution   controllers.AccountController.cancelRegularContribution
 
+POST       /user-attributes/me/cancel-membership   controllers.AccountController.cancelMembership
+OPTIONS    /user-attributes/me/cancel-membership   controllers.AccountController.cancelMembership
+
+POST       /user-attributes/me/cancel-free-membership   controllers.AccountController.cancelFreeMembership
+OPTIONS    /user-attributes/me/cancel-free-membership   controllers.AccountController.cancelFreeMembership
+
 POST       /user-attributes/me/contribution-update-amount   controllers.AccountController.contributionUpdateAmount
 OPTIONS    /user-attributes/me/contribution-update-amount   controllers.AccountController.contributionUpdateAmount
 

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -15,20 +15,17 @@ OPTIONS    /user-attributes/me/membership-update-card       controllers.AccountC
 POST       /user-attributes/me/digitalpack-update-card      controllers.AccountController.digitalPackUpdateCard
 OPTIONS    /user-attributes/me/digitalpack-update-card      controllers.AccountController.digitalPackUpdateCard
 
-POST       /user-attributes/me/paper-update-card      controllers.AccountController.paperUpdateCard
-OPTIONS    /user-attributes/me/paper-update-card      controllers.AccountController.paperUpdateCard
+POST       /user-attributes/me/paper-update-card            controllers.AccountController.paperUpdateCard
+OPTIONS    /user-attributes/me/paper-update-card            controllers.AccountController.paperUpdateCard
 
-POST       /user-attributes/me/contribution-update-card      controllers.AccountController.contributionUpdateCard
-OPTIONS    /user-attributes/me/contribution-update-card      controllers.AccountController.contributionUpdateCard
+POST       /user-attributes/me/contribution-update-card     controllers.AccountController.contributionUpdateCard
+OPTIONS    /user-attributes/me/contribution-update-card     controllers.AccountController.contributionUpdateCard
 
-POST       /user-attributes/me/cancel-regular-contribution   controllers.AccountController.cancelRegularContribution
-OPTIONS    /user-attributes/me/cancel-regular-contribution   controllers.AccountController.cancelRegularContribution
+POST       /user-attributes/me/cancel-regular-contribution  controllers.AccountController.cancelRegularContribution
+OPTIONS    /user-attributes/me/cancel-regular-contribution  controllers.AccountController.cancelRegularContribution
 
-POST       /user-attributes/me/cancel-paid-membership   controllers.AccountController.cancelPaidMembership
-OPTIONS    /user-attributes/me/cancel-paid-membership   controllers.AccountController.cancelPaidMembership
-
-POST       /user-attributes/me/cancel-free-membership   controllers.AccountController.cancelFreeMembership
-OPTIONS    /user-attributes/me/cancel-free-membership   controllers.AccountController.cancelFreeMembership
+POST       /user-attributes/me/cancel-membership            controllers.AccountController.cancelMembership
+OPTIONS    /user-attributes/me/cancel-membership            controllers.AccountController.cancelMembership
 
 POST       /user-attributes/me/contribution-update-amount   controllers.AccountController.contributionUpdateAmount
 OPTIONS    /user-attributes/me/contribution-update-amount   controllers.AccountController.contributionUpdateAmount

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -24,8 +24,8 @@ OPTIONS    /user-attributes/me/contribution-update-card      controllers.Account
 POST       /user-attributes/me/cancel-regular-contribution   controllers.AccountController.cancelRegularContribution
 OPTIONS    /user-attributes/me/cancel-regular-contribution   controllers.AccountController.cancelRegularContribution
 
-POST       /user-attributes/me/cancel-membership   controllers.AccountController.cancelMembership
-OPTIONS    /user-attributes/me/cancel-membership   controllers.AccountController.cancelMembership
+POST       /user-attributes/me/cancel-paid-membership   controllers.AccountController.cancelPaidMembership
+OPTIONS    /user-attributes/me/cancel-paid-membership   controllers.AccountController.cancelPaidMembership
 
 POST       /user-attributes/me/cancel-free-membership   controllers.AccountController.cancelFreeMembership
 OPTIONS    /user-attributes/me/cancel-free-membership   controllers.AccountController.cancelFreeMembership


### PR DESCRIPTION
Added new endpoint...
`/user-attributes/me/cancel-membership`

... which make use of the existing `cancelSubscription` function (used for cancelling regular contributions).

Needed to support Supporter Experience team's new online cancellation flow (online saves OKR).