### PR TITLE
introduced 'ContentSubscription' to facilitate combined Subscriptions tab in manage-frontend

### DIFF
--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -286,14 +286,17 @@ class AccountController(commonActions: CommonActions, override val controllerCom
   case class FilterByProductType(productType: String) extends OptionalSubscriptionsFilter
   case object NoFilter extends OptionalSubscriptionsFilter
 
-  private def productIsInstanceOfProductType(product: Product, productType: String) = product match {
-    // this ordering prevents Weekly subs from coming back when Paper is requested (which is different from the type hierarchy where Weekly extends Paper)
-    case _: Product.Weekly => productType == "Weekly"
-    case _: Product.Paper => productType == "Paper"
-    case _: Product.Contribution => productType == "Contribution"
-    case _: Product.Membership => productType == "Membership"
-    case _: Product.ZDigipack => productType == "Digipack"
-    case _ => productType == product.name // fallback
+  private def productIsInstanceOfProductType(product: Product, requestedProductType: String) = {
+    val requestedProductTypeIsContentSubscription: Boolean = requestedProductType == "ContentSubscription"
+    product match {
+      // this ordering prevents Weekly subs from coming back when Paper is requested (which is different from the type hierarchy where Weekly extends Paper)
+      case _: Product.Weekly => requestedProductType == "Weekly" || requestedProductTypeIsContentSubscription
+      case _: Product.Paper => requestedProductType == "Paper" || requestedProductTypeIsContentSubscription
+      case _: Product.Contribution => requestedProductType == "Contribution"
+      case _: Product.Membership => requestedProductType == "Membership"
+      case _: Product.ZDigipack => requestedProductType == "Digipack" || requestedProductTypeIsContentSubscription
+      case _ => requestedProductType == product.name // fallback
+    }
   }
 
   def allSubscriptions(


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
In order to consolidate Paper, Weekly & Digipack (but not Membership or Contributions) into a **single Subscriptions tab** (see https://github.com/guardian/manage-frontend/pull/185) the recent `?productType=` functionality (introduced in https://github.com/guardian/members-data-api/pull/359) needed to support an additional value which would return this meaningful grouping of products, but since technically everything is a subscription, this sub-grouping was entitled **'ContentSubscription`**

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
A simple update to the pattern match, to return instances of `Paper`, `Weekly` and `ZDigipack` if 
`/user-attributes/me/mma?productType=ContentSubscription`