### PR TITLE
Tweak the wording of 'alertText' in mma responses (so it can be used more widely)

### DIFF
--- a/membership-attribute-service/app/services/PaymentFailureAlerter.scala
+++ b/membership-attribute-service/app/services/PaymentFailureAlerter.scala
@@ -76,7 +76,7 @@ object PaymentFailureAlerter extends LoggingWithLogstashFields {
           val fields = customFields(accountSummary.identityId, latestDate.toString(formatter), productName)
           logInfoWithCustomFields(s"Logging an alert for identityId: ${accountSummary.identityId} accountId: ${accountSummary.id}. Payment failed on ${latestDate.toString(formatter)}", fields)
 
-          s"Our attempt to take payment for your $productDescription failed on ${latestDate.toString(formatter)}. Please check below that your card details are up to date."
+          s"Our attempt to take payment for your $productDescription failed on ${latestDate.toString(formatter)}. Please check that the card details shown are up to date."
         }
       }
     }

--- a/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
+++ b/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
@@ -42,7 +42,7 @@ class PaymentFailureAlerterTest(implicit ee: ExecutionEnv)  extends Specificatio
 
         val attemptDateTime = DateTime.now().minusDays(1)
         val formatter = DateTimeFormat.forPattern("d MMMM yyyy").withLocale(Locale.ENGLISH)
-        val expectedActionText = s"Our attempt to take payment for your Supporter membership failed on ${attemptDateTime.toString(formatter)}. Please check below that your card details are up to date."
+        val expectedActionText = s"Our attempt to take payment for your Supporter membership failed on ${attemptDateTime.toString(formatter)}. Please check that the card details shown are up to date."
 
         result must be_==(Some(expectedActionText)).await
       }
@@ -52,7 +52,7 @@ class PaymentFailureAlerterTest(implicit ee: ExecutionEnv)  extends Specificatio
 
         val attemptDateTime = DateTime.now().minusDays(1)
         val formatter = DateTimeFormat.forPattern("d MMMM yyyy").withLocale(Locale.ENGLISH)
-        val expectedActionText = s"Our attempt to take payment for your contribution failed on ${attemptDateTime.toString(formatter)}. Please check below that your card details are up to date."
+        val expectedActionText = s"Our attempt to take payment for your contribution failed on ${attemptDateTime.toString(formatter)}. Please check that the card details shown are up to date."
 
         result must be_==(Some(expectedActionText)).await
       }


### PR DESCRIPTION
the wording of the `alertText` had "Please check below" which limits where this text can be placed on a page, now reads "Please check that the card details shown"