### PR TITLE
expose the currency ISO via a new 'currencyISO' property in plan section of mma responses

### DIFF
--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -72,6 +72,7 @@ object AccountDetails {
             "name" -> paymentDetails.plan.name,
             "amount" -> paymentDetails.plan.price.amount * 100,
             "currency" -> paymentDetails.plan.price.currency.glyph,
+            "currencyISO" -> paymentDetails.plan.price.currency.iso,
             "interval" -> paymentDetails.plan.interval.mkString
           )))
       )


### PR DESCRIPTION
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
Previously there was no way to know which actual regional currency was being used for a product (just the glyph, e.g. £, $, € ) which wasn't enough to distinguish between say USD, NZD or AUD. Now we expose the currency ISO under a new property 'currencyISO' so we can both display it in manage-frontend for example but also determine min/max amounts for amount update feature of say the contributions tab.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
Very simple change to expose a field we already had retrieved server-side.
