### PR TITLE
filterable 'all subscriptions' endpoint

### DIFF
--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -390,7 +390,7 @@ class AccountController(commonActions: CommonActions, override val controllerCom
   @Deprecated def monthlyContributionDetails = paymentDetails[SubscriptionPlan.Contributor, Nothing]
   @Deprecated def digitalPackDetails = paymentDetails[SubscriptionPlan.Digipack, Nothing]
   @Deprecated def paperDetails = paymentDetails[SubscriptionPlan.PaperPlan, Nothing]
-  def allPaymentDetails(productType: Option[String]) = anyPaymentDetails(productType.fold[OptionalSubscriptionsFilter](NoFilter)(FilterByProductType))
+  def allPaymentDetails(productType: Option[String]) = anyPaymentDetails(productType.fold[OptionalSubscriptionsFilter](NoFilter)(FilterByProductType.apply))
   def paymentDetailsSpecificSub(subscriptionName: String) = anyPaymentDetails(FilterBySubName(memsub.Subscription.Name(subscriptionName)))
 
 }

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -2,7 +2,7 @@ GET         /healthcheck                                                        
 
 GET         /user-attributes/me                                                 controllers.AttributeController.attributes
 
-GET         /user-attributes/me/mma                                             controllers.AccountController.allPaymentDetails
+GET         /user-attributes/me/mma                                             controllers.AccountController.allPaymentDetails(productNameStartsWith: Option[String])
 GET         /user-attributes/me/mma/:subscriptionName                           controllers.AccountController.paymentDetailsSpecificSub(subscriptionName: String)
 
 POST        /user-attributes/me/cancel/:subscriptionName                        controllers.AccountController.cancelSpecificSub(subscriptionName: String)

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -2,7 +2,7 @@ GET         /healthcheck                                                        
 
 GET         /user-attributes/me                                                 controllers.AttributeController.attributes
 
-GET         /user-attributes/me/mma                                             controllers.AccountController.allPaymentDetails(productNameStartsWith: Option[String])
+GET         /user-attributes/me/mma                                             controllers.AccountController.allPaymentDetails(productType: Option[String])
 GET         /user-attributes/me/mma/:subscriptionName                           controllers.AccountController.paymentDetailsSpecificSub(subscriptionName: String)
 
 POST        /user-attributes/me/cancel/:subscriptionName                        controllers.AccountController.cancelSpecificSub(subscriptionName: String)

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -3,6 +3,7 @@ GET         /healthcheck                                                        
 GET         /user-attributes/me                                                 controllers.AttributeController.attributes
 
 GET         /user-attributes/me/mma                                             controllers.AccountController.allPaymentDetails
+GET         /user-attributes/me/mma/:subscriptionName                           controllers.AccountController.paymentDetailsSpecificSub(subscriptionName: String)
 
 POST        /user-attributes/me/cancel/:subscriptionName                        controllers.AccountController.cancelSpecificSub(subscriptionName: String)
 


### PR DESCRIPTION
Follows on from https://github.com/guardian/members-data-api/pull/357 and https://github.com/guardian/members-data-api/pull/358 and allows filtering on the all subs endpoint...

- Optional `subscriptionName` **path parameter** on the end of `/user-attributes/me/mma/` limits the list to zero or one subs which match the sub name
- Optional `productType` **query parameter** which will filter the list based on the type of `plan.product` (pattern matched against the provided string)

**Importantly** in both cases the filtering is done BEFORE the more expensive calls to Stripe etc