### PR TITLE
Upgrade to Scala 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ def buildInfoSettings = Seq(
 val commonSettings = Seq(
   organization := "com.gu",
   version := appVersion,
-  scalaVersion := "2.11.12",
+  scalaVersion := "2.12.6",
   resolvers ++= Seq(
     "Guardian Github Releases" at "https://guardian.github.io/maven/repo-releases",
     "Guardian Github Snapshots" at "http://guardian.github.com/maven/repo-snapshots",

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -66,6 +66,7 @@ class AttributeControllerTest extends Specification with AfterAll {
   }
   private val controller = new AttributeController(new AttributesFromZuora(), commonActions, Helpers.stubControllerComponents()) {
     override lazy val authenticationService = fakeAuthService
+    override val executionContext = scala.concurrent.ExecutionContext.global
     override def pickAttributes(identityId: String)(implicit request: BackendRequest[AnyContent]): Future[(String, Option[Attributes])] = Future {
       if (identityId == validUserId ) ("Zuora", Some(testAttributes)) else ("Zuora", None)
     }

--- a/membership-attribute-service/test/services/AttributesFromZuoraTest.scala
+++ b/membership-attribute-service/test/services/AttributesFromZuoraTest.scala
@@ -14,11 +14,8 @@ import org.specs2.mutable.Specification
 import org.specs2.specification.{BeforeEach, Scope}
 import testdata.SubscriptionTestData
 import testdata.AccountObjectTestData._
-
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scalaz.\/
-
 
 class AttributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification with SubscriptionTestData with Mockito with BeforeEach {
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   //libraries
   val sentryLogback = "io.sentry" % "sentry-logback" % "1.7.5"
   val identityCookie = "com.gu.identity" %% "identity-cookie" % "3.99"
-  val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "2.1"
+  val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "2.5"
   val identityTestUsers =  "com.gu" %% "identity-test-users" % "0.7"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache
@@ -18,7 +18,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.520"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.527"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.9"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.2"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"


### PR DESCRIPTION
### Why do we need this? 

This project depends on a couple of libraries which have now dropped 2.11 support. This PR brings the project up to date, which allows us to pick up: https://github.com/guardian/membership-common/pull/585

This is required so that this app can continue to load the catalog after some planned changes.

### The changes 

* Upgrade to 2.12.6
* Upgrade to latest version of membership-common and identity-play-auth
* Fix tests with ambiguous implicits