### PR TITLE
Recognise cancelled contributors correctly

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.519"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.520"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.9"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.2"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"


### PR DESCRIPTION
### Why do we need this?
This allows cancelled recurring contributors to sign up again after cancellation. It also allows us to start showing them the epic/banner again.

For more detail, see https://github.com/guardian/membership-common/pull/580.

### The changes
* Update membership-common

### trello card/screenshot/json/related PRs etc
https://trello.com/c/Vgy8FS6g/23-allow-a-user-who-cancelled-his-her-account-to-make-another-recurring-contribution-within-the-same-month