### PR TITLE
Updated gulocal cert reference for new 2020 cert

### DIFF
--- a/nginx/members-data-api.conf
+++ b/nginx/members-data-api.conf
@@ -3,8 +3,8 @@ server {
     server_name members-data-api.thegulocal.com;
 
     ssl on;
-    ssl_certificate wildcard-thegulocal-com-exp2019-01-09.crt; ## Supplied by https://github.com/guardian/identity-platform#setup-nginx-for-local-development
-    ssl_certificate_key wildcard-thegulocal-com-exp2019-01-09.key; ## ditto
+    ssl_certificate STAR_thegulocal_com_exp2020-01-09.crt; ## Supplied by https://github.com/guardian/identity-platform#setup-nginx-for-local-development
+    ssl_certificate_key STAR_thegulocal_com_exp2020-01-09.key; ## ditto
 
     ssl_session_timeout 5m;
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19289579/50964465-46c6ec80-14c7-11e9-866c-2078a3bd1d1a.png)

Much like https://github.com/guardian/identity-platform/pull/303

1. If you haven't already fetch the certs, download them (see hangouts chat message from Rupert on how/where to fetch).
2. Navigate to `./nginx` and run `./setup.sh`
3. `sudo nginx -s reload`