### PR TITLE
no default payment method alarm PLUS automatic cloudformation on deploy

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,6 +52,7 @@ val buildDebSettings = Seq(
   packageDescription := """Members Data API""",
 
   riffRaffPackageType := (packageBin in Debian).value,
+  riffRaffArtifactResources += (file("cloudformation/membership-attribute-service.yaml") -> "cloudformation/membership-attribute-service.yaml"),
 
   javaOptions in Universal ++= Seq(
     "-Dpidfile.path=/dev/null",

--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -303,7 +303,7 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
       - Name: LogGroup
-        Value: !Sub "${LogGroupNamePrefix}-${Stage}"
+        Value: !Sub members-data-api-${Stage}
       - Name: Stage
         Value: !Sub ${Stage}
       EvaluationPeriods: 1

--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -280,6 +280,40 @@ Resources:
     Properties:
       LogGroupName: !Sub members-data-api-${Stage}
       RetentionInDays: 14
+  MembersDataDefaultPaymentMethodLeftEmptyMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    DependsOn: MembersDataApiLogGroup
+    Properties:
+      FilterPattern: "Default payment method for user *, was set to nothing, when attempting to update Direct Debit details"
+      LogGroupName: !Sub members-data-api-${Stage}
+      MetricTransformations:
+      - MetricValue: "1"
+        MetricNamespace: "members-data-api"
+        MetricName: "Default Payment Method set to nothing"
+  MembersDataDefaultPaymentMethodLeftEmptyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    DependsOn:
+    - MembersDataDefaultPaymentMethodLeftEmptyMetricFilter
+    - MembersDataApiLogGroup
+    Condition: CreateProdMonitoring
+    Properties:
+      AlarmActions:
+      - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:subscriptions_dev
+      AlarmName: !Sub "Default Payment Method set to nothing : members-data-api ${Stage}"
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+      - Name: LogGroup
+        Value: !Sub "${LogGroupNamePrefix}-${Stage}"
+      - Name: Stage
+        Value: !Sub ${Stage}
+      EvaluationPeriods: 1
+      MetricName: "Default Payment Method set to nothing"
+      Namespace: "members-data-api"
+      Period: 3600
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching
+
   ExpiredTtlAlarm:
         Type: AWS::CloudWatch::Alarm
         Condition: CreateProdMonitoring

--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -289,7 +289,7 @@ Resources:
       MetricTransformations:
       - MetricValue: "1"
         MetricNamespace: "members-data-api"
-        MetricName: "Default Payment Method set to nothing"
+        MetricName: !Sub "${Stage} - Default Payment Method set to nothing"
   MembersDataDefaultPaymentMethodLeftEmptyAlarm:
     Type: AWS::CloudWatch::Alarm
     DependsOn:
@@ -307,7 +307,7 @@ Resources:
       - Name: Stage
         Value: !Sub ${Stage}
       EvaluationPeriods: 1
-      MetricName: "Default Payment Method set to nothing"
+      MetricName: !Sub "${Stage} - Default Payment Method set to nothing"
       Namespace: "members-data-api"
       Period: 3600
       Statistic: Sum

--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -284,7 +284,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     DependsOn: MembersDataApiLogGroup
     Properties:
-      FilterPattern: "Default payment method for user *, was set to nothing, when attempting to update Direct Debit details"
+      FilterPattern: "default-payment-method-lost"
       LogGroupName: !Sub members-data-api-${Stage}
       MetricTransformations:
       - MetricValue: "1"

--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -128,7 +128,7 @@ class AccountController(commonActions: CommonActions, override val controllerCom
         logger.error(s"New payment method for user $maybeUserId, does not match the posted Direct Debit details")
         InternalServerError("")
       case None =>
-        logger.error(s"Default payment method for user $maybeUserId, was set to nothing, when attempting to update Direct Debit details")
+        logger.error(s"default-payment-method-lost: Default payment method for user $maybeUserId, was set to nothing, when attempting to update Direct Debit details")
         InternalServerError("")
     }
 
@@ -168,7 +168,7 @@ class AccountController(commonActions: CommonActions, override val controllerCom
       freshDefaultPaymentMethodOption <- EitherT(annotateFailableFuture(tp.paymentService.getPaymentMethod(subscription.accountId), "get fresh default payment method"))
     } yield checkDirectDebitUpdateResult(maybeUserId, freshDefaultPaymentMethodOption, bankAccountName, bankAccountNumber, bankSortCode)).run.map {
       case -\/(message) =>
-        logger.warn(s"Failed to update direct debit for user $maybeUserId, due to $message")
+        logger.warn(s"default-payment-method-lost: failed to update direct debit for user $maybeUserId, due to $message")
         InternalServerError("")
       case \/-(result) => result
     }

--- a/membership-attribute-service/conf/riff-raff.yaml
+++ b/membership-attribute-service/conf/riff-raff.yaml
@@ -1,10 +1,11 @@
 stacks: [membership]
 regions: [eu-west-1]
 deployments:
-  ami:
-    type: ami-cloudformation-parameter
+  cloudformation:
+    type: cloud-formation
     app: membership-attribute-service
     parameters:
+      templatePath: cloudformation/membership-attribute-service.yaml
       amiTags:
         Recipe: xenial-membership
         AmigoStage: PROD
@@ -12,6 +13,6 @@ deployments:
       amiParameter: AmiId
   membership-attribute-service:
     type: autoscaling
-    dependencies: [ami]
+    dependencies: [cloudformation]
     parameters:
       bucket: gu-membership-attribute-service-dist

--- a/membership-attribute-service/conf/riff-raff.yaml
+++ b/membership-attribute-service/conf/riff-raff.yaml
@@ -5,7 +5,7 @@ deployments:
     type: cloud-formation
     app: membership-attribute-service
     parameters:
-      templatePath: cloudformation/membership-attribute-service.yaml
+      templatePath: membership-attribute-service.yaml
       amiTags:
         Recipe: xenial-membership
         AmigoStage: PROD


### PR DESCRIPTION
added an metric filter and accompanying ALARM for when an account is left with no default payment method (during Direct Debit update)

also configured riff-raff to perform the cloudformation update on deploy

#### Related PRs
- https://github.com/guardian/manage-frontend/pull/158
- https://github.com/guardian/members-data-api/pull/348