### PR TITLE
Remove KeepFreshForStaffAdFree flag

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -52,7 +52,7 @@ class AttributeController(attributesFromZuora: AttributesFromZuora, commonAction
             def customFields(supporterType: String): List[LogField] = List(LogFieldString("lookup-endpoint-description", endpointDescription), LogFieldString("supporter-type", supporterType), LogFieldString("data-source", fromWhere))
 
             attributes match {
-              case Some(attrs @ Attributes(_, Some(tier), _, _, _, _, _, _, _, _)) =>
+              case Some(attrs @ Attributes(_, Some(tier), _, _, _, _, _, _, _)) =>
                 logInfoWithCustomFields(s"$identityId is a $tier member - $endpointDescription - $attrs found via $fromWhere", customFields("member"))
                 onSuccessMember(attrs).withHeaders(
                   "X-Gu-Membership-Tier" -> tier,

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -34,7 +34,6 @@ case class Attributes(
   PaperSubscriptionExpiryDate: Option[LocalDate] = None,
   MembershipNumber: Option[String] = None,
   AdFree: Option[Boolean] = None,
-  KeepFreshForStaffAdFree: Option[Boolean] = None,
   AlertAvailableFor: Option[String] = None) {
   lazy val isFriendTier = Tier.exists(_.equalsIgnoreCase("friend"))
   lazy val isSupporterTier = Tier.exists(_.equalsIgnoreCase("supporter"))
@@ -77,7 +76,6 @@ case class DynamoAttributes(
   PaperSubscriptionExpiryDate: Option[LocalDate] = None,
   MembershipNumber: Option[String],
   AdFree: Option[Boolean],
-  KeepFreshForStaffAdFree: Option[Boolean] = None,
   TTLTimestamp: Long) {
   lazy val isFriendTier = Tier.exists(_.equalsIgnoreCase("friend"))
   lazy val isSupporterTier = Tier.exists(_.equalsIgnoreCase("supporter"))
@@ -97,7 +95,6 @@ object DynamoAttributes {
     PaperSubscriptionExpiryDate = dynamoAttributes.PaperSubscriptionExpiryDate,
     MembershipNumber = dynamoAttributes.MembershipNumber,
     AdFree = dynamoAttributes.AdFree,
-    KeepFreshForStaffAdFree = dynamoAttributes.KeepFreshForStaffAdFree
   )
 }
 
@@ -112,7 +109,6 @@ object Attributes {
       (__ \ "paperSubscriptionExpiryDate").writeNullable[LocalDate] and
       (__ \ "membershipNumber").writeNullable[String] and
       (__ \ "adFree").writeNullable[Boolean] and
-      (__ \ "keepFreshForStaffAdFree").writeNullable[Boolean] and
       (__ \ "alertAvailableFor").writeNullable[String]
   )(unlift(Attributes.unapply))
     .addNullableField("digitalSubscriptionExpiryDate", _.latestDigitalSubscriptionExpiryDate)

--- a/membership-attribute-service/app/services/AttributesFromZuora.scala
+++ b/membership-attribute-service/app/services/AttributesFromZuora.scala
@@ -108,7 +108,7 @@ class AttributesFromZuora(implicit val executionContext: ExecutionContext) exten
     val newExpiry: DateTime = calculateExpiry(currentExpiry)
 
     def expiryShouldChange(dynamoAttributes: Option[DynamoAttributes], currentExpiry: Option[DateTime], newExpiry: DateTime) =
-      dynamoAttributes.isDefined && (!currentExpiry.contains(newExpiry) || dynamoAttributes.exists(_.KeepFreshForStaffAdFree.getOrElse(false)))
+      dynamoAttributes.isDefined && !currentExpiry.contains(newExpiry)
 
     expiryShouldChange(dynamoAttributes, currentExpiry, newExpiry) || !dynamoAndZuoraAgree(dynamoAttributes, zuoraAttributes, identityId)
   }
@@ -124,7 +124,6 @@ class AttributesFromZuora(implicit val executionContext: ExecutionContext) exten
         PaperSubscriptionExpiryDate = attributes.PaperSubscriptionExpiryDate,
         MembershipNumber = attributes.MembershipNumber,
         AdFree = attributes.AdFree,
-        KeepFreshForStaffAdFree = attributes.KeepFreshForStaffAdFree,
         TTLTimestamp = TtlConversions.toDynamoTtlInSeconds(twoWeekExpiry)
       )
     }

--- a/membership-attribute-service/app/services/AttributesMaker.scala
+++ b/membership-attribute-service/app/services/AttributesMaker.scala
@@ -129,7 +129,6 @@ class AttributesMaker extends LoggingWithLogstashFields{
           PaperSubscriptionExpiryDate = zuora.PaperSubscriptionExpiryDate,
           MembershipNumber = dynamo.MembershipNumber,
           AdFree = dynamo.AdFree,
-          KeepFreshForStaffAdFree = dynamo.KeepFreshForStaffAdFree,
           AlertAvailableFor = zuora.AlertAvailableFor
         ))
       case (Some(zuora), None) =>
@@ -142,20 +141,7 @@ class AttributesMaker extends LoggingWithLogstashFields{
           PaperSubscriptionExpiryDate = zuora.PaperSubscriptionExpiryDate,
           MembershipNumber = None,
           AdFree = None,
-          KeepFreshForStaffAdFree = None,
           AlertAvailableFor = zuora.AlertAvailableFor
-        ))
-      case (None, Some(dynamo)) if dynamo.KeepFreshForStaffAdFree.getOrElse(false) =>
-        Some(Attributes(
-          UserId = dynamo.UserId,
-          Tier = None,
-          RecurringContributionPaymentPlan = None,
-          MembershipJoinDate = None,
-          DigitalSubscriptionExpiryDate = None,
-          MembershipNumber = None,
-          AdFree = dynamo.AdFree,
-          KeepFreshForStaffAdFree = dynamo.KeepFreshForStaffAdFree,
-          AlertAvailableFor = None
         ))
       case (None, _) => None
     }

--- a/membership-attribute-service/test/repositories/ScanamoAttributeServiceTest.scala
+++ b/membership-attribute-service/test/repositories/ScanamoAttributeServiceTest.scala
@@ -70,8 +70,7 @@ class ScanamoAttributeServiceTest(implicit ee: ExecutionEnv) extends Specificati
         MembershipJoinDate = Some(new LocalDate(2017, 6, 13)),
         TTLTimestamp = toDynamoTtl(testExpiryDate),
         DigitalSubscriptionExpiryDate = None,
-        AdFree = None,
-        KeepFreshForStaffAdFree = None
+        AdFree = None
       )
 
       val result = for {
@@ -94,17 +93,17 @@ class ScanamoAttributeServiceTest(implicit ee: ExecutionEnv) extends Specificati
   "getMany" should {
 
     val testUsers = Seq(
-      DynamoAttributes(UserId = "1234", Tier = Some("Partner"), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None, KeepFreshForStaffAdFree = None),
-      DynamoAttributes(UserId = "2345", Tier = Some("Partner"), MembershipJoinDate = Some(new LocalDate(2017, 6, 12)), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None, KeepFreshForStaffAdFree = None),
-      DynamoAttributes(UserId = "3456", Tier = Some("Partner"), MembershipJoinDate = Some(new LocalDate(2017, 6, 11)), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None, KeepFreshForStaffAdFree = None),
-      DynamoAttributes(UserId = "4567", Tier = Some("Partner"), MembershipJoinDate = Some(new LocalDate(2017, 6, 10)), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None, KeepFreshForStaffAdFree = None)
+      DynamoAttributes(UserId = "1234", Tier = Some("Partner"), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None),
+      DynamoAttributes(UserId = "2345", Tier = Some("Partner"), MembershipJoinDate = Some(new LocalDate(2017, 6, 12)), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None),
+      DynamoAttributes(UserId = "3456", Tier = Some("Partner"), MembershipJoinDate = Some(new LocalDate(2017, 6, 11)), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None),
+      DynamoAttributes(UserId = "4567", Tier = Some("Partner"), MembershipJoinDate = Some(new LocalDate(2017, 6, 10)), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None)
     )
 
     "Fetch many people by user id" in {
       Await.result(Future.sequence(testUsers.map(repo.set)), 5.seconds)
       Await.result(repo.getMany(List("1234", "3456", "abcd")), 5.seconds) mustEqual Seq(
-        DynamoAttributes(UserId = "1234", Tier = Some("Partner"), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None, KeepFreshForStaffAdFree = None),
-        DynamoAttributes(UserId = "3456", Tier = Some("Partner"), MembershipJoinDate = Some(new LocalDate(2017, 6, 11)), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None, KeepFreshForStaffAdFree = None)
+        DynamoAttributes(UserId = "1234", Tier = Some("Partner"), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None),
+        DynamoAttributes(UserId = "3456", Tier = Some("Partner"), MembershipJoinDate = Some(new LocalDate(2017, 6, 11)), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None)
       )
     }
   }
@@ -112,7 +111,7 @@ class ScanamoAttributeServiceTest(implicit ee: ExecutionEnv) extends Specificati
   "update" should {
     "add the attribute if it's not already in the table" in {
 
-      val newAttributes = DynamoAttributes(UserId = "6789", RecurringContributionPaymentPlan = Some("Monthly Contribution"), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None, KeepFreshForStaffAdFree = None)
+      val newAttributes = DynamoAttributes(UserId = "6789", RecurringContributionPaymentPlan = Some("Monthly Contribution"), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None)
 
       val result = for {
         _ <- repo.update(newAttributes)
@@ -124,8 +123,8 @@ class ScanamoAttributeServiceTest(implicit ee: ExecutionEnv) extends Specificati
     }
 
     "update a user who has bought a digital subscription" in {
-      val oldAttributes = DynamoAttributes(UserId = "6789", RecurringContributionPaymentPlan = Some("Monthly Contribution"), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None, KeepFreshForStaffAdFree = None)
-      val newAttributes = DynamoAttributes(UserId = "6789", RecurringContributionPaymentPlan = Some("Monthly Contribution"), DigitalSubscriptionExpiryDate = Some(LocalDate.now().plusWeeks(5)), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None, KeepFreshForStaffAdFree = None)
+      val oldAttributes = DynamoAttributes(UserId = "6789", RecurringContributionPaymentPlan = Some("Monthly Contribution"), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None)
+      val newAttributes = DynamoAttributes(UserId = "6789", RecurringContributionPaymentPlan = Some("Monthly Contribution"), DigitalSubscriptionExpiryDate = Some(LocalDate.now().plusWeeks(5)), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None)
 
       val result = for {
         _ <- repo.set(oldAttributes)
@@ -137,7 +136,7 @@ class ScanamoAttributeServiceTest(implicit ee: ExecutionEnv) extends Specificati
     }
 
     "leave attribute in the table if nothing has changed" in {
-      val existingAttributes = DynamoAttributes(UserId = "6789", AdFree = Some(true), DigitalSubscriptionExpiryDate = Some(LocalDate.now().plusWeeks(5)), TTLTimestamp = testTtl, MembershipNumber = None, KeepFreshForStaffAdFree = None)
+      val existingAttributes = DynamoAttributes(UserId = "6789", AdFree = Some(true), DigitalSubscriptionExpiryDate = Some(LocalDate.now().plusWeeks(5)), TTLTimestamp = testTtl, MembershipNumber = None)
 
       val result = for {
         _ <- repo.set(existingAttributes)
@@ -149,8 +148,8 @@ class ScanamoAttributeServiceTest(implicit ee: ExecutionEnv) extends Specificati
     }
 
     "leave existing values in an attribute that cannot be determined from a zuora update alone" in {
-      val existingAttributes = DynamoAttributes(UserId = "6789", AdFree = Some(true), DigitalSubscriptionExpiryDate = Some(LocalDate.now().minusWeeks(5)), MembershipNumber = Some("1234"), TTLTimestamp = testTtl, KeepFreshForStaffAdFree = None)
-      val updatedAttributes = DynamoAttributes(UserId = "6789", DigitalSubscriptionExpiryDate = Some(LocalDate.now().plusWeeks(5)), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None, KeepFreshForStaffAdFree = None)
+      val existingAttributes = DynamoAttributes(UserId = "6789", AdFree = Some(true), DigitalSubscriptionExpiryDate = Some(LocalDate.now().minusWeeks(5)), MembershipNumber = Some("1234"), TTLTimestamp = testTtl)
+      val updatedAttributes = DynamoAttributes(UserId = "6789", DigitalSubscriptionExpiryDate = Some(LocalDate.now().plusWeeks(5)), TTLTimestamp = testTtl, MembershipNumber = None, AdFree = None)
       val attributesWithPreservedValues = existingAttributes.copy(DigitalSubscriptionExpiryDate = updatedAttributes.DigitalSubscriptionExpiryDate) //TTL is also only in dynamo, but the logic for it is in attributesFromZuora.
 
       val result = for {

--- a/membership-attribute-service/test/services/AttributesFromZuoraTest.scala
+++ b/membership-attribute-service/test/services/AttributesFromZuoraTest.scala
@@ -41,7 +41,6 @@ class AttributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
     None,
     None,
     None,
-    KeepFreshForStaffAdFree = None,
     referenceDateInSeconds
   )
   val contributorAttributes = DynamoAttributes.asAttributes(contributorDynamoAttributes)
@@ -54,7 +53,6 @@ class AttributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
     RecurringContributionPaymentPlan = None,
     MembershipJoinDate = Some(referenceDate),
     DigitalSubscriptionExpiryDate = None,
-    KeepFreshForStaffAdFree = None,
     TTLTimestamp = referenceDateInSeconds)
 
   def asZuoraAttributes(dynamoAttributes: DynamoAttributes): ZuoraAttributes = ZuoraAttributes(
@@ -359,21 +357,6 @@ class AttributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
         updateRequired must be_==(true)
       }
 
-      "return true if Dynamo record is marked KeepFreshForStaffAdFree even without a Zuora record" in {
-        val recentEnough = toDynamoTtl(twoWeeksFromReferenceDate.minusHours(14))
-        val dynamoAttributes = Some(supporterDynamoAttributes.copy(TTLTimestamp = recentEnough, KeepFreshForStaffAdFree = Some(true)))
-        val updateRequired = attributesFromZuora.dynamoUpdateRequired(dynamoAttributes, None, "123", twoWeeksFromReferenceDate)
-
-        updateRequired must be_==(true)
-      }
-
-      "return true if Zuora and Dynamo agree and the timestamp is recent enough but Dynamo is marked KeepFreshForStaffAdFree" in {
-        val recentEnough = toDynamoTtl(twoWeeksFromReferenceDate.minusHours(14))
-        val updateRequired = attributesFromZuora.dynamoUpdateRequired(dynamoAttributes = Some(supporterDynamoAttributes.copy(TTLTimestamp = recentEnough, KeepFreshForStaffAdFree = Some(true))), Some(asZuoraAttributes(supporterDynamoAttributes)), supporterDynamoAttributes.UserId, twoWeeksFromReferenceDate)
-
-        updateRequired must be_==(true)
-      }
-
       "return false if zuora and dynamo agree and the timestamp is recent enough" in {
         val recentEnough = toDynamoTtl(twoWeeksFromReferenceDate.minusHours(14))
         val updateRequired = attributesFromZuora.dynamoUpdateRequired(dynamoAttributes = Some(supporterDynamoAttributes.copy(TTLTimestamp = recentEnough)), Some(asZuoraAttributes(supporterDynamoAttributes)), supporterDynamoAttributes.UserId, twoWeeksFromReferenceDate)
@@ -408,7 +391,6 @@ class AttributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
       RecurringContributionPaymentPlan = Some("Monthly Contribution"),
       MembershipJoinDate = None,
       DigitalSubscriptionExpiryDate = Some(digitalPackExpirationDate),
-      KeepFreshForStaffAdFree = None,
       TTLTimestamp = toDynamoTtl(twoWeeksFromReferenceDate)
     )
     val zuoraContributorDigitalPackAttributes = asZuoraAttributes(dynamoContributorDigitalPackAttributes)

--- a/membership-attribute-service/test/services/AttributesMakerTest.scala
+++ b/membership-attribute-service/test/services/AttributesMakerTest.scala
@@ -192,7 +192,6 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
         DigitalSubscriptionExpiryDate = None,
         MembershipNumber = None,
         AdFree = None,
-        KeepFreshForStaffAdFree = None,
         TTLTimestamp = referenceDateAsDynamoTimestamp
       )
 
@@ -235,7 +234,7 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
       attributes === expected
     }
 
-    "return Dynamo attributes if present even if no Zuora records exist, as long as marked KeepFreshForStaffAdFree" in {
+    "return none if a Dynamo record exists but no Zuora records exist" in {
       val dynamoAttributes = DynamoAttributes(
         UserId = identityId,
         Tier = None,
@@ -244,38 +243,6 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
         DigitalSubscriptionExpiryDate = None,
         MembershipNumber = None,
         AdFree = Some(true),
-        KeepFreshForStaffAdFree = Some(true),
-        TTLTimestamp = referenceDateAsDynamoTimestamp
-      )
-
-      val expected = Some(
-        Attributes(
-          UserId = identityId,
-          Tier = None,
-          RecurringContributionPaymentPlan = None,
-          MembershipJoinDate = None,
-          DigitalSubscriptionExpiryDate = None,
-          MembershipNumber = None,
-          AdFree = Some(true),
-          KeepFreshForStaffAdFree = Some(true)
-        )
-      )
-
-      val attributes = AttributesMaker.zuoraAttributesWithAddedDynamoFields(None, Some(dynamoAttributes))
-
-      attributes === expected
-    }
-
-    "return none if a Dynamo record exists but is NOT marked KeepFreshForStaffAdFree if no Zuora records exist" in {
-      val dynamoAttributes = DynamoAttributes(
-        UserId = identityId,
-        Tier = None,
-        RecurringContributionPaymentPlan = None,
-        MembershipJoinDate = None,
-        DigitalSubscriptionExpiryDate = None,
-        MembershipNumber = None,
-        AdFree = Some(true),
-        KeepFreshForStaffAdFree = None,
         TTLTimestamp = referenceDateAsDynamoTimestamp
       )
 


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
Since AdFree is in the wild and no longer in a staff trial, it's time to remove this code that supported a staff trial. 

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
Reverts https://github.com/guardian/members-data-api/pull/336/files

### trello card/screenshot/json/related PRs etc
We are able to remove KeepFreshForStaffAdFree from the Attributes and DynamoAttributes model because: 

![image](https://user-images.githubusercontent.com/3072877/50227070-bc460e00-039c-11e9-8dc6-768912e70027.png)

(I removed the flag manually from the 4 results that came up when I first queried)