### PR TITLE
add 'paperSubscriber' boolean to the 'contentAccess' section of the  /me endpoint

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -52,7 +52,7 @@ class AttributeController(attributesFromZuora: AttributesFromZuora, commonAction
             def customFields(supporterType: String): List[LogField] = List(LogFieldString("lookup-endpoint-description", endpointDescription), LogFieldString("supporter-type", supporterType), LogFieldString("data-source", fromWhere))
 
             attributes match {
-              case Some(attrs @ Attributes(_, Some(tier), _, _, _, _, _, _, _)) =>
+              case Some(attrs @ Attributes(_, Some(tier), _, _, _, _, _, _, _, _)) =>
                 logInfoWithCustomFields(s"$identityId is a $tier member - $endpointDescription - $attrs found via $fromWhere", customFields("member"))
                 onSuccessMember(attrs).withHeaders(
                   "X-Gu-Membership-Tier" -> tier,
@@ -61,6 +61,9 @@ class AttributeController(attributesFromZuora: AttributesFromZuora, commonAction
               case Some(attrs) =>
                 attrs.DigitalSubscriptionExpiryDate.foreach { date =>
                   logInfoWithCustomFields(s"$identityId is a digital subscriber expiring $date", customFields("digital-subscriber"))
+                }
+                attrs.PaperSubscriptionExpiryDate.foreach {date =>
+                  logInfoWithCustomFields(s"$identityId is a paper subscriber expiring $date", customFields("paper-subscriber"))
                 }
                 attrs.RecurringContributionPaymentPlan.foreach { paymentPlan =>
                   logInfoWithCustomFields(s"$identityId is a regular $paymentPlan contributor", customFields("contributor"))

--- a/membership-attribute-service/app/services/AttributesFromZuora.scala
+++ b/membership-attribute-service/app/services/AttributesFromZuora.scala
@@ -115,16 +115,17 @@ class AttributesFromZuora(implicit val executionContext: ExecutionContext) exten
 
   private def updateCache(identityId: String, maybeAttributes: Option[Attributes], dynamoAttributeService: AttributeService, twoWeekExpiry: => DateTime): Future[Unit] = {
     val attributesWithTTL: Option[DynamoAttributes] = maybeAttributes map { attributes =>
-        DynamoAttributes(
-        attributes.UserId,
-        attributes.Tier,
-        attributes.RecurringContributionPaymentPlan,
-        attributes.MembershipJoinDate,
-        attributes.DigitalSubscriptionExpiryDate,
-        attributes.MembershipNumber,
-        attributes.AdFree,
-        attributes.KeepFreshForStaffAdFree,
-        TtlConversions.toDynamoTtlInSeconds(twoWeekExpiry)
+      DynamoAttributes(
+        UserId = attributes.UserId,
+        Tier = attributes.Tier,
+        RecurringContributionPaymentPlan = attributes.RecurringContributionPaymentPlan,
+        MembershipJoinDate = attributes.MembershipJoinDate,
+        DigitalSubscriptionExpiryDate = attributes.DigitalSubscriptionExpiryDate,
+        PaperSubscriptionExpiryDate = attributes.PaperSubscriptionExpiryDate,
+        MembershipNumber = attributes.MembershipNumber,
+        AdFree = attributes.AdFree,
+        KeepFreshForStaffAdFree = attributes.KeepFreshForStaffAdFree,
+        TTLTimestamp = TtlConversions.toDynamoTtlInSeconds(twoWeekExpiry)
       )
     }
 

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -30,7 +30,8 @@ class AttributeControllerTest extends Specification with AfterAll {
     AdFree = Some(false),
     MembershipJoinDate = Some(new LocalDate(2017, 5, 13)),
     RecurringContributionPaymentPlan = Some("Monthly Contribution"),
-    DigitalSubscriptionExpiryDate = Some(new LocalDate(2100, 1, 1))
+    DigitalSubscriptionExpiryDate = Some(new LocalDate(2100, 1, 1)),
+    PaperSubscriptionExpiryDate = Some(new LocalDate(2099, 1, 1))
   )
 
   private val validUserCookie = Cookie("validUser", "true")
@@ -127,11 +128,13 @@ class AttributeControllerTest extends Specification with AfterAll {
                    |   "membershipJoinDate": "2017-05-13",
                    |   "recurringContributionPaymentPlan":"Monthly Contribution",
                    |   "digitalSubscriptionExpiryDate":"2100-01-01",
+                   |   "paperSubscriptionExpiryDate":"2099-01-01",
                    |   "contentAccess": {
                    |     "member": true,
                    |     "paidMember": true,
                    |     "recurringContributor": true,
-                   |     "digitalPack": true
+                   |     "digitalPack": true,
+                   |     "paperSubscriber": true
                    |   }
                    | }
                  """.stripMargin)
@@ -171,7 +174,8 @@ class AttributeControllerTest extends Specification with AfterAll {
                      |    "member": false,
                      |    "paidMember": false,
                      |    "recurringContributor": false,
-                     |    "digitalPack": false
+                     |    "digitalPack": false,
+                     |    "paperSubscriber": false
                      |  }
                      |}""".stripMargin)
     }

--- a/membership-attribute-service/test/services/AttributesFromZuoraTest.scala
+++ b/membership-attribute-service/test/services/AttributesFromZuoraTest.scala
@@ -35,7 +35,18 @@ class AttributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
   val oneAccountQueryResponse = GetAccountsQueryResponse(records = List(AccountObject(testAccountId, 0, Some(GBP))), size = 1)
   val twoAccountsQueryResponse = GetAccountsQueryResponse(records = List(AccountObject(testAccountId, 0, Some(GBP)), AccountObject(anotherTestAccountId, 0, Some(GBP))), size = 2)
 
-  val contributorDynamoAttributes = DynamoAttributes(UserId = testId, None, RecurringContributionPaymentPlan = Some("Monthly Contribution"), None, None, None, None, KeepFreshForStaffAdFree = None, referenceDateInSeconds)
+  val contributorDynamoAttributes = DynamoAttributes(
+    UserId = testId,
+    None,
+    RecurringContributionPaymentPlan = Some("Monthly Contribution"),
+    None,
+    None,
+    None,
+    None,
+    None,
+    KeepFreshForStaffAdFree = None,
+    referenceDateInSeconds
+  )
   val contributorAttributes = DynamoAttributes.asAttributes(contributorDynamoAttributes)
 
   val supporterDynamoAttributes = DynamoAttributes(

--- a/membership-attribute-service/test/services/AttributesMakerTest.scala
+++ b/membership-attribute-service/test/services/AttributesMakerTest.scala
@@ -44,7 +44,8 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
         Tier = None,
         RecurringContributionPaymentPlan = None,
         MembershipJoinDate = None,
-        DigitalSubscriptionExpiryDate = Some(referenceDate + 1.year)
+        DigitalSubscriptionExpiryDate = Some(referenceDate + 1.year),
+        PaperSubscriptionExpiryDate = Some(referenceDate + 1.year)
       ))
       val result = AttributesMaker.zuoraAttributes(identityId, List(AccountWithSubscriptions(accountObjectWithZeroBalance, List(sunday)), AccountWithSubscriptions(anotherAccountSummary, List(sundayPlus))), paymentMethodResponseNoFailures, referenceDate)
       result must be_==(expected).await
@@ -162,6 +163,7 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
         Tier = None,
         RecurringContributionPaymentPlan = Some("Monthly Contribution"),
         MembershipJoinDate = None,
+        PaperSubscriptionExpiryDate = Some(referenceDate + 1.year),
         AlertAvailableFor = Some("contribution")
       )
       )


### PR DESCRIPTION



<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
This facilitates on-boarding print to the payment update flow in manage-frontend - see https://github.com/guardian/manage-frontend/pull/157

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
add 'paperSubscriber' boolean to the 'contentAccess' section of the simple lightweight' /me endpoint

### trello card/screenshot/json/related PRs etc
![image](https://user-images.githubusercontent.com/19289579/48711283-c42a5b00-ec02-11e8-8407-3e2cf5344a92.png)