### PR TITLE
Add delete override to dynamo attributes for staff ad-free trial

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -52,7 +52,7 @@ class AttributeController(attributesFromZuora: AttributesFromZuora, commonAction
             def customFields(supporterType: String): List[LogField] = List(LogFieldString("lookup-endpoint-description", endpointDescription), LogFieldString("supporter-type", supporterType), LogFieldString("data-source", fromWhere))
 
             attributes match {
-              case Some(attrs @ Attributes(_, Some(tier), _, _, _, _, _, _)) =>
+              case Some(attrs @ Attributes(_, Some(tier), _, _, _, _, _, _, _)) =>
                 logInfoWithCustomFields(s"$identityId is a $tier member - $endpointDescription - $attrs found via $fromWhere", customFields("member"))
                 onSuccessMember(attrs).withHeaders(
                   "X-Gu-Membership-Tier" -> tier,

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -61,7 +61,7 @@ case class DynamoAttributes(
   DigitalSubscriptionExpiryDate: Option[LocalDate] = None,
   MembershipNumber: Option[String],
   AdFree: Option[Boolean],
-  KeepFreshForStaffAdFree: Option[Boolean],
+  KeepFreshForStaffAdFree: Option[Boolean] = None,
   TTLTimestamp: Long) {
   lazy val isFriendTier = Tier.exists(_.equalsIgnoreCase("friend"))
   lazy val isSupporterTier = Tier.exists(_.equalsIgnoreCase("supporter"))

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -27,6 +27,7 @@ case class Attributes(
   DigitalSubscriptionExpiryDate: Option[LocalDate] = None,
   MembershipNumber: Option[String] = None,
   AdFree: Option[Boolean] = None,
+  KeepFresh: Option[Boolean] = None,
   AlertAvailableFor: Option[String] = None) {
   lazy val isFriendTier = Tier.exists(_.equalsIgnoreCase("friend"))
   lazy val isSupporterTier = Tier.exists(_.equalsIgnoreCase("supporter"))
@@ -60,6 +61,7 @@ case class DynamoAttributes(
   DigitalSubscriptionExpiryDate: Option[LocalDate] = None,
   MembershipNumber: Option[String],
   AdFree: Option[Boolean],
+  KeepFresh: Option[Boolean],
   TTLTimestamp: Long) {
   lazy val isFriendTier = Tier.exists(_.equalsIgnoreCase("friend"))
   lazy val isSupporterTier = Tier.exists(_.equalsIgnoreCase("supporter"))
@@ -77,7 +79,8 @@ object DynamoAttributes {
     MembershipJoinDate = dynamoAttributes.MembershipJoinDate,
     DigitalSubscriptionExpiryDate = dynamoAttributes.DigitalSubscriptionExpiryDate,
     MembershipNumber = dynamoAttributes.MembershipNumber,
-    AdFree = dynamoAttributes.AdFree
+    AdFree = dynamoAttributes.AdFree,
+    KeepFresh = dynamoAttributes.KeepFresh
   )
 }
 
@@ -91,6 +94,7 @@ object Attributes {
       (__ \ "digitalSubscriptionExpiryDate").writeNullable[LocalDate] and
       (__ \ "membershipNumber").writeNullable[String] and
       (__ \ "adFree").writeNullable[Boolean] and
+      (__ \ "keepFresh").writeNullable[Boolean] and
       (__ \ "alertAvailableFor").writeNullable[String]
   )(unlift(Attributes.unapply))
     .addNullableField("digitalSubscriptionExpiryDate", _.latestDigitalSubscriptionExpiryDate)

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -27,7 +27,7 @@ case class Attributes(
   DigitalSubscriptionExpiryDate: Option[LocalDate] = None,
   MembershipNumber: Option[String] = None,
   AdFree: Option[Boolean] = None,
-  KeepFresh: Option[Boolean] = None,
+  KeepFreshForStaffAdFree: Option[Boolean] = None,
   AlertAvailableFor: Option[String] = None) {
   lazy val isFriendTier = Tier.exists(_.equalsIgnoreCase("friend"))
   lazy val isSupporterTier = Tier.exists(_.equalsIgnoreCase("supporter"))
@@ -61,7 +61,7 @@ case class DynamoAttributes(
   DigitalSubscriptionExpiryDate: Option[LocalDate] = None,
   MembershipNumber: Option[String],
   AdFree: Option[Boolean],
-  KeepFresh: Option[Boolean],
+  KeepFreshForStaffAdFree: Option[Boolean],
   TTLTimestamp: Long) {
   lazy val isFriendTier = Tier.exists(_.equalsIgnoreCase("friend"))
   lazy val isSupporterTier = Tier.exists(_.equalsIgnoreCase("supporter"))
@@ -80,7 +80,7 @@ object DynamoAttributes {
     DigitalSubscriptionExpiryDate = dynamoAttributes.DigitalSubscriptionExpiryDate,
     MembershipNumber = dynamoAttributes.MembershipNumber,
     AdFree = dynamoAttributes.AdFree,
-    KeepFresh = dynamoAttributes.KeepFresh
+    KeepFreshForStaffAdFree = dynamoAttributes.KeepFreshForStaffAdFree
   )
 }
 
@@ -94,7 +94,7 @@ object Attributes {
       (__ \ "digitalSubscriptionExpiryDate").writeNullable[LocalDate] and
       (__ \ "membershipNumber").writeNullable[String] and
       (__ \ "adFree").writeNullable[Boolean] and
-      (__ \ "keepFresh").writeNullable[Boolean] and
+      (__ \ "keepFreshForStaffAdFree").writeNullable[Boolean] and
       (__ \ "alertAvailableFor").writeNullable[String]
   )(unlift(Attributes.unapply))
     .addNullableField("digitalSubscriptionExpiryDate", _.latestDigitalSubscriptionExpiryDate)

--- a/membership-attribute-service/app/services/AttributesFromZuora.scala
+++ b/membership-attribute-service/app/services/AttributesFromZuora.scala
@@ -107,7 +107,8 @@ class AttributesFromZuora(implicit val executionContext: ExecutionContext) exten
     val currentExpiry: Option[DateTime] = dynamoAttributes.map { attributes => TtlConversions.secondsToDateTime(attributes.TTLTimestamp) }
     val newExpiry: DateTime = calculateExpiry(currentExpiry)
 
-    def expiryShouldChange(dynamoAttributes: Option[DynamoAttributes], currentExpiry: Option[DateTime], newExpiry: DateTime) = dynamoAttributes.isDefined && !currentExpiry.contains(newExpiry)
+    def expiryShouldChange(dynamoAttributes: Option[DynamoAttributes], currentExpiry: Option[DateTime], newExpiry: DateTime) =
+      dynamoAttributes.isDefined && (!currentExpiry.contains(newExpiry) || dynamoAttributes.exists(_.KeepFresh.getOrElse(false)))
 
     expiryShouldChange(dynamoAttributes, currentExpiry, newExpiry) || !dynamoAndZuoraAgree(dynamoAttributes, zuoraAttributes, identityId)
   }
@@ -122,6 +123,7 @@ class AttributesFromZuora(implicit val executionContext: ExecutionContext) exten
         attributes.DigitalSubscriptionExpiryDate,
         attributes.MembershipNumber,
         attributes.AdFree,
+        attributes.KeepFresh,
         TtlConversions.toDynamoTtlInSeconds(twoWeekExpiry)
       )
     }

--- a/membership-attribute-service/app/services/AttributesFromZuora.scala
+++ b/membership-attribute-service/app/services/AttributesFromZuora.scala
@@ -108,7 +108,7 @@ class AttributesFromZuora(implicit val executionContext: ExecutionContext) exten
     val newExpiry: DateTime = calculateExpiry(currentExpiry)
 
     def expiryShouldChange(dynamoAttributes: Option[DynamoAttributes], currentExpiry: Option[DateTime], newExpiry: DateTime) =
-      dynamoAttributes.isDefined && (!currentExpiry.contains(newExpiry) || dynamoAttributes.exists(_.KeepFresh.getOrElse(false)))
+      dynamoAttributes.isDefined && (!currentExpiry.contains(newExpiry) || dynamoAttributes.exists(_.KeepFreshForStaffAdFree.getOrElse(false)))
 
     expiryShouldChange(dynamoAttributes, currentExpiry, newExpiry) || !dynamoAndZuoraAgree(dynamoAttributes, zuoraAttributes, identityId)
   }
@@ -123,7 +123,7 @@ class AttributesFromZuora(implicit val executionContext: ExecutionContext) exten
         attributes.DigitalSubscriptionExpiryDate,
         attributes.MembershipNumber,
         attributes.AdFree,
-        attributes.KeepFresh,
+        attributes.KeepFreshForStaffAdFree,
         TtlConversions.toDynamoTtlInSeconds(twoWeekExpiry)
       )
     }

--- a/membership-attribute-service/app/services/AttributesMaker.scala
+++ b/membership-attribute-service/app/services/AttributesMaker.scala
@@ -117,6 +117,7 @@ class AttributesMaker extends LoggingWithLogstashFields{
           DigitalSubscriptionExpiryDate = zuora.DigitalSubscriptionExpiryDate,
           MembershipNumber = dynamo.MembershipNumber,
           AdFree = dynamo.AdFree,
+          KeepFresh = dynamo.KeepFresh,
           AlertAvailableFor = zuora.AlertAvailableFor
         ))
       case (Some(zuora), None) =>
@@ -128,7 +129,20 @@ class AttributesMaker extends LoggingWithLogstashFields{
           DigitalSubscriptionExpiryDate = zuora.DigitalSubscriptionExpiryDate,
           MembershipNumber = None,
           AdFree = None,
+          KeepFresh = None,
           AlertAvailableFor = zuora.AlertAvailableFor
+        ))
+      case (None, Some(dynamo)) if dynamo.KeepFresh.getOrElse(false) =>
+        Some(Attributes(
+          UserId = dynamo.UserId,
+          Tier = None,
+          RecurringContributionPaymentPlan = None,
+          MembershipJoinDate = None,
+          DigitalSubscriptionExpiryDate = None,
+          MembershipNumber = None,
+          AdFree = dynamo.AdFree,
+          KeepFresh = dynamo.KeepFresh,
+          AlertAvailableFor = None
         ))
       case (None, _) => None
     }

--- a/membership-attribute-service/app/services/AttributesMaker.scala
+++ b/membership-attribute-service/app/services/AttributesMaker.scala
@@ -117,7 +117,7 @@ class AttributesMaker extends LoggingWithLogstashFields{
           DigitalSubscriptionExpiryDate = zuora.DigitalSubscriptionExpiryDate,
           MembershipNumber = dynamo.MembershipNumber,
           AdFree = dynamo.AdFree,
-          KeepFresh = dynamo.KeepFresh,
+          KeepFreshForStaffAdFree = dynamo.KeepFreshForStaffAdFree,
           AlertAvailableFor = zuora.AlertAvailableFor
         ))
       case (Some(zuora), None) =>
@@ -129,10 +129,10 @@ class AttributesMaker extends LoggingWithLogstashFields{
           DigitalSubscriptionExpiryDate = zuora.DigitalSubscriptionExpiryDate,
           MembershipNumber = None,
           AdFree = None,
-          KeepFresh = None,
+          KeepFreshForStaffAdFree = None,
           AlertAvailableFor = zuora.AlertAvailableFor
         ))
-      case (None, Some(dynamo)) if dynamo.KeepFresh.getOrElse(false) =>
+      case (None, Some(dynamo)) if dynamo.KeepFreshForStaffAdFree.getOrElse(false) =>
         Some(Attributes(
           UserId = dynamo.UserId,
           Tier = None,
@@ -141,7 +141,7 @@ class AttributesMaker extends LoggingWithLogstashFields{
           DigitalSubscriptionExpiryDate = None,
           MembershipNumber = None,
           AdFree = dynamo.AdFree,
-          KeepFresh = dynamo.KeepFresh,
+          KeepFreshForStaffAdFree = dynamo.KeepFreshForStaffAdFree,
           AlertAvailableFor = None
         ))
       case (None, _) => None

--- a/membership-attribute-service/test/repositories/ScanamoAttributeServiceTest.scala
+++ b/membership-attribute-service/test/repositories/ScanamoAttributeServiceTest.scala
@@ -71,7 +71,7 @@ class ScanamoAttributeServiceTest(implicit ee: ExecutionEnv) extends Specificati
         TTLTimestamp = toDynamoTtl(testExpiryDate),
         DigitalSubscriptionExpiryDate = None,
         AdFree = None,
-        KeepFresh = None
+        KeepFreshForStaffAdFree = None
       )
 
       val result = for {
@@ -94,17 +94,17 @@ class ScanamoAttributeServiceTest(implicit ee: ExecutionEnv) extends Specificati
   "getMany" should {
 
     val testUsers = Seq(
-      DynamoAttributes(UserId = "1234", Tier = Some("Partner"), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None, KeepFresh = None),
-      DynamoAttributes(UserId = "2345", Tier = Some("Partner"), MembershipJoinDate = Some(new LocalDate(2017, 6, 12)), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None, KeepFresh = None),
-      DynamoAttributes(UserId = "3456", Tier = Some("Partner"), MembershipJoinDate = Some(new LocalDate(2017, 6, 11)), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None, KeepFresh = None),
-      DynamoAttributes(UserId = "4567", Tier = Some("Partner"), MembershipJoinDate = Some(new LocalDate(2017, 6, 10)), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None, KeepFresh = None)
+      DynamoAttributes(UserId = "1234", Tier = Some("Partner"), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None, KeepFreshForStaffAdFree = None),
+      DynamoAttributes(UserId = "2345", Tier = Some("Partner"), MembershipJoinDate = Some(new LocalDate(2017, 6, 12)), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None, KeepFreshForStaffAdFree = None),
+      DynamoAttributes(UserId = "3456", Tier = Some("Partner"), MembershipJoinDate = Some(new LocalDate(2017, 6, 11)), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None, KeepFreshForStaffAdFree = None),
+      DynamoAttributes(UserId = "4567", Tier = Some("Partner"), MembershipJoinDate = Some(new LocalDate(2017, 6, 10)), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None, KeepFreshForStaffAdFree = None)
     )
 
     "Fetch many people by user id" in {
       Await.result(Future.sequence(testUsers.map(repo.set)), 5.seconds)
       Await.result(repo.getMany(List("1234", "3456", "abcd")), 5.seconds) mustEqual Seq(
-        DynamoAttributes(UserId = "1234", Tier = Some("Partner"), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None, KeepFresh = None),
-        DynamoAttributes(UserId = "3456", Tier = Some("Partner"), MembershipJoinDate = Some(new LocalDate(2017, 6, 11)), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None, KeepFresh = None)
+        DynamoAttributes(UserId = "1234", Tier = Some("Partner"), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None, KeepFreshForStaffAdFree = None),
+        DynamoAttributes(UserId = "3456", Tier = Some("Partner"), MembershipJoinDate = Some(new LocalDate(2017, 6, 11)), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None, KeepFreshForStaffAdFree = None)
       )
     }
   }
@@ -112,7 +112,7 @@ class ScanamoAttributeServiceTest(implicit ee: ExecutionEnv) extends Specificati
   "update" should {
     "add the attribute if it's not already in the table" in {
 
-      val newAttributes = DynamoAttributes(UserId = "6789", RecurringContributionPaymentPlan = Some("Monthly Contribution"), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None, KeepFresh = None)
+      val newAttributes = DynamoAttributes(UserId = "6789", RecurringContributionPaymentPlan = Some("Monthly Contribution"), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None, KeepFreshForStaffAdFree = None)
 
       val result = for {
         _ <- repo.update(newAttributes)
@@ -124,8 +124,8 @@ class ScanamoAttributeServiceTest(implicit ee: ExecutionEnv) extends Specificati
     }
 
     "update a user who has bought a digital subscription" in {
-      val oldAttributes = DynamoAttributes(UserId = "6789", RecurringContributionPaymentPlan = Some("Monthly Contribution"), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None, KeepFresh = None)
-      val newAttributes = DynamoAttributes(UserId = "6789", RecurringContributionPaymentPlan = Some("Monthly Contribution"), DigitalSubscriptionExpiryDate = Some(LocalDate.now().plusWeeks(5)), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None, KeepFresh = None)
+      val oldAttributes = DynamoAttributes(UserId = "6789", RecurringContributionPaymentPlan = Some("Monthly Contribution"), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None, KeepFreshForStaffAdFree = None)
+      val newAttributes = DynamoAttributes(UserId = "6789", RecurringContributionPaymentPlan = Some("Monthly Contribution"), DigitalSubscriptionExpiryDate = Some(LocalDate.now().plusWeeks(5)), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None, KeepFreshForStaffAdFree = None)
 
       val result = for {
         _ <- repo.set(oldAttributes)
@@ -137,7 +137,7 @@ class ScanamoAttributeServiceTest(implicit ee: ExecutionEnv) extends Specificati
     }
 
     "leave attribute in the table if nothing has changed" in {
-      val existingAttributes = DynamoAttributes(UserId = "6789", AdFree = Some(true), DigitalSubscriptionExpiryDate = Some(LocalDate.now().plusWeeks(5)), TTLTimestamp = testTtl, MembershipNumber = None, KeepFresh = None)
+      val existingAttributes = DynamoAttributes(UserId = "6789", AdFree = Some(true), DigitalSubscriptionExpiryDate = Some(LocalDate.now().plusWeeks(5)), TTLTimestamp = testTtl, MembershipNumber = None, KeepFreshForStaffAdFree = None)
 
       val result = for {
         _ <- repo.set(existingAttributes)
@@ -149,8 +149,8 @@ class ScanamoAttributeServiceTest(implicit ee: ExecutionEnv) extends Specificati
     }
 
     "leave existing values in an attribute that cannot be determined from a zuora update alone" in {
-      val existingAttributes = DynamoAttributes(UserId = "6789", AdFree = Some(true), DigitalSubscriptionExpiryDate = Some(LocalDate.now().minusWeeks(5)), MembershipNumber = Some("1234"), TTLTimestamp = testTtl, KeepFresh = None)
-      val updatedAttributes = DynamoAttributes(UserId = "6789", DigitalSubscriptionExpiryDate = Some(LocalDate.now().plusWeeks(5)), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None, KeepFresh = None)
+      val existingAttributes = DynamoAttributes(UserId = "6789", AdFree = Some(true), DigitalSubscriptionExpiryDate = Some(LocalDate.now().minusWeeks(5)), MembershipNumber = Some("1234"), TTLTimestamp = testTtl, KeepFreshForStaffAdFree = None)
+      val updatedAttributes = DynamoAttributes(UserId = "6789", DigitalSubscriptionExpiryDate = Some(LocalDate.now().plusWeeks(5)), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None, KeepFreshForStaffAdFree = None)
       val attributesWithPreservedValues = existingAttributes.copy(DigitalSubscriptionExpiryDate = updatedAttributes.DigitalSubscriptionExpiryDate) //TTL is also only in dynamo, but the logic for it is in attributesFromZuora.
 
       val result = for {

--- a/membership-attribute-service/test/services/AttributesFromZuoraTest.scala
+++ b/membership-attribute-service/test/services/AttributesFromZuoraTest.scala
@@ -341,6 +341,21 @@ class AttributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
         updateRequired must be_==(true)
       }
 
+      "return true if Dynamo record is marked KeepFreshForStaffAdFree even without a Zuora record" in {
+        val recentEnough = toDynamoTtl(twoWeeksFromReferenceDate.minusHours(14))
+        val dynamoAttributes = Some(supporterDynamoAttributes.copy(TTLTimestamp = recentEnough, KeepFreshForStaffAdFree = Some(true)))
+        val updateRequired = attributesFromZuora.dynamoUpdateRequired(dynamoAttributes, None, "123", twoWeeksFromReferenceDate)
+
+        updateRequired must be_==(true)
+      }
+
+      "return true if Zuora and Dynamo agree and the timestamp is recent enough but Dynamo is marked KeepFreshForStaffAdFree" in {
+        val recentEnough = toDynamoTtl(twoWeeksFromReferenceDate.minusHours(14))
+        val updateRequired = attributesFromZuora.dynamoUpdateRequired(dynamoAttributes = Some(supporterDynamoAttributes.copy(TTLTimestamp = recentEnough, KeepFreshForStaffAdFree = Some(true))), Some(asZuoraAttributes(supporterDynamoAttributes)), supporterDynamoAttributes.UserId, twoWeeksFromReferenceDate)
+
+        updateRequired must be_==(true)
+      }
+
       "return false if zuora and dynamo agree and the timestamp is recent enough" in {
         val recentEnough = toDynamoTtl(twoWeeksFromReferenceDate.minusHours(14))
         val updateRequired = attributesFromZuora.dynamoUpdateRequired(dynamoAttributes = Some(supporterDynamoAttributes.copy(TTLTimestamp = recentEnough)), Some(asZuoraAttributes(supporterDynamoAttributes)), supporterDynamoAttributes.UserId, twoWeeksFromReferenceDate)

--- a/membership-attribute-service/test/services/AttributesFromZuoraTest.scala
+++ b/membership-attribute-service/test/services/AttributesFromZuoraTest.scala
@@ -35,7 +35,7 @@ class AttributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
   val oneAccountQueryResponse = GetAccountsQueryResponse(records = List(AccountObject(testAccountId, 0, Some(GBP))), size = 1)
   val twoAccountsQueryResponse = GetAccountsQueryResponse(records = List(AccountObject(testAccountId, 0, Some(GBP)), AccountObject(anotherTestAccountId, 0, Some(GBP))), size = 2)
 
-  val contributorDynamoAttributes = DynamoAttributes(UserId = testId, None, RecurringContributionPaymentPlan = Some("Monthly Contribution"), None, None, None, None, KeepFresh = None, referenceDateInSeconds)
+  val contributorDynamoAttributes = DynamoAttributes(UserId = testId, None, RecurringContributionPaymentPlan = Some("Monthly Contribution"), None, None, None, None, KeepFreshForStaffAdFree = None, referenceDateInSeconds)
   val contributorAttributes = DynamoAttributes.asAttributes(contributorDynamoAttributes)
 
   val supporterDynamoAttributes = DynamoAttributes(
@@ -46,7 +46,7 @@ class AttributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
     RecurringContributionPaymentPlan = None,
     MembershipJoinDate = Some(referenceDate),
     DigitalSubscriptionExpiryDate = None,
-    KeepFresh = None,
+    KeepFreshForStaffAdFree = None,
     TTLTimestamp = referenceDateInSeconds)
 
   def asZuoraAttributes(dynamoAttributes: DynamoAttributes): ZuoraAttributes = ZuoraAttributes(
@@ -376,7 +376,7 @@ class AttributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
       RecurringContributionPaymentPlan = Some("Monthly Contribution"),
       MembershipJoinDate = None,
       DigitalSubscriptionExpiryDate = Some(digitalPackExpirationDate),
-      KeepFresh = None,
+      KeepFreshForStaffAdFree = None,
       TTLTimestamp = toDynamoTtl(twoWeeksFromReferenceDate)
     )
     val zuoraContributorDigitalPackAttributes = asZuoraAttributes(dynamoContributorDigitalPackAttributes)

--- a/membership-attribute-service/test/services/AttributesFromZuoraTest.scala
+++ b/membership-attribute-service/test/services/AttributesFromZuoraTest.scala
@@ -35,7 +35,7 @@ class AttributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
   val oneAccountQueryResponse = GetAccountsQueryResponse(records = List(AccountObject(testAccountId, 0, Some(GBP))), size = 1)
   val twoAccountsQueryResponse = GetAccountsQueryResponse(records = List(AccountObject(testAccountId, 0, Some(GBP)), AccountObject(anotherTestAccountId, 0, Some(GBP))), size = 2)
 
-  val contributorDynamoAttributes = DynamoAttributes(UserId = testId, None, RecurringContributionPaymentPlan = Some("Monthly Contribution"), None, None, None, None, referenceDateInSeconds)
+  val contributorDynamoAttributes = DynamoAttributes(UserId = testId, None, RecurringContributionPaymentPlan = Some("Monthly Contribution"), None, None, None, None, KeepFresh = None, referenceDateInSeconds)
   val contributorAttributes = DynamoAttributes.asAttributes(contributorDynamoAttributes)
 
   val supporterDynamoAttributes = DynamoAttributes(
@@ -46,6 +46,7 @@ class AttributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
     RecurringContributionPaymentPlan = None,
     MembershipJoinDate = Some(referenceDate),
     DigitalSubscriptionExpiryDate = None,
+    KeepFresh = None,
     TTLTimestamp = referenceDateInSeconds)
 
   def asZuoraAttributes(dynamoAttributes: DynamoAttributes): ZuoraAttributes = ZuoraAttributes(
@@ -375,6 +376,7 @@ class AttributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
       RecurringContributionPaymentPlan = Some("Monthly Contribution"),
       MembershipJoinDate = None,
       DigitalSubscriptionExpiryDate = Some(digitalPackExpirationDate),
+      KeepFresh = None,
       TTLTimestamp = toDynamoTtl(twoWeeksFromReferenceDate)
     )
     val zuoraContributorDigitalPackAttributes = asZuoraAttributes(dynamoContributorDigitalPackAttributes)

--- a/membership-attribute-service/test/services/AttributesMakerTest.scala
+++ b/membership-attribute-service/test/services/AttributesMakerTest.scala
@@ -190,6 +190,7 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
         DigitalSubscriptionExpiryDate = None,
         MembershipNumber = None,
         AdFree = None,
+        KeepFresh = None,
         TTLTimestamp = referenceDateAsDynamoTimestamp
       )
 

--- a/membership-attribute-service/test/services/AttributesMakerTest.scala
+++ b/membership-attribute-service/test/services/AttributesMakerTest.scala
@@ -190,7 +190,7 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
         DigitalSubscriptionExpiryDate = None,
         MembershipNumber = None,
         AdFree = None,
-        KeepFresh = None,
+        KeepFreshForStaffAdFree = None,
         TTLTimestamp = referenceDateAsDynamoTimestamp
       )
 

--- a/membership-attribute-service/test/services/AttributesMakerTest.scala
+++ b/membership-attribute-service/test/services/AttributesMakerTest.scala
@@ -233,6 +233,53 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
       attributes === expected
     }
 
+    "return Dynamo attributes if present even if no Zuora records exist, as long as marked KeepFreshForStaffAdFree" in {
+      val dynamoAttributes = DynamoAttributes(
+        UserId = identityId,
+        Tier = None,
+        RecurringContributionPaymentPlan = None,
+        MembershipJoinDate = None,
+        DigitalSubscriptionExpiryDate = None,
+        MembershipNumber = None,
+        AdFree = Some(true),
+        KeepFreshForStaffAdFree = Some(true),
+        TTLTimestamp = referenceDateAsDynamoTimestamp
+      )
+
+      val expected = Some(
+        Attributes(
+          UserId = identityId,
+          Tier = None,
+          RecurringContributionPaymentPlan = None,
+          MembershipJoinDate = None,
+          DigitalSubscriptionExpiryDate = None,
+          MembershipNumber = None,
+          AdFree = Some(true),
+          KeepFreshForStaffAdFree = Some(true)
+        )
+      )
+
+      val attributes = AttributesMaker.zuoraAttributesWithAddedDynamoFields(None, Some(dynamoAttributes))
+
+      attributes === expected
+    }
+
+    "return none if a Dynamo record exists but is NOT marked KeepFreshForStaffAdFree if no Zuora records exist" in {
+      val dynamoAttributes = DynamoAttributes(
+        UserId = identityId,
+        Tier = None,
+        RecurringContributionPaymentPlan = None,
+        MembershipJoinDate = None,
+        DigitalSubscriptionExpiryDate = None,
+        MembershipNumber = None,
+        AdFree = Some(true),
+        KeepFreshForStaffAdFree = None,
+        TTLTimestamp = referenceDateAsDynamoTimestamp
+      )
+
+      AttributesMaker.zuoraAttributesWithAddedDynamoFields(None, Some(dynamoAttributes)) === None
+    }
+
     "return none if both Dynamo and Zuora attributes are none" in {
       AttributesMaker.zuoraAttributesWithAddedDynamoFields(None, None) === None
     }


### PR DESCRIPTION
### Why do we need this?
We want to reopen the ad-free trial to staff, but without fully committing everybody by default. Yet. We used to use the membership attributes Dynamo tables to do this, but changes made there for GDPR reasons meant that anyone who had previously signed up for the trial but not signed in for a couple of weeks had their data removed, and unless they had a Zuora account, would be removed every time they sign in. 

So we need some mechanism through which to reinstate the trial, without having a strong dependency on Zuora, at least at this stage.

### The changes
This change adds support for a new field in the Dynamo data: `KeepFreshForStaffAdFree`. This is a **temporary** situation until we're through the internal testing phase and ready to push into automatic adoption for staff accounts, which may or may not be distinctly separate from the roll out to paying subscribers.

To summarise: If a Dynamo record has the `KeepFreshForStaffAdFree` it will have its `TTL` updated on every access to ensure it doesn't fall foul of automatic removal operations. This will work regardless of whether Zuora finds any data for the user or not.

The _only_ way to set the keep-fresh data is by manually adding it to an existing record, or manually creating a new record in Dynamo. This is no better or worse than when we ran the trial last time.

I considered adding a completely separate table to do this, but the overhead in terms of wiring it into AWS via cloudformation, and then adding a third layer of assessment into the already complex code that manages the current Zuora<->Dynamo relationship made that undesirable for a relatively short-lived feature (this is part of an OKR now, so we are approaching a time when it can be properly delivered). Also, if we later revert the changes in this PR, the data in the Dynamo table will gradually be cleared out by the automatic removal process, and we won't have to do anything with it.

In terms of numbers, we're expecting participation in the mid-hundreds range at best. It'd be nice to have more, but until the comms go out, that's unlikely to happen imminently.

### [Trello card](https://trello.com/c/Jxd1svI8/1595-give-ad-free-entitlement-to-staff-membership)
