### PR TITLE
expose more Direct Debit details via new key entitled 'mandate'

### DIFF
--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -50,8 +50,13 @@ object AccountDetails {
         )
         case dd: GoCardless => Json.obj(
           "paymentMethod" -> "DirectDebit",
-          "account" -> Json.obj(
+          "account" -> Json.obj( // DEPRECATED
             "accountName" -> dd.accountName
+          ),
+          "mandate" -> Json.obj(
+            "accountName" -> dd.accountName,
+            "accountNumber" -> dd.accountNumber,
+            "sortCode" -> dd.sortCode
           )
         )
       }


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
In preparation for self-service direct debit update flow, we need to be able to display users current direct debit details.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
expose more Direct Debit details via new key entitled 'mandate', leaving behind 'account' for the time being for compatibility, but marked as deprecated. The 'account' keyword is misleading/overused so moving to the word 'mandate' for direct debit payment method.

### trello card/screenshot/json/related PRs etc
![image](https://user-images.githubusercontent.com/19289579/49011844-7320e680-f16f-11e8-969d-fb2ac5ee9f0a.png)
