### PR TITLE
ensure start-api works when from any directory

### DIFF
--- a/start-api-debug.sh
+++ b/start-api-debug.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+cd $(dirname $0)
 sbt -Djava.awt.headless=true -jvm-debug 9997 "project membership-attribute-service" "devrun"

--- a/start-api.sh
+++ b/start-api.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
+
+cd $(dirname $0)
 sbt -Djava.awt.headless=true "project membership-attribute-service" "devrun"


### PR DESCRIPTION
Motivated by work with the manage-frontend repository: members-data-api is required to be run locally when running manage-frontend locally. This allows for e.g:
```sh
../members-data-api/start-api.sh
```
from within the manage-frontend working directory (slightly easier than changing directory etc).

__Of course this is just an example and not required to run the command__