### PR TITLE
Use latest membership-common to support new GW plans

### DIFF
--- a/membership-attribute-service/test/testdata/AccountObjectTestData.scala
+++ b/membership-attribute-service/test/testdata/AccountObjectTestData.scala
@@ -27,12 +27,18 @@ object AccountSummaryTestData {
     AccountSummary(
       id = accountId,
       identityId = Some(testIdentityId),
-      billToContact = BillToContact(Some("email"), Some(Country.UK)),
+      billToContact = BillToContact(email = Some("email"), country = Some(Country.UK)),
       soldToContact = SoldToContact(
         title = None,
         firstName = Some("Joe"),
         lastName = "Bloggs",
-        None, None, None, None, None, None
+        email = None,
+        address1 = None,
+        address2 = None,
+        city = None,
+        postCode = None,
+        state = None,
+        country = None
       ),
       invoices = List(Invoice(
         id = InvoiceId("someid"),
@@ -43,7 +49,8 @@ object AccountSummaryTestData {
       )),
       currency = None,
       balance = balance,
-      defaultPaymentMethod = Some(DefaultPaymentMethod(paymentMethodId))
+      defaultPaymentMethod = Some(DefaultPaymentMethod(paymentMethodId)),
+      sfContactId = SalesforceContactId("foo")
     )
 
   val accountSummaryWithBalance = accountSummaryWith(20.0, testPaymentMethodId, testAccountId)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.527"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.529"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.9"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.2"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
Ensures Members Data API can understand the new Guardian Weekly renewal 1 year only plan.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->

- Update to latest Membership Common
- Update test to match new model for a previous change in 0.528
