### PR TITLE
FIX: direct OPTIONS hit (without CORS pre-flight headers) would execute POST behaviour

### DIFF
--- a/membership-attribute-service/app/wiring/AppLoader.scala
+++ b/membership-attribute-service/app/wiring/AppLoader.scala
@@ -57,13 +57,7 @@ class MyComponents(context: Context)
     "/user-attributes/me/mma-membership",
     "/user-attributes/me/mma-paper")
 
-  val mmaUpdatePaths = Seq(
-    "/user-attributes/me/membership-update-card",
-    "/user-attributes/me/digitalpack-update-card",
-    "/user-attributes/me/paper-update-card",
-    "/user-attributes/me/contribution-update-card",
-    "/user-attributes/me/cancel-regular-contribution",
-    "/user-attributes/me/contribution-update-amount")
+  val postPaths = router.documentation.filter(triple => triple._1.contains("POST")).map(triple => triple._2)
 
   override lazy val httpFilters: Seq[EssentialFilter] = Seq(
     new CheckCacheHeadersFilter(),
@@ -71,7 +65,7 @@ class MyComponents(context: Context)
     new AddEC2InstanceHeader(wsClient),
     new AddGuIdentityHeaders(),
     CORSFilter(corsConfig = Config.mmaCorsConfig, pathPrefixes = mmaPaths),
-    CORSFilter(corsConfig = Config.mmaUpdateCorsConfig, pathPrefixes = mmaUpdatePaths),
+    CORSFilter(corsConfig = Config.mmaUpdateCorsConfig, pathPrefixes = postPaths),
     CORSFilter(corsConfig = Config.corsConfig, pathPrefixes = regularCorsPaths)
   )
 }

--- a/membership-attribute-service/app/wiring/AppLoader.scala
+++ b/membership-attribute-service/app/wiring/AppLoader.scala
@@ -57,7 +57,7 @@ class MyComponents(context: Context)
     "/user-attributes/me/mma-membership",
     "/user-attributes/me/mma-paper")
 
-  val postPaths = router.documentation.filter(triple => triple._1.contains("POST")).map(triple => triple._2)
+  val postPaths: List[String] = router.documentation.collect { case ("POST", path, _) => path }
 
   override lazy val httpFilters: Seq[EssentialFilter] = Seq(
     new CheckCacheHeadersFilter(),

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -1,4 +1,3 @@
-# Healthcheck
 GET        /healthcheck                                     controllers.HealthCheckController.healthCheck
 
 GET        /user-attributes/me/membership                   controllers.AttributeController.membership
@@ -9,7 +8,6 @@ GET        /user-attributes/me/mma-membership               controllers.AccountC
 GET        /user-attributes/me/mma-monthlycontribution      controllers.AccountController.monthlyContributionDetails
 GET        /user-attributes/me/mma-paper                    controllers.AccountController.paperDetails
 
-# IMPORTANT: for update endpoints (e.g. POST) to correctly support OPTIONS for CORS they must be added to AppLoader.scala
 POST       /user-attributes/me/membership-update-card       controllers.AccountController.membershipUpdateCard
 POST       /user-attributes/me/digitalpack-update-card      controllers.AccountController.digitalPackUpdateCard
 POST       /user-attributes/me/paper-update-card            controllers.AccountController.paperUpdateCard

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -9,26 +9,16 @@ GET        /user-attributes/me/mma-membership               controllers.AccountC
 GET        /user-attributes/me/mma-monthlycontribution      controllers.AccountController.monthlyContributionDetails
 GET        /user-attributes/me/mma-paper                    controllers.AccountController.paperDetails
 
+# IMPORTANT: for update endpoints (e.g. POST) to correctly support OPTIONS for CORS they must be added to AppLoader.scala
 POST       /user-attributes/me/membership-update-card       controllers.AccountController.membershipUpdateCard
-OPTIONS    /user-attributes/me/membership-update-card       controllers.AccountController.membershipUpdateCard
-
 POST       /user-attributes/me/digitalpack-update-card      controllers.AccountController.digitalPackUpdateCard
-OPTIONS    /user-attributes/me/digitalpack-update-card      controllers.AccountController.digitalPackUpdateCard
-
 POST       /user-attributes/me/paper-update-card            controllers.AccountController.paperUpdateCard
-OPTIONS    /user-attributes/me/paper-update-card            controllers.AccountController.paperUpdateCard
-
 POST       /user-attributes/me/contribution-update-card     controllers.AccountController.contributionUpdateCard
-OPTIONS    /user-attributes/me/contribution-update-card     controllers.AccountController.contributionUpdateCard
 
 POST       /user-attributes/me/cancel-regular-contribution  controllers.AccountController.cancelRegularContribution
-OPTIONS    /user-attributes/me/cancel-regular-contribution  controllers.AccountController.cancelRegularContribution
-
 POST       /user-attributes/me/cancel-membership            controllers.AccountController.cancelMembership
-OPTIONS    /user-attributes/me/cancel-membership            controllers.AccountController.cancelMembership
 
 POST       /user-attributes/me/contribution-update-amount   controllers.AccountController.contributionUpdateAmount
-OPTIONS    /user-attributes/me/contribution-update-amount   controllers.AccountController.contributionUpdateAmount
 
 #The endpoint below will replace /user-attributes/me/membership in the long term
 GET        /user-attributes/me                              controllers.AttributeController.attributes


### PR DESCRIPTION
removed `OPTIONS` routes from `routes` file as were unnecessary and could be called directly which would in-fact perform POST behaviour. 

Also made the CORSFilter build its list of POST paths dynamically from the generated `Routes.scala`