### PR TITLE
Use the latest membership common

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.515"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.519"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.9"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.2"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"


### PR DESCRIPTION
### Why do we need this? 
* To remove some unused metrics (which cost us money)
* To keep up to date with the latest version of this library

### The changes 
* Use futureRunner instead of loggingRunner (which pushes several CloudWatch metrics for every HTTP request) for a number of services.

### trello card/screenshot/json/related PRs etc
See also:

https://github.com/guardian/membership-frontend/pull/1828
https://github.com/guardian/membership-common/pull/578