### PR TITLE
Add 'email' to the the 'card' section of mma responses

### DIFF
--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -186,7 +186,7 @@ class AccountController(commonActions: CommonActions, override val controllerCom
       accountSummary <- OptionEither.liftOption(tp.zuoraRestService.getAccount(sub.accountId).recover { case x => \/.left(s"error receiving account summary for subscription: ${sub.name} with account id ${sub.accountId}. Reason: $x") })
       stripeService = accountSummary.billToContact.country.map(RegionalStripeGateways.getGatewayForCountry).flatMap(tp.stripeServicesByPaymentGateway.get).getOrElse(tp.ukStripeService)
       alertText <- OptionEither.liftEitherOption(alertText(accountSummary, sub, getPaymentMethod))
-    } yield AccountDetails(contact, upToDatePaymentDetails, stripeService.publicKey, alertText).toResult).run.run.map {
+    } yield AccountDetails(contact, accountSummary.billToContact.email, upToDatePaymentDetails, stripeService.publicKey, alertText).toResult).run.run.map {
       case \/-(Some(result)) =>
         logger.info(s"Successfully retrieved payment details result for identity user: ${maybeUserId.mkString}")
         result

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -6,7 +6,7 @@ import json.localDateWrites
 import play.api.libs.json._
 import play.api.mvc.Results.Ok
 
-case class AccountDetails(contact: Contact, paymentDetails: PaymentDetails, stripePublicKey: String, membershipAlertText: Option[String])
+case class AccountDetails(contact: Contact, email: Option[String], paymentDetails: PaymentDetails, stripePublicKey: String, membershipAlertText: Option[String])
 
 object AccountDetails {
 
@@ -14,7 +14,7 @@ object AccountDetails {
 
     def toResult = {
 
-      val accountJsonObj = memberDetails(accountDetails.contact, accountDetails.paymentDetails) ++ toJson(accountDetails.paymentDetails, accountDetails.stripePublicKey)
+      val accountJsonObj = memberDetails(accountDetails.contact, accountDetails.paymentDetails) ++ toJson(accountDetails.paymentDetails, accountDetails.stripePublicKey, accountDetails.email)
       val accountWithAlertJsonObj = accountDetails.membershipAlertText match {
         case Some(text) => accountJsonObj ++ Json.obj("alertText" -> text)
         case None => accountJsonObj
@@ -27,7 +27,7 @@ object AccountDetails {
       Json.obj("tier" -> paymentDetails.plan.name, "isPaidTier" -> (paymentDetails.plan.price.amount > 0f)) ++
         contact.regNumber.fold(Json.obj())({m => Json.obj("regNumber" -> m)})
 
-    private def toJson(paymentDetails: PaymentDetails, stripePublicKey: String): JsObject = {
+    private def toJson(paymentDetails: PaymentDetails, stripePublicKey: String, email: Option[String]): JsObject = {
 
       val endDate = paymentDetails.chargedThroughDate
         .getOrElse(paymentDetails.termEndDate)
@@ -43,7 +43,8 @@ object AccountDetails {
             Json.obj(
               "last4" -> card.paymentCardDetails.map(_.lastFourDigits).getOrElse[String]("••••"),
               "type" -> card.cardType.getOrElse[String]("unknown"),
-              "stripePublicKeyForUpdate" -> stripePublicKey
+              "stripePublicKeyForUpdate" -> stripePublicKey,
+              "email" -> email
             )
           }
         )


### PR DESCRIPTION
added email address to the card section of the mma response so it can be used in combination with the 'stripePublicKeyForUpdate' to create stripe tokens.

This is just an additive change to the json response and doesn't require any additional network calls on the server side as the information was already available just need exposing.