### PR TITLE
add 'guardianWeeklySubscriber' boolean to the 'contentAccess' section of the /me endpoint

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -52,7 +52,7 @@ class AttributeController(attributesFromZuora: AttributesFromZuora, commonAction
             def customFields(supporterType: String): List[LogField] = List(LogFieldString("lookup-endpoint-description", endpointDescription), LogFieldString("supporter-type", supporterType), LogFieldString("data-source", fromWhere))
 
             attributes match {
-              case Some(attrs @ Attributes(_, Some(tier), _, _, _, _, _)) =>
+              case Some(attrs @ Attributes(_, Some(tier), _, _, _, _, _, _)) =>
                 logInfoWithCustomFields(s"$identityId is a $tier member - $endpointDescription - $attrs found via $fromWhere", customFields("member"))
                 onSuccessMember(attrs).withHeaders(
                   "X-Gu-Membership-Tier" -> tier,
@@ -64,6 +64,9 @@ class AttributeController(attributesFromZuora: AttributesFromZuora, commonAction
                 }
                 attrs.PaperSubscriptionExpiryDate.foreach {date =>
                   logInfoWithCustomFields(s"$identityId is a paper subscriber expiring $date", customFields("paper-subscriber"))
+                }
+                attrs.GuardianWeeklySubscriptionExpiryDate.foreach {date =>
+                  logInfoWithCustomFields(s"$identityId is a Guardian Weekly subscriber expiring $date", customFields("guardian-weekly-subscriber"))
                 }
                 attrs.RecurringContributionPaymentPlan.foreach { paymentPlan =>
                   logInfoWithCustomFields(s"$identityId is a regular $paymentPlan contributor", customFields("contributor"))

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -17,7 +17,8 @@ case class ContentAccess(
   paidMember: Boolean,
   recurringContributor: Boolean,
   digitalPack: Boolean,
-  paperSubscriber: Boolean
+  paperSubscriber: Boolean,
+  guardianWeeklySubscriber: Boolean
 )
 
 object ContentAccess {
@@ -32,6 +33,7 @@ case class Attributes(
   MembershipJoinDate: Option[LocalDate] = None,
   DigitalSubscriptionExpiryDate: Option[LocalDate] = None,
   PaperSubscriptionExpiryDate: Option[LocalDate] = None,
+  GuardianWeeklySubscriptionExpiryDate: Option[LocalDate] = None,
   AlertAvailableFor: Option[String] = None) {
   lazy val isFriendTier = Tier.exists(_.equalsIgnoreCase("friend"))
   lazy val isSupporterTier = Tier.exists(_.equalsIgnoreCase("supporter"))
@@ -44,13 +46,15 @@ case class Attributes(
   lazy val latestDigitalSubscriptionExpiryDate =  Some(Set(staffDigitalSubscriptionExpiryDate, DigitalSubscriptionExpiryDate).flatten).filter(_.nonEmpty).map(_.max)
   lazy val digitalSubscriberHasActivePlan = latestDigitalSubscriptionExpiryDate.exists(_.isAfter(now))
   lazy val isPaperSubscriber = PaperSubscriptionExpiryDate.exists(_.isAfter(now))
+  lazy val isGuardianWeeklySubscriber = GuardianWeeklySubscriptionExpiryDate.exists(_.isAfter(now))
 
   lazy val contentAccess = ContentAccess(
     member = isPaidTier || isFriendTier,
     paidMember = isPaidTier,
     recurringContributor = isContributor,
     digitalPack = digitalSubscriberHasActivePlan,
-    paperSubscriber = isPaperSubscriber
+    paperSubscriber = isPaperSubscriber,
+    guardianWeeklySubscriber = isGuardianWeeklySubscriber
   )
 
 }
@@ -62,6 +66,7 @@ case class ZuoraAttributes(
   MembershipJoinDate: Option[LocalDate] = None,
   DigitalSubscriptionExpiryDate: Option[LocalDate] = None,
   PaperSubscriptionExpiryDate: Option[LocalDate] = None,
+  GuardianWeeklySubscriptionExpiryDate: Option[LocalDate] = None,
   AlertAvailableFor: Option[String] = None)
 
 object ZuoraAttributes {
@@ -72,6 +77,7 @@ object ZuoraAttributes {
     MembershipJoinDate = zuoraAttributes.MembershipJoinDate,
     DigitalSubscriptionExpiryDate = zuoraAttributes.DigitalSubscriptionExpiryDate,
     PaperSubscriptionExpiryDate = zuoraAttributes.PaperSubscriptionExpiryDate,
+    GuardianWeeklySubscriptionExpiryDate = zuoraAttributes.GuardianWeeklySubscriptionExpiryDate,
     AlertAvailableFor = zuoraAttributes.AlertAvailableFor
   )
 }
@@ -83,6 +89,7 @@ case class DynamoAttributes(
   MembershipJoinDate: Option[LocalDate] = None,
   DigitalSubscriptionExpiryDate: Option[LocalDate] = None,
   PaperSubscriptionExpiryDate: Option[LocalDate] = None,
+  GuardianWeeklySubscriptionExpiryDate: Option[LocalDate] = None,
   TTLTimestamp: Long) {
   lazy val isFriendTier = Tier.exists(_.equalsIgnoreCase("friend"))
   lazy val isSupporterTier = Tier.exists(_.equalsIgnoreCase("supporter"))
@@ -99,7 +106,8 @@ object DynamoAttributes {
     RecurringContributionPaymentPlan = dynamoAttributes.RecurringContributionPaymentPlan,
     MembershipJoinDate = dynamoAttributes.MembershipJoinDate,
     DigitalSubscriptionExpiryDate = dynamoAttributes.DigitalSubscriptionExpiryDate,
-    PaperSubscriptionExpiryDate = dynamoAttributes.PaperSubscriptionExpiryDate
+    PaperSubscriptionExpiryDate = dynamoAttributes.PaperSubscriptionExpiryDate,
+    GuardianWeeklySubscriptionExpiryDate = dynamoAttributes.GuardianWeeklySubscriptionExpiryDate
   )
 }
 
@@ -112,6 +120,7 @@ object Attributes {
       (__ \ "membershipJoinDate").writeNullable[LocalDate] and
       (__ \ "digitalSubscriptionExpiryDate").writeNullable[LocalDate] and
       (__ \ "paperSubscriptionExpiryDate").writeNullable[LocalDate] and
+      (__ \ "guardianWeeklyExpiryDate").writeNullable[LocalDate] and
       (__ \ "alertAvailableFor").writeNullable[String]
   )(unlift(Attributes.unapply))
     .addNullableField("digitalSubscriptionExpiryDate", _.latestDigitalSubscriptionExpiryDate)

--- a/membership-attribute-service/app/services/AttributesFromZuora.scala
+++ b/membership-attribute-service/app/services/AttributesFromZuora.scala
@@ -124,6 +124,7 @@ class AttributesFromZuora(implicit val executionContext: ExecutionContext) exten
         MembershipJoinDate = attributes.MembershipJoinDate,
         DigitalSubscriptionExpiryDate = attributes.DigitalSubscriptionExpiryDate,
         PaperSubscriptionExpiryDate = attributes.PaperSubscriptionExpiryDate,
+        GuardianWeeklySubscriptionExpiryDate = attributes.GuardianWeeklySubscriptionExpiryDate,
         TTLTimestamp = TtlConversions.toDynamoTtlInSeconds(twoWeekExpiry)
       )
     }

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -29,7 +29,8 @@ class AttributeControllerTest extends Specification with AfterAll {
     MembershipJoinDate = Some(new LocalDate(2017, 5, 13)),
     RecurringContributionPaymentPlan = Some("Monthly Contribution"),
     DigitalSubscriptionExpiryDate = Some(new LocalDate(2100, 1, 1)),
-    PaperSubscriptionExpiryDate = Some(new LocalDate(2099, 1, 1))
+    PaperSubscriptionExpiryDate = Some(new LocalDate(2099, 1, 1)),
+    GuardianWeeklySubscriptionExpiryDate = Some(new LocalDate(2099, 1, 1))
   )
 
   private val validUserCookie = Cookie("validUser", "true")
@@ -122,12 +123,14 @@ class AttributeControllerTest extends Specification with AfterAll {
                    |   "recurringContributionPaymentPlan":"Monthly Contribution",
                    |   "digitalSubscriptionExpiryDate":"2100-01-01",
                    |   "paperSubscriptionExpiryDate":"2099-01-01",
+                   |   "guardianWeeklyExpiryDate":"2099-01-01",
                    |   "contentAccess": {
                    |     "member": true,
                    |     "paidMember": true,
                    |     "recurringContributor": true,
                    |     "digitalPack": true,
-                   |     "paperSubscriber": true
+                   |     "paperSubscriber": true,
+                   |     "guardianWeeklySubscriber": true
                    |   }
                    | }
                  """.stripMargin)
@@ -167,7 +170,8 @@ class AttributeControllerTest extends Specification with AfterAll {
                      |    "paidMember": false,
                      |    "recurringContributor": false,
                      |    "digitalPack": false,
-                     |    "paperSubscriber": false
+                     |    "paperSubscriber": false,
+                     |    "guardianWeeklySubscriber": false
                      |  }
                      |}""".stripMargin)
     }

--- a/membership-attribute-service/test/services/AttributesFromZuoraTest.scala
+++ b/membership-attribute-service/test/services/AttributesFromZuoraTest.scala
@@ -41,6 +41,7 @@ class AttributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
     MembershipJoinDate = None,
     DigitalSubscriptionExpiryDate = None,
     PaperSubscriptionExpiryDate = None,
+    GuardianWeeklySubscriptionExpiryDate = None,
     TTLTimestamp = referenceDateInSeconds
   )
   val contributorAttributes = DynamoAttributes.asAttributes(contributorDynamoAttributes)

--- a/membership-attribute-service/test/testdata/SubscriptionTestData.scala
+++ b/membership-attribute-service/test/testdata/SubscriptionTestData.scala
@@ -32,6 +32,9 @@ trait SubscriptionTestData {
   def contributorPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan.Contributor = PaidSubscriptionPlan[Product.Contribution, PaidCharge[Benefit.Contributor.type, BillingPeriod]](
     RatePlanId("idContributor"), ProductRatePlanId("prpi"), "Monthly Contribution", "desc", "Monthly Contribution", Product.Contribution, List.empty, PaidCharge(Contributor, BillingPeriod.Month, PricingSummary(Map(GBP -> Price(5.0f, GBP))), ProductRatePlanChargeId("bar"), SubscriptionRatePlanChargeId("nar")), None, startDate, endDate
   )
+  def guardianWeeklyPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan.WeeklyPlan = PaidSubscriptionPlan[Product.WeeklyDomestic, PaidCharge[Benefit.Weekly.type, BillingPeriod]](
+    RatePlanId("idGuardianWeeklyPlan"), ProductRatePlanId("prpi"), "Guardian Weekly", "desc", "Guardian Weekly", Product.WeeklyDomestic, List.empty, PaidCharge(Weekly, BillingPeriod.Quarter, PricingSummary(Map(GBP -> Price(37.50f, GBP))), ProductRatePlanChargeId("bar"), SubscriptionRatePlanChargeId("nar")), None, startDate, endDate
+  )
 
   def toSubscription[P <: SubscriptionPlan.AnyPlan](isCancelled: Boolean)(plans: NonEmptyList[P]): Subscription[P] = {
     Subscription(
@@ -53,6 +56,7 @@ trait SubscriptionTestData {
   }
 
   val digipack = toSubscription(false)(NonEmptyList(digipackPlan(referenceDate, referenceDate + 1.year)))
+  val guardianWeekly = toSubscription(false)(NonEmptyList(guardianWeeklyPlan(referenceDate, referenceDate + 1.year)))
   val sunday = toSubscription(false)(NonEmptyList(paperPlan(referenceDate, referenceDate + 1.year)))
   val sundayPlus = toSubscription(false)(NonEmptyList(paperPlusPlan(referenceDate, referenceDate + 1.year)))
   val membership = toSubscription(false)(NonEmptyList(supporterPlan(referenceDate, referenceDate + 1.year)))


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
Similar to https://github.com/guardian/members-data-api/pull/346 - this adds the last of the main products to the `contentAccess` section so this change is mainly for completeness.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
add 'guardianWeeklySubscriber' boolean to the 'contentAccess' section of the /me endpoint

### trello card/screenshot/json/related PRs etc
![image](https://user-images.githubusercontent.com/19289579/51564571-90c8ae80-1e87-11e9-9708-f9d6f7a12be3.png)

