### PR TITLE
New 'write' endpoints which target specific subscription

### DIFF
--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -346,27 +346,27 @@ class AccountController(commonActions: CommonActions, override val controllerCom
     }
   }
 
-  def cancelRegularContribution = cancelSubscription[SubscriptionPlan.Contributor](None)
-  def cancelMembership = cancelSubscription[SubscriptionPlan.Member](None)
+  @Deprecated def cancelRegularContribution = cancelSubscription[SubscriptionPlan.Contributor](None)
+  @Deprecated def cancelMembership = cancelSubscription[SubscriptionPlan.Member](None)
   def cancelSpecificSub(subscriptionName: String) = cancelSubscription[SubscriptionPlan.AnyPlan](Some(memsub.Subscription.Name(subscriptionName)))
 
-  def membershipUpdateCard = updateCard[SubscriptionPlan.PaidMember](None)
-  def digitalPackUpdateCard = updateCard[SubscriptionPlan.Digipack](None)
-  def paperUpdateCard = updateCard[SubscriptionPlan.PaperPlan](None)
-  def contributionUpdateCard = updateCard[SubscriptionPlan.Contributor](None)
+  @Deprecated def membershipUpdateCard = updateCard[SubscriptionPlan.PaidMember](None)
+  @Deprecated def digitalPackUpdateCard = updateCard[SubscriptionPlan.Digipack](None)
+  @Deprecated def paperUpdateCard = updateCard[SubscriptionPlan.PaperPlan](None)
+  @Deprecated def contributionUpdateCard = updateCard[SubscriptionPlan.Contributor](None)
   def updateCardOnSpecificSub(subscriptionName: String) = updateCard[SubscriptionPlan.AnyPlan](Some(memsub.Subscription.Name(subscriptionName)))
 
-  def contributionUpdateAmount = updateContributionAmount(None)
+  @Deprecated def contributionUpdateAmount = updateContributionAmount(None)
   def updateAmountForSpecificContribution(subscriptionName: String) = updateContributionAmount(Some(memsub.Subscription.Name(subscriptionName)))
 
-  def contributionUpdateDirectDebit = updateDirectDebit[SubscriptionPlan.Contributor](None)
-  def paperUpdateDirectDebit = updateDirectDebit[SubscriptionPlan.PaperPlan](None)
+  @Deprecated def contributionUpdateDirectDebit = updateDirectDebit[SubscriptionPlan.Contributor](None)
+  @Deprecated def paperUpdateDirectDebit = updateDirectDebit[SubscriptionPlan.PaperPlan](None)
   def updateDirectDebitOnSpecificSub(subscriptionName: String) = updateDirectDebit[SubscriptionPlan.AnyPlan](Some(memsub.Subscription.Name(subscriptionName)))
 
 
-  def membershipDetails = paymentDetails[SubscriptionPlan.PaidMember, SubscriptionPlan.FreeMember]
-  def monthlyContributionDetails = paymentDetails[SubscriptionPlan.Contributor, Nothing]
-  def digitalPackDetails = paymentDetails[SubscriptionPlan.Digipack, Nothing]
-  def paperDetails = paymentDetails[SubscriptionPlan.PaperPlan, Nothing]
+  @Deprecated def membershipDetails = paymentDetails[SubscriptionPlan.PaidMember, SubscriptionPlan.FreeMember]
+  @Deprecated def monthlyContributionDetails = paymentDetails[SubscriptionPlan.Contributor, Nothing]
+  @Deprecated def digitalPackDetails = paymentDetails[SubscriptionPlan.Digipack, Nothing]
+  @Deprecated def paperDetails = paymentDetails[SubscriptionPlan.PaperPlan, Nothing]
 
 }

--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -1,5 +1,6 @@
 package controllers
 import actions._
+import com.gu.memsub
 import services.PaymentFailureAlerter._
 import services.{AuthenticationService, IdentityAuthService}
 import com.gu.memsub._
@@ -41,7 +42,12 @@ class AccountController(commonActions: CommonActions, override val controllerCom
   implicit val executionContext: ExecutionContext= controllerComponents.executionContext
   lazy val authenticationService: AuthenticationService = IdentityAuthService
 
-   def cancelSubscription [P <: SubscriptionPlan.AnyPlan : SubPlanReads] = BackendFromCookieAction.async { implicit request =>
+  def subscriptionSelector[P <: SubscriptionPlan.AnyPlan](subscriptionNameOption: Option[memsub.Subscription.Name])(subscriptions: List[Subscription[P]]): Option[Subscription[P]] = subscriptionNameOption match {
+    case Some(subName) => subscriptions.find(_.name == subName)
+    case None => subscriptions.headOption
+  }
+
+  def cancelSubscription[P <: SubscriptionPlan.AnyPlan : SubPlanReads](subscriptionNameOption: Option[memsub.Subscription.Name]) = BackendFromCookieAction.async { implicit request =>
 
     val tp = request.touchpoint
     val cancelForm = Form { single("reason" -> nonEmptyText) }
@@ -59,7 +65,7 @@ class AccountController(commonActions: CommonActions, override val controllerCom
     def retrieveZuoraSubscription(user: String): Future[ApiError \/ Subscription[P]] = {
       val getSubscriptionData = for {
         sfUser <- EitherT(tp.contactRepo.get(user).map(_.flatMap(_ \/> s"No Salesforce user: $user")))
-        zuoraSubscription <- EitherT(tp.subService.current[P](sfUser).map(_.headOption).map (_ \/> s"No current subscriptions for the Salesforce user: $sfUser"))
+        zuoraSubscription <- EitherT(tp.subService.current[P](sfUser).map(subscriptionSelector(subscriptionNameOption)).map (_ \/> s"No current subscriptions for the Salesforce user: $sfUser"))
       } yield zuoraSubscription
 
       getSubscriptionData.run.map {
@@ -70,6 +76,7 @@ class AccountController(commonActions: CommonActions, override val controllerCom
           \/-(subscription)
       }
     }
+
 
     def executeCancellation(zuoraSubscription: Subscription[P], reason: String): Future[ApiError \/ Unit] = {
       val cancellationSteps = for {
@@ -329,18 +336,19 @@ class AccountController(commonActions: CommonActions, override val controllerCom
       reasonForChange = s"User updated contribution via self-service MMA. Amount changed from $currencyGlyph$oldPrice to $currencyGlyph$newPrice effective from $applyFromDate"
       result <- EitherT(tp.zuoraRestService.updateChargeAmount(subscription.name, subscription.plan.charges.subRatePlanChargeId, subscription.plan.id, newPrice.toDouble, reasonForChange, applyFromDate)).leftMap(message => s"Error while updating contribution amount: $message")
     } yield result).run map { _ match {
-        case -\/(message) =>
-          SafeLogger.error(scrub"Failed to update payment amount for user ${maybeUserId.mkString}, due to: $message")
-          InternalServerError(message)
-        case \/-(()) =>
-          logger.info(s"Contribution amount updated for user ${maybeUserId.mkString}")
-          Ok("Success")
-      }
+      case -\/(message) =>
+        SafeLogger.error(scrub"Failed to update payment amount for user ${maybeUserId.mkString}, due to: $message")
+        InternalServerError(message)
+      case \/-(()) =>
+        logger.info(s"Contribution amount updated for user ${maybeUserId.mkString}")
+        Ok("Success")
+    }
     }
   }
 
-  def cancelRegularContribution = cancelSubscription[SubscriptionPlan.Contributor]
-  def cancelMembership = cancelSubscription[SubscriptionPlan.Member]
+  def cancelRegularContribution = cancelSubscription[SubscriptionPlan.Contributor](None)
+  def cancelMembership = cancelSubscription[SubscriptionPlan.Member](None)
+  def cancelSpecificSub(subscriptionName: String) = cancelSubscription[SubscriptionPlan.AnyPlan](Some(memsub.Subscription.Name(subscriptionName)))
 
   def membershipUpdateCard = updateCard[SubscriptionPlan.PaidMember]
   def digitalPackUpdateCard = updateCard[SubscriptionPlan.Digipack]

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -6,6 +6,8 @@ GET         /user-attributes/me/mma                                             
 
 POST        /user-attributes/me/cancel/:subscriptionName                        controllers.AccountController.cancelSpecificSub(subscriptionName: String)
 
+POST        /user-attributes/me/update-card/:subscriptionName                   controllers.AccountController.updateCardOnSpecificSub(subscriptionName: String)
+
 POST        /user-attributes/me/contribution-update-amount/:subscriptionName    controllers.AccountController.updateAmountForSpecificContribution(subscriptionName: String)
 
 

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -1,10 +1,12 @@
-GET         /healthcheck                                                controllers.HealthCheckController.healthCheck
+GET         /healthcheck                                                        controllers.HealthCheckController.healthCheck
 
-GET         /user-attributes/me                                         controllers.AttributeController.attributes
+GET         /user-attributes/me                                                 controllers.AttributeController.attributes
 
-GET         /user-attributes/me/mma                                     controllers.AccountController.allPaymentDetails
+GET         /user-attributes/me/mma                                             controllers.AccountController.allPaymentDetails
 
-POST        /user-attributes/me/cancel/:subscriptionName                controllers.AccountController.cancelSpecificSub(subscriptionName: String)
+POST        /user-attributes/me/cancel/:subscriptionName                        controllers.AccountController.cancelSpecificSub(subscriptionName: String)
+
+POST        /user-attributes/me/contribution-update-amount/:subscriptionName    controllers.AccountController.updateAmountForSpecificContribution(subscriptionName: String)
 
 
 # OLD ENDPOINTS below will be phased out as traffic moves over to the new endpoints above
@@ -28,4 +30,3 @@ POST        /user-attributes/me/cancel-regular-contribution             controll
 POST        /user-attributes/me/cancel-membership                       controllers.AccountController.cancelMembership
 
 POST        /user-attributes/me/contribution-update-amount              controllers.AccountController.contributionUpdateAmount
-

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -1,15 +1,20 @@
 GET         /healthcheck                                                controllers.HealthCheckController.healthCheck
 
+GET         /user-attributes/me                                         controllers.AttributeController.attributes
+
+GET         /user-attributes/me/mma                                     controllers.AccountController.allPaymentDetails
+
+POST        /user-attributes/me/cancel/:subscriptionName                controllers.AccountController.cancelSpecificSub(subscriptionName: String)
+
+
+# OLD ENDPOINTS below will be phased out as traffic moves over to the new endpoints above
 GET         /user-attributes/me/membership                              controllers.AttributeController.membership
 GET         /user-attributes/me/features                                controllers.AttributeController.features
 
-# /user-attributes/me/mma-* will be phased out once manage platform starts using the 'allDetails' one
 GET         /user-attributes/me/mma-digitalpack                         controllers.AccountController.digitalPackDetails
 GET         /user-attributes/me/mma-membership                          controllers.AccountController.membershipDetails
 GET         /user-attributes/me/mma-monthlycontribution                 controllers.AccountController.monthlyContributionDetails
 GET         /user-attributes/me/mma-paper                               controllers.AccountController.paperDetails
-# this will become the dominant endpoint for getting subscription details
-GET         /user-attributes/me/mma                                     controllers.AccountController.allPaymentDetails
 
 POST        /user-attributes/me/membership-update-card                  controllers.AccountController.membershipUpdateCard
 POST        /user-attributes/me/digitalpack-update-card                 controllers.AccountController.digitalPackUpdateCard
@@ -23,7 +28,4 @@ POST        /user-attributes/me/cancel-regular-contribution             controll
 POST        /user-attributes/me/cancel-membership                       controllers.AccountController.cancelMembership
 
 POST        /user-attributes/me/contribution-update-amount              controllers.AccountController.contributionUpdateAmount
-
-#The endpoint below will replace /user-attributes/me/membership in the long term
-GET         /user-attributes/me                                         controllers.AttributeController.attributes
 

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -8,6 +8,8 @@ POST        /user-attributes/me/cancel/:subscriptionName                        
 
 POST        /user-attributes/me/update-card/:subscriptionName                   controllers.AccountController.updateCardOnSpecificSub(subscriptionName: String)
 
+POST        /user-attributes/me/update-direct-debit/:subscriptionName           controllers.AccountController.updateDirectDebitOnSpecificSub(subscriptionName: String)
+
 POST        /user-attributes/me/contribution-update-amount/:subscriptionName    controllers.AccountController.updateAmountForSpecificContribution(subscriptionName: String)
 
 


### PR DESCRIPTION
Now that we have a new endpoint for returning multiple subs (**_https://github.com/guardian/members-data-api/pull/357_**) - moving away from the `_.headOption` concept - all the write endpoints need to be able to target specific subs.

This PR refactors all the existing 'write' action functions...

- Update Card
- Update Direct Debit
- Cancel
- Update Contribution Amount

... to take an `Option` of subscription name (aka _A-S number_) which is then passed (**provided as a path parameter**) to a new re-usable function `subscriptionSelector` which if...

- `Some` - filters the list of subs for the authenticated user based on the subscription name
- `None` - uses the `headOption` as before

**NOTE** the old endpoints have been retained but marked as `@Deprecated` and pass a `None` to the newly refactored functions which now require the `Option`