### PR TITLE
Expose `autoRenew` boolean in the mma response

### DIFF
--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -4,7 +4,7 @@ import com.gu.services.model.PaymentDetails
 import json.localDateWrites
 import play.api.libs.json.{Json, _}
 
-case class AccountDetails(regNumber: Option[String], email: Option[String], paymentDetails: PaymentDetails, stripePublicKey: String, membershipAlertText: Option[String])
+case class AccountDetails(regNumber: Option[String], email: Option[String], paymentDetails: PaymentDetails, stripePublicKey: String, isAutoRenew: Boolean, membershipAlertText: Option[String])
 
 object AccountDetails {
 
@@ -64,6 +64,7 @@ object AccountDetails {
             "subscriberId" -> paymentDetails.subscriberId, // TODO remove once nothing is using this key (same time as removing old deprecated endpoints
             "subscriptionId" -> paymentDetails.subscriberId,
             "trialLength" -> paymentDetails.remainingTrialLength,
+            "autoRenew" -> isAutoRenew,
             "plan" -> Json.obj(
               "name" -> paymentDetails.plan.name,
               "amount" -> paymentDetails.plan.price.amount * 100,

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -61,7 +61,8 @@ object AccountDetails {
             "nextPaymentDate" -> paymentDetails.nextPaymentDate,
             "renewalDate" -> paymentDetails.termEndDate,
             "cancelledAt" -> (paymentDetails.pendingAmendment || paymentDetails.pendingCancellation),
-            "subscriberId" -> paymentDetails.subscriberId,
+            "subscriberId" -> paymentDetails.subscriberId, // TODO remove once nothing is using this key (same time as removing old deprecated endpoints
+            "subscriptionId" -> paymentDetails.subscriberId,
             "trialLength" -> paymentDetails.remainingTrialLength,
             "plan" -> Json.obj(
               "name" -> paymentDetails.plan.name,


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
`manage-frontend` needs to display a renew subscription button (see https://github.com/guardian/manage-frontend/pull/185) if a Guardian Weekly is one-off (i.e. not auto-renewing) - so this needs to be exposed in the the mma response from members-data-api

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
Expose `autoRenew` boolean (within`subscription` object) in the detailed response.

PLUS expose `subscriberId` AGAIN as `subscriptionId` as we're moving to that nomenclature generally (old key will be removed in a future clean up PR along with `@Deprecated` routes)

### trello card/screenshot/json/related PRs etc
![image](https://user-images.githubusercontent.com/19289579/52054274-e0783b80-2553-11e9-8249-ebe1b6152a0f.png)
