### PR TITLE
Improve CORS setup

### DIFF
--- a/membership-attribute-service/app/configuration/Config.scala
+++ b/membership-attribute-service/app/configuration/Config.scala
@@ -43,22 +43,9 @@ object Config {
   val testTouchpointBackendStage = config.getString("touchpoint.backend.test")
   val corsConfig = CORSConfig.fromConfiguration(Configuration(config))
 
-  val mmaCorsConfig = CORSConfig.denyAll.copy(
-    allowedOrigins = Origins.Matching( str =>
-      config.getStringList("mma.cors.allowedOrigins").contains(str)
-    )
-  )
-
-  val ftCorsConfig = CORSConfig.denyAll.copy(
-    allowedOrigins = Origins.Matching( str =>
-      config.getStringList("ft.cors.allowedOrigins").contains(str)
-    )
-  )
-
-  lazy val mmaUpdateCorsConfig = Config.mmaCorsConfig.copy(
+  lazy val mmaUpdateCorsConfig = corsConfig.copy(
     isHttpHeaderAllowed = Seq("accept", "content-type", "csrf-token", "origin").contains(_),
-    isHttpMethodAllowed = Seq("POST","OPTIONS").contains(_),
-    supportsCredentials = true
+    isHttpMethodAllowed = Seq("POST","OPTIONS").contains(_)
   )
 
   object Logstash {

--- a/membership-attribute-service/app/wiring/AppLoader.scala
+++ b/membership-attribute-service/app/wiring/AppLoader.scala
@@ -45,18 +45,6 @@ class MyComponents(context: Context)
     new AccountController(commonActions, controllerComponents)
   )
 
-  val regularCorsPaths = Seq(
-    "/user-attributes/me/membership",
-    "/user-attributes/me/features",
-    "/user-attributes/me"
-  )
-
-  val mmaPaths = Seq(
-    "/user-attributes/me/mma-digitalpack",
-    "/user-attributes/me/mma-monthlycontribution",
-    "/user-attributes/me/mma-membership",
-    "/user-attributes/me/mma-paper")
-
   val postPaths: List[String] = router.documentation.collect { case ("POST", path, _) => path }
 
   override lazy val httpFilters: Seq[EssentialFilter] = Seq(
@@ -64,8 +52,7 @@ class MyComponents(context: Context)
     csrfFilter,
     new AddEC2InstanceHeader(wsClient),
     new AddGuIdentityHeaders(),
-    CORSFilter(corsConfig = Config.mmaCorsConfig, pathPrefixes = mmaPaths),
     CORSFilter(corsConfig = Config.mmaUpdateCorsConfig, pathPrefixes = postPaths),
-    CORSFilter(corsConfig = Config.corsConfig, pathPrefixes = regularCorsPaths)
+    CORSFilter(corsConfig = Config.corsConfig, pathPrefixes = Seq("/user-attributes"))
   )
 }

--- a/membership-attribute-service/conf/DEV.public.conf
+++ b/membership-attribute-service/conf/DEV.public.conf
@@ -11,28 +11,18 @@ touchpoint.backend.test=UAT
 
 stage=DEV
 
+play.filters.cors.supportsCredentials = true
+
 play.filters.cors.allowedOrigins = [
-  "http://m.code.dev-theguardian.com",
   "https://m.code.dev-theguardian.com",
   "https://subscribe.code.dev-theguardian.com",
   "https://profile.code.dev-theguardian.com",
   "https://profile.thegulocal.com",
   "https://membership.thegulocal.com",
   "https://mem.thegulocal.com",
-  "http://m.thegulocal.com",
   "https://m.thegulocal.com",
   "https://subscribe.thegulocal.com",
-  "http://thegulocal.com",
-  "https://thegulocal.com"
-]
-
-mma.cors.allowedOrigins = [
-  "https://profile.code.dev-theguardian.com",
-  "https://subscribe.code.dev-theguardian.com",
-  "https://profile.thegulocal.com",
-  "https://sub.thegulocal.com"
-]
-
-ft.cors.allowedOrigins = [
+  "https://sub.thegulocal.com",
+  "https://thegulocal.com",
   "https://interactive.guimlocal.co.uk"
 ]

--- a/membership-attribute-service/conf/PROD.public.conf
+++ b/membership-attribute-service/conf/PROD.public.conf
@@ -11,20 +11,13 @@ logger.application=INFO
 touchpoint.backend.default=PROD
 touchpoint.backend.test=UAT
 
+play.filters.cors.supportsCredentials = true
+
 play.filters.cors.allowedOrigins = [
-  "http://www.theguardian.com",
   "https://www.theguardian.com",
   "https://membership.theguardian.com",
   "https://profile.theguardian.com",
-  "https://subscribe.theguardian.com"
-]
-
-mma.cors.allowedOrigins = [
-  "https://profile.theguardian.com",
-  "https://subscribe.theguardian.com"
-]
-
-ft.cors.allowedOrigins = [
+  "https://subscribe.theguardian.com",
   "https://interactive.guim.co.uk"
 ]
 


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->

The CORS setup was configured in a confusing way since the Play 2.6 upgrade changed how the configuration was wired in. Even though we had multiple URL paths configured, it was only finding the shortest, and so only evaluating to the standard CORS list, ignoring the mma-specific one.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
 This change simplifies and standardises the CORS settings for all endpoints on the API.

cc @jacobwinch 
