### PR TITLE
changed to use StageMappings for the MinInstances and MaxInstances

### DIFF
--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -17,15 +17,6 @@ Parameters:
     - m3.large
     - m3.xlarge
     ConstraintDescription: must be a valid EC2 instance type.
-  MaxInstances:
-    Description: Maximum number of instances. This should be (at least) double the
-      desired capacity.
-    Type: Number
-    Default: 12
-  MinInstances:
-    Description: "Minimum number of instances desired. NOTE: there is a Zuora concurrent call threshold configured in MembershipFeatureToggles-[STAGE] DynamoDB table which will need adjusting if you increase this value."
-    Type: Number
-    Default: 6
   VpcId:
     Description: ID of the VPC onto which to launch the application
     Type: AWS::EC2::VPC::Id
@@ -43,6 +34,8 @@ Parameters:
 Mappings:
   StageVariables:
     PROD:
+      MaxInstances: 12 # This should be (at least) double the desired capacity.
+      MinInstances: 6 # NOTE: there is a Zuora concurrent call threshold configured in MembershipFeatureToggles-[STAGE] DynamoDB table which will need adjusting if you increase this value.
       NotificationAlarmPeriod: 1200
       InstanceName: PROD:membership-attribute-service
       DynamoDBTable: "Memb-Attributes-Tables-PROD-SupporterAttributesFallback"
@@ -54,6 +47,8 @@ Mappings:
         - arn:aws:s3:::gu-reader-revenue-private/membership/members-data-api/PROD/*
 
     CODE:
+      MaxInstances: 2
+      MinInstances: 1
       NotificationAlarmPeriod: 1200
       InstanceName: CODE:membership-attribute-service
       DynamoDBTable: "Memb-Attributes-Tables-DEV-SupporterAttributesFallback"
@@ -176,10 +171,8 @@ Resources:
         Fn::GetAZs: ''
       LaunchConfigurationName:
         Ref: LaunchConfig
-      MinSize:
-        Ref: MinInstances
-      MaxSize:
-        Ref: MaxInstances
+      MinSize: !FindInMap [ StageVariables, !Ref Stage, MinInstances ]
+      MaxSize: !FindInMap [ StageVariables, !Ref Stage, MaxInstances ]
       HealthCheckType: ELB
       HealthCheckGracePeriod: 400
       LoadBalancerNames:


### PR DESCRIPTION
using parameters provided no distinction for CODE where we need far fewer instances, RiffRaff was reverting CODE to the `MinInstances` param default of `6` on every CODE deploy 😢 

**So now the defaults are in the `StageMappings`.**

In an emergency scale up scenario, changes can be made in the AWS console to scale up immediately, then a follow-up PR to change the values in `StageMappings` if necessary.

**This should save some wasted resources in CODE.**