### PR TITLE
Adding a warning for whomever may decide to increase the desired number of instances

### DIFF
--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -23,7 +23,7 @@ Parameters:
     Type: Number
     Default: 12
   MinInstances:
-    Description: Minimum number of instances. NOTE: there is a Zuora concurrent call threshold configured in MembershipFeatureToggles-[STAGE] DynamoDB table which will need adjusting if you up this value.
+    Description: "Minimum number of instances. NOTE: there is a Zuora concurrent call threshold configured in MembershipFeatureToggles-[STAGE] DynamoDB table which will need adjusting if you up this value."
     Type: Number
     Default: 6
   VpcId:

--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -23,7 +23,7 @@ Parameters:
     Type: Number
     Default: 12
   MinInstances:
-    Description: "Minimum number of instances. NOTE: there is a Zuora concurrent call threshold configured in MembershipFeatureToggles-[STAGE] DynamoDB table which will need adjusting if you increase this value."
+    Description: "Minimum number of instances desired. NOTE: there is a Zuora concurrent call threshold configured in MembershipFeatureToggles-[STAGE] DynamoDB table which will need adjusting if you increase this value."
     Type: Number
     Default: 6
   VpcId:
@@ -177,6 +177,8 @@ Resources:
       LaunchConfigurationName:
         Ref: LaunchConfig
       MinSize:
+        Ref: MinInstances
+      DesiredCapacity:
         Ref: MinInstances
       MaxSize:
         Ref: MaxInstances

--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -23,7 +23,7 @@ Parameters:
     Type: Number
     Default: 12
   MinInstances:
-    Description: Minimum number of instances. NOTE: there is a Zuora concurrent call threshhold configured in MembershipFeatureToggles-[STAGE] DynamoDB table which will need adjusting if you up this value.
+    Description: Minimum number of instances. NOTE: there is a Zuora concurrent call threshold configured in MembershipFeatureToggles-[STAGE] DynamoDB table which will need adjusting if you up this value.
     Type: Number
     Default: 6
   VpcId:

--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -23,7 +23,7 @@ Parameters:
     Type: Number
     Default: 12
   MinInstances:
-    Description: "Minimum number of instances. NOTE: there is a Zuora concurrent call threshold configured in MembershipFeatureToggles-[STAGE] DynamoDB table which will need adjusting if you up this value."
+    Description: "Minimum number of instances. NOTE: there is a Zuora concurrent call threshold configured in MembershipFeatureToggles-[STAGE] DynamoDB table which will need adjusting if you increase this value."
     Type: Number
     Default: 6
   VpcId:

--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -178,8 +178,6 @@ Resources:
         Ref: LaunchConfig
       MinSize:
         Ref: MinInstances
-      DesiredCapacity:
-        Ref: MinInstances
       MaxSize:
         Ref: MaxInstances
       HealthCheckType: ELB

--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -23,7 +23,7 @@ Parameters:
     Type: Number
     Default: 12
   MinInstances:
-    Description: Minimum number of instances
+    Description: Minimum number of instances. NOTE: there is a Zuora concurrent call threshhold configured in MembershipFeatureToggles-[STAGE] DynamoDB table which will need adjusting if you up this value.
     Type: Number
     Default: 6
   VpcId:


### PR DESCRIPTION
Adding a warning for whomever may decide to increase the desired number of instances:

Members Data API limits the number of concurrent calls it makes via its Zuora Service, so as to protect against breaching [Zuora's Concurrent Request Limits](https://knowledgecenter.zuora.com/BB_Introducing_Z_Business/Policies/Concurrent_Request_Limits)

The value is configured in DynamoDB and is currently set at 15 requests per instance. So 15 x 6 = 90 which is too big anyway! - I'll test setting this to 6 tomorrow.

<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->

### trello card/screenshot/json/related PRs etc

cc @jacobwinch @johnduffell @lmath 
