### PR TITLE
Update CFN with current ASG defaults

### DIFF
--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -21,11 +21,11 @@ Parameters:
     Description: Maximum number of instances. This should be (at least) double the
       desired capacity.
     Type: Number
-    Default: 6
+    Default: 12
   MinInstances:
     Description: Minimum number of instances
     Type: Number
-    Default: 3
+    Default: 6
   VpcId:
     Description: ID of the VPC onto which to launch the application
     Type: AWS::EC2::VPC::Id


### PR DESCRIPTION
I noticed that the defaults are out of date (since we started running 6 instances by default). This PR fixes them.

I'll apply this change to get us back into a consistent state.
