### PR TITLE
Fix issue with card update in subscriptions /manage portal

### DIFF
--- a/membership-attribute-service/conf/DEV.public.conf
+++ b/membership-attribute-service/conf/DEV.public.conf
@@ -14,12 +14,14 @@ stage=DEV
 play.filters.cors.allowedOrigins = [
   "http://m.code.dev-theguardian.com",
   "https://m.code.dev-theguardian.com",
+  "https://subscribe.code.dev-theguardian.com",
   "https://profile.code.dev-theguardian.com",
   "https://profile.thegulocal.com",
   "https://membership.thegulocal.com",
   "https://mem.thegulocal.com",
   "http://m.thegulocal.com",
   "https://m.thegulocal.com",
+  "https://subscribe.thegulocal.com",
   "http://thegulocal.com",
   "https://thegulocal.com"
 ]

--- a/membership-attribute-service/conf/PROD.public.conf
+++ b/membership-attribute-service/conf/PROD.public.conf
@@ -12,19 +12,16 @@ touchpoint.backend.default=PROD
 touchpoint.backend.test=UAT
 
 play.filters.cors.allowedOrigins = [
-  "http://m.code.dev-theguardian.com",
-  "https://m.code.dev-theguardian.com",
   "http://www.theguardian.com",
   "https://www.theguardian.com",
   "https://membership.theguardian.com",
-  "https://profile.theguardian.com"
+  "https://profile.theguardian.com",
+  "https://subscribe.theguardian.com"
 ]
 
 mma.cors.allowedOrigins = [
-  "https://profile.thegulocal.com",
   "https://profile.theguardian.com",
-  "https://profile.code.dev-theguardian.com",
-  "https://subscribe.theguardian.com",
+  "https://subscribe.theguardian.com"
 ]
 
 ft.cors.allowedOrigins = [


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
There is an issue where the card update functionality is not working in /manage because the fetch request is returning 403.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
Enable the subscriptions site to connect to the Members Data API via CORS.
I've also taken this opportunity to tidy up the CORS settings because now we have a CODE Members Data API, there is no reason for the code sites to connect to prod.

### trello card/screenshot/json/related PRs etc
Issue reported by email.