### PR TITLE
new 'showSupportMessaging' boolean on the /me response - facilitates centrally controlling support messaging on app & dotcom

### DIFF
--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -57,6 +57,10 @@ case class Attributes(
     guardianWeeklySubscriber = isGuardianWeeklySubscriber
   )
 
+  // show support messaging (in app & on dotcom) if they do NOT have any active products
+  // TODO in future this could become more sophisticated (e.g. two weeks before their products expire)
+  lazy val showSupportMessaging = !(isPaidTier || isContributor || digitalSubscriberHasActivePlan || isPaperSubscriber || isGuardianWeeklySubscriber)
+
 }
 
 case class ZuoraAttributes(
@@ -124,6 +128,7 @@ object Attributes {
       (__ \ "alertAvailableFor").writeNullable[String]
   )(unlift(Attributes.unapply))
     .addNullableField("digitalSubscriptionExpiryDate", _.latestDigitalSubscriptionExpiryDate)
+    .addField("showSupportMessaging", _.showSupportMessaging)
     .addField("contentAccess", _.contentAccess)
 
   implicit def toResult(attrs: Attributes): Result =

--- a/membership-attribute-service/app/services/AttributesMaker.scala
+++ b/membership-attribute-service/app/services/AttributesMaker.scala
@@ -95,7 +95,7 @@ class AttributesMaker extends LoggingWithLogstashFields{
       case _ => false
     }.values.flatten
 
-    val hasAttributableProduct = membershipSub.nonEmpty ||
+    val hasAttributableProduct: Boolean = membershipSub.nonEmpty ||
       contributionSub.nonEmpty ||
       subsWhichIncludeDigitalPack.nonEmpty ||
       paperSubscriptions.nonEmpty ||

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -124,6 +124,7 @@ class AttributeControllerTest extends Specification with AfterAll {
                    |   "digitalSubscriptionExpiryDate":"2100-01-01",
                    |   "paperSubscriptionExpiryDate":"2099-01-01",
                    |   "guardianWeeklyExpiryDate":"2099-01-01",
+                   |   "showSupportMessaging": false,
                    |   "contentAccess": {
                    |     "member": true,
                    |     "paidMember": true,
@@ -165,6 +166,7 @@ class AttributeControllerTest extends Specification with AfterAll {
         Json.parse("""
                      |{
                      |  "userId": "456",
+                     |  "showSupportMessaging": true,
                      |  "contentAccess": {
                      |    "member": false,
                      |    "paidMember": false,

--- a/membership-attribute-service/test/repositories/ScanamoAttributeServiceTest.scala
+++ b/membership-attribute-service/test/repositories/ScanamoAttributeServiceTest.scala
@@ -116,7 +116,7 @@ class ScanamoAttributeServiceTest(implicit ee: ExecutionEnv) extends Specificati
         retrieved <- repo.get("6789")
       } yield retrieved
 
-      result must be_==(Some(newAttributes)).await
+      result must beSome(newAttributes).await
 
     }
 

--- a/membership-attribute-service/test/services/AttributesFromZuoraTest.scala
+++ b/membership-attribute-service/test/services/AttributesFromZuoraTest.scala
@@ -52,7 +52,8 @@ class AttributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
     RecurringContributionPaymentPlan = None,
     MembershipJoinDate = Some(referenceDate),
     DigitalSubscriptionExpiryDate = None,
-    TTLTimestamp = referenceDateInSeconds)
+    TTLTimestamp = referenceDateInSeconds
+  )
 
   def asZuoraAttributes(dynamoAttributes: DynamoAttributes): ZuoraAttributes = ZuoraAttributes(
     UserId = dynamoAttributes.UserId,


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
Currently app and dotcom rely on the booleans in the `contentAccess` section, but this means any time we want to change when _support messaging_* should be shown, apps and dotcom have to change their logic (particularly long release/uptake cycle for the app) - this PR makes it centrally controlled.

_* = header, footer, epic, banner, thrasher etc_

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
Initially this just introduces the **`showSupportMessaging`** boolean which is `false` if the signed in user has any active products and `true` if they don't. However once the app & dotcom are updated to use it, we can make the calculation of the boolean more sophisticated, for example re-showing support messaging as users approach renewal, including one-off contributions (as we are planning to do in `members-data-api` anyway).

### trello card/screenshot/json/related PRs etc
| No Products | Some Products |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/19289579/51742595-1f108080-2092-11e9-8784-68464e3b22c8.png) | ![image](https://user-images.githubusercontent.com/19289579/51743557-ec1bbc00-2094-11e9-972f-bd282f802a6f.png) |
