### PR TITLE
made the alertAvailableFor and alertText work for Digital Pack

### DIFF
--- a/membership-attribute-service/app/services/AttributesMaker.scala
+++ b/membership-attribute-service/app/services/AttributesMaker.scala
@@ -63,6 +63,7 @@ class AttributesMaker extends LoggingWithLogstashFields{
       }.toList.sortWith(_.product.name < _.product.name)
     }
 
+    //TODO this should really return a list of all products with alerts and the banner logic etc should handle multiple
     def findFirstAlert(productData: List[ProductData]): Future[Option[String]] = productData match {
 
       case Nil => Future.successful(None)

--- a/membership-attribute-service/app/services/PaymentFailureAlerter.scala
+++ b/membership-attribute-service/app/services/PaymentFailureAlerter.scala
@@ -76,6 +76,7 @@ object PaymentFailureAlerter extends LoggingWithLogstashFields {
           val fields = customFields(accountSummary.identityId, latestDate.toString(formatter), productName)
           logInfoWithCustomFields(s"Logging an alert for identityId: ${accountSummary.identityId} accountId: ${accountSummary.id}. Payment failed on ${latestDate.toString(formatter)}", fields)
 
+          //TODO remove the "Please check that the card details shown are up to date." part of the below string once manage-frontend is the only consumer of this.
           s"Our attempt to take payment for your $productDescription failed on ${latestDate.toString(formatter)}. Please check that the card details shown are up to date."
         }
       }
@@ -85,7 +86,7 @@ object PaymentFailureAlerter extends LoggingWithLogstashFields {
       expectedAlertText.map { someText => shouldShowAlert.option (someText).flatten }
     }
   }
-  val alertableProducts = List(Product.Membership, Product.Contribution)
+  val alertableProducts = List(Product.Membership, Product.Contribution, Product.Digipack)
 
   def alertAvailableFor(
     account: AccountObject, subscription: Subscription[AnyPlan],

--- a/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
+++ b/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
@@ -57,6 +57,16 @@ class PaymentFailureAlerterTest(implicit ee: ExecutionEnv)  extends Specificatio
         result must be_==(Some(expectedActionText)).await
       }
 
+      "return a message for a digipack holder who is in payment failure" in {
+        val result: Future[Option[String]] = PaymentFailureAlerter.alertText(accountSummaryWithBalance, digipack, paymentMethodResponseRecentFailure)
+
+        val attemptDateTime = DateTime.now().minusDays(1)
+        val formatter = DateTimeFormat.forPattern("d MMMM yyyy").withLocale(Locale.ENGLISH)
+        val expectedActionText = s"Our attempt to take payment for your Digital Pack failed on ${attemptDateTime.toString(formatter)}. Please check that the card details shown are up to date."
+
+        result must be_==(Some(expectedActionText)).await
+      }
+
     }
 
     "alertAvailableFor" should {
@@ -95,6 +105,12 @@ class PaymentFailureAlerterTest(implicit ee: ExecutionEnv)  extends Specificatio
 
       "return true for a contributor with a failed payment and an invoice in the last 27 days" in {
         val result = PaymentFailureAlerter.alertAvailableFor(accountObjectWithBalance, contributor, paymentMethodResponseRecentFailure)
+
+        result must be_==(true).await
+      }
+
+      "return true for a digipack holder with a failed payment and an invoice in the last 27 days" in {
+        val result = PaymentFailureAlerter.alertAvailableFor(accountObjectWithBalance, digipack, paymentMethodResponseRecentFailure)
 
         result must be_==(true).await
       }


### PR DESCRIPTION
Previously we were only showing the [action required banner (aka: payment failure banner)](https://github.com/guardian/frontend/pull/20659) for Membership & Contributions. **This PR facilitates the same for Digital Pack.**

### `/user-attributes/me`
![image](https://user-images.githubusercontent.com/19289579/51322777-4b0e7f00-1a5e-11e9-8651-bf413b0930fd.png)

### `/user-attributes/me/mma`
![image](https://user-images.githubusercontent.com/19289579/51322848-7db87780-1a5e-11e9-8023-21b4f498d0ba.png)

_This PR accompanies_ 
