### PR TITLE
new endpoint which returns all current subscription details (as JSON array)

### DIFF
--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -6,9 +6,11 @@ import com.gu.memsub._
 import com.gu.memsub.subsv2.reads.ChargeListReads._
 import com.gu.memsub.subsv2.reads.SubPlanReads
 import com.gu.memsub.subsv2.reads.SubPlanReads._
-import com.gu.memsub.subsv2.{Subscription, SubscriptionPlan}
+import com.gu.memsub.subsv2.services.SubscriptionService
+import com.gu.memsub.subsv2.{PaidChargeList, Subscription, SubscriptionPlan}
 import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.SafeLogger._
+import com.gu.salesforce.SimpleContactRepository
 import com.gu.services.model.PaymentDetails
 import com.gu.stripe.{Stripe, StripeService}
 import com.gu.zuora.api.RegionalStripeGateways
@@ -29,7 +31,7 @@ import scalaz.std.scalaFuture._
 import scalaz.syntax.monad._
 import scalaz.syntax.std.option._
 import scalaz.syntax.traverse._
-import scalaz.{-\/, EitherT, OptionT, \/, \/-}
+import scalaz.{-\/, EitherT, ListT, OptionT, \/, \/-}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -258,13 +260,47 @@ class AccountController(commonActions: CommonActions, override val controllerCom
       accountSummary <- OptionEither.liftOption(tp.zuoraRestService.getAccount(sub.accountId).recover { case x => \/.left(s"error receiving account summary for subscription: ${sub.name} with account id ${sub.accountId}. Reason: $x") })
       stripeService = accountSummary.billToContact.country.map(RegionalStripeGateways.getGatewayForCountry).flatMap(tp.stripeServicesByPaymentGateway.get).getOrElse(tp.ukStripeService)
       alertText <- OptionEither.liftEitherOption(alertText(accountSummary, sub, getPaymentMethod))
-    } yield AccountDetails(contact, accountSummary.billToContact.email, upToDatePaymentDetails, stripeService.publicKey, alertText).toResult).run.run.map {
+    } yield AccountDetails(contact.regNumber, accountSummary.billToContact.email, upToDatePaymentDetails, stripeService.publicKey, alertText).toJson).run.run.map {
       case \/-(Some(result)) =>
         logger.info(s"Successfully retrieved payment details result for identity user: ${maybeUserId.mkString}")
-        result
+        Ok(result)
       case \/-(None) =>
         logger.info(s"identity user doesn't exist in SF: ${maybeUserId.mkString}")
         Ok(Json.obj())
+      case -\/(message) =>
+        logger.warn(s"Unable to retrieve payment details result for identity user ${maybeUserId.mkString} due to $message")
+        InternalServerError("Failed to retrieve payment details due to an internal error")
+    }
+  }
+
+
+  def allSubscriptions(contactRepo: SimpleContactRepository, subService: SubscriptionService[Future])(maybeUserId: Option[String]): OptionT[OptionEither.FutureEither, List[Subscription[SubscriptionPlan.AnyPlan]]] = for {
+    user <- OptionEither.liftFutureEither(maybeUserId)
+    contact <- OptionEither(contactRepo.get(user))
+    subscriptions <- OptionEither.liftEitherOption(subService.current[SubscriptionPlan.AnyPlan](contact)) // TODO are we happy with an empty list in case of error ?!?!
+  } yield subscriptions
+
+  private def allPaymentDetails = BackendFromCookieAction.async { implicit request =>
+    implicit val tp = request.touchpoint
+    def getPaymentMethod(id: PaymentMethodId) = tp.zuoraRestService.getPaymentMethod(id.get)
+    val maybeUserId = authenticationService.userId
+
+    logger.info(s"Attempting to retrieve payment details for identity user: ${maybeUserId.mkString}")
+    (for {
+      subscription <- ListEither.fromOptionEither(allSubscriptions(tp.contactRepo, tp.subService)(maybeUserId))
+      freeOrPaidSub = subscription.plan.charges match {
+        case _: PaidChargeList => \/.right(subscription.asInstanceOf[Subscription[SubscriptionPlan.Paid]])
+        case _ => \/.left(subscription.asInstanceOf[Subscription[SubscriptionPlan.Free]])
+      }
+      paymentDetails <- ListEither.liftList(tp.paymentService.paymentDetails(freeOrPaidSub).map(\/.right).recover { case x => \/.left(s"error retrieving payment details for subscription: ${subscription.name}. Reason: $x") })
+      upToDatePaymentDetails <- ListEither.liftList(getUpToDatePaymentDetailsFromStripe(subscription.accountId, paymentDetails).map(\/.right).recover { case x => \/.left(s"error getting up-to-date card details for payment method of account: ${subscription.accountId}. Reason: $x") })
+      accountSummary <- ListEither.liftList(tp.zuoraRestService.getAccount(subscription.accountId).recover { case x => \/.left(s"error receiving account summary for subscription: ${subscription.name} with account id ${subscription.accountId}. Reason: $x") })
+      stripeService = accountSummary.billToContact.country.map(RegionalStripeGateways.getGatewayForCountry).flatMap(tp.stripeServicesByPaymentGateway.get).getOrElse(tp.ukStripeService)
+      alertText <- ListEither.liftEitherList(alertText(accountSummary, subscription, getPaymentMethod))
+    } yield AccountDetails(None, accountSummary.billToContact.email, upToDatePaymentDetails, stripeService.publicKey, alertText).toJson).run.run.map {
+      case \/-(subscriptionJSONs) =>
+        logger.info(s"Successfully retrieved payment details result for identity user: ${maybeUserId.mkString}")
+        Ok(Json.toJson(subscriptionJSONs))
       case -\/(message) =>
         logger.warn(s"Unable to retrieve payment details result for identity user ${maybeUserId.mkString} due to $message")
         InternalServerError("Failed to retrieve payment details due to an internal error")
@@ -314,6 +350,9 @@ class AccountController(commonActions: CommonActions, override val controllerCom
   def monthlyContributionDetails = paymentDetails[SubscriptionPlan.Contributor, Nothing]
   def digitalPackDetails = paymentDetails[SubscriptionPlan.Digipack, Nothing]
   def paperDetails = paymentDetails[SubscriptionPlan.PaperPlan, Nothing]
+
+  def allDetails = allPaymentDetails
+
 }
 
 // this is helping us stack future/either/option
@@ -333,6 +372,30 @@ object OptionEither {
   def liftEitherOption[A](future: Future[A])(implicit ex: ExecutionContext): OptionT[FutureEither, A] = {
     apply(future map { value: A =>
       \/.right[String, Option[A]](Some(value))
+    })
+  }
+
+}
+
+object ListEither {
+
+  type FutureEither[X] = EitherT[Future, String, X]
+
+  def apply[A](m: Future[\/[String, List[A]]]): ListT[FutureEither, A] =
+    ListT[FutureEither, A](EitherT[Future, String, List[A]](m))
+
+  def fromOptionEither[A](value: OptionT[FutureEither, List[A]])(implicit ex: ExecutionContext): ListT[FutureEither, A] =
+    ListT[FutureEither, A](value.run.map(_.toList.flatten))
+
+  def liftList[A](x: Future[\/[String, A]])(implicit ex: ExecutionContext): ListT[FutureEither, A] =
+    apply(x.map(_.map[List[A]](a => List(a))))
+
+  def liftFutureEither[A](x: List[A]): ListT[FutureEither, A] =
+    apply(Future.successful(\/.right[String,List[A]](x)))
+
+  def liftEitherList[A](future: Future[A])(implicit ex: ExecutionContext): ListT[FutureEither, A] = {
+    apply(future map { value: A =>
+      \/.right[String, List[A]](List(value))
     })
   }
 

--- a/membership-attribute-service/app/utils/ListEither.scala
+++ b/membership-attribute-service/app/utils/ListEither.scala
@@ -1,0 +1,26 @@
+package utils
+
+import scalaz.{EitherT, ListT, OptionT, \/}
+import scalaz.std.scalaFuture._
+import scala.concurrent.{ExecutionContext, Future}
+
+object ListEither {
+
+  type FutureEither[X] = EitherT[Future, String, X]
+
+  def apply[A](m: Future[\/[String, List[A]]]): ListT[FutureEither, A] =
+    ListT[FutureEither, A](EitherT[Future, String, List[A]](m))
+
+  def fromOptionEither[A](value: OptionT[FutureEither, List[A]])(implicit ex: ExecutionContext): ListT[FutureEither, A] =
+    ListT[FutureEither, A](value.run.map(_.toList.flatten))
+
+  def liftList[A](x: Future[\/[String, A]])(implicit ex: ExecutionContext): ListT[FutureEither, A] =
+    apply(x.map(_.map[List[A]](a => List(a))))
+
+  def liftEitherList[A](future: Future[A])(implicit ex: ExecutionContext): ListT[FutureEither, A] = {
+    apply(future map { value: A =>
+      \/.right[String, List[A]](List(value))
+    })
+  }
+
+}

--- a/membership-attribute-service/app/utils/OptionEither.scala
+++ b/membership-attribute-service/app/utils/OptionEither.scala
@@ -1,0 +1,27 @@
+package utils
+
+import scalaz.{EitherT, OptionT, \/}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+// this is helping us stack future/either/option
+object OptionEither {
+
+  type FutureEither[X] = EitherT[Future, String, X]
+
+  def apply[A](m: Future[\/[String, Option[A]]]): OptionT[FutureEither, A] =
+    OptionT[FutureEither, A](EitherT[Future, String, Option[A]](m))
+
+  def liftOption[A](x: Future[\/[String, A]])(implicit ex: ExecutionContext): OptionT[FutureEither, A] =
+    apply(x.map(_.map[Option[A]](Some.apply)))
+
+  def liftFutureEither[A](x: Option[A]): OptionT[FutureEither, A] =
+    apply(Future.successful(\/.right[String,Option[A]](x)))
+
+  def liftEitherOption[A](future: Future[A])(implicit ex: ExecutionContext): OptionT[FutureEither, A] = {
+    apply(future map { value: A =>
+      \/.right[String, Option[A]](Some(value))
+    })
+  }
+
+}

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -3,10 +3,13 @@ GET         /healthcheck                                                controll
 GET         /user-attributes/me/membership                              controllers.AttributeController.membership
 GET         /user-attributes/me/features                                controllers.AttributeController.features
 
+# /user-attributes/me/mma-* will be phased out once manage platform starts using the 'allDetails' one
 GET         /user-attributes/me/mma-digitalpack                         controllers.AccountController.digitalPackDetails
 GET         /user-attributes/me/mma-membership                          controllers.AccountController.membershipDetails
 GET         /user-attributes/me/mma-monthlycontribution                 controllers.AccountController.monthlyContributionDetails
 GET         /user-attributes/me/mma-paper                               controllers.AccountController.paperDetails
+# this will become the dominant endpoint for getting subscription details
+GET         /user-attributes/me/mma                                     controllers.AccountController.allDetails
 
 POST        /user-attributes/me/membership-update-card                  controllers.AccountController.membershipUpdateCard
 POST        /user-attributes/me/digitalpack-update-card                 controllers.AccountController.digitalPackUpdateCard

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -9,7 +9,7 @@ GET         /user-attributes/me/mma-membership                          controll
 GET         /user-attributes/me/mma-monthlycontribution                 controllers.AccountController.monthlyContributionDetails
 GET         /user-attributes/me/mma-paper                               controllers.AccountController.paperDetails
 # this will become the dominant endpoint for getting subscription details
-GET         /user-attributes/me/mma                                     controllers.AccountController.allDetails
+GET         /user-attributes/me/mma                                     controllers.AccountController.allPaymentDetails
 
 POST        /user-attributes/me/membership-update-card                  controllers.AccountController.membershipUpdateCard
 POST        /user-attributes/me/digitalpack-update-card                 controllers.AccountController.digitalPackUpdateCard


### PR DESCRIPTION
… in the long term this will replace the product specific endpoints

The current product specific endpoints (e.g. `/user-attributes/me/mma-monthlycontribution`) have a `headOption` which always limits the result to a single subscription, however since Guest Checkout on `support-frontend` there are legitimate scenarios where there can be multiple recurring contributions - and hence we needed an endpoint to expose this.

Furthermore the plan for Q4 for `manage-frontend` is to consolidate all products into a single view and so this change has been made with that in mind - hence a single endpoint listing all current subs (all products).

_Paired with @johnduffell_ 

The /mma endpoint will now return a json array containing zero or more instances of the subscription response object, before it would have returned exactly one, otherwise an empty Json Object.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/19289579/50647644-08827800-0f71-11e9-9bbc-48fb3a122ada.png) | ![image](https://user-images.githubusercontent.com/19289579/50647493-9ca00f80-0f70-11e9-9a26-d3d58c7cbeb7.png) | 
| `/user-attributes/me/mma-monthlycontribution`|`/user-attributes/me/mma` | 

