### PR TITLE
fixed the 'X-Gu-Membership-Test-User' header as it was always returning false

### DIFF
--- a/membership-attribute-service/app/actions/WithBackendFromCookieAction.scala
+++ b/membership-attribute-service/app/actions/WithBackendFromCookieAction.scala
@@ -1,18 +1,17 @@
 package actions
 
 import components.TouchpointBackends
-import configuration.Config
+import filters.AddGuIdentityHeaders
 import play.api.mvc.{ActionRefiner, Request, Result}
 import services.IdentityAuthService
+
 import scala.concurrent.{ExecutionContext, Future}
 
 class WithBackendFromCookieAction(touchpointBackends: TouchpointBackends)(implicit ex: ExecutionContext) extends ActionRefiner[Request, BackendRequest] {
   override val executionContext = ex
   override protected def refine[A](request: Request[A]): Future[Either[Result, BackendRequest[A]]] = Future {
-    val firstName = IdentityAuthService.username(request).flatMap(_.split(' ').headOption) //Identity checks for test users by first name
-    val exists = firstName.exists(Config.testUsernames.isValid)
 
-    val backendConf = if (exists) {
+    val backendConf = if (AddGuIdentityHeaders.isTestUser(IdentityAuthService.username(request))) {
       touchpointBackends.test
     } else {
       touchpointBackends.normal

--- a/membership-attribute-service/app/filters/AddGuIdentityHeaders.scala
+++ b/membership-attribute-service/app/filters/AddGuIdentityHeaders.scala
@@ -20,11 +20,15 @@ class AddGuIdentityHeaders (implicit val mat: Materializer, ex: ExecutionContext
 
 object AddGuIdentityHeaders {
 
+  //Identity checks for test users by first name
+  def isTestUser(displayName: Option[String]) =
+    displayName.flatMap(_.split(' ').headOption).exists(Config.testUsernames.isValid)
+
   def headersFor(request: RequestHeader, result: Result) = (for {
     user <- IdentityAuthService.playAuthService.authenticatedUserFor(request)
   } yield result.withHeaders(
     "X-Gu-Identity-Id" -> user.id,
     "X-Gu-Identity-Credentials-Type" -> user.credentials.getClass.getSimpleName,
-    "X-Gu-Membership-Test-User" -> Config.testUsernames.isValid(user.id).toString
+    "X-Gu-Membership-Test-User" -> isTestUser(user.displayName).toString
     )).getOrElse(result)
 }


### PR DESCRIPTION
Previously this was using the _identityID_ to check against test-user lib, when in fact the _first name_ is the thing to use.
Also refactored so the evaluation of test-user status is only defined in one place.

_This needed to be fixed before it can be used in `manage-frontend` to determine a flag to send to the new GoCardless validation endpoint in `payment-api`._ 

---

TESTED IN CODE
![image](https://user-images.githubusercontent.com/19289579/49890559-45f55900-fe3c-11e8-88cf-78d97b83ae58.png)
