### PR TITLE
Correct sub 'start' field and expose some more useful info from detail endpoint

### DIFF
--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -55,10 +55,11 @@ object AccountDetails {
           "joinDate" -> paymentDetails.startDate,
           "optIn" -> !paymentDetails.pendingCancellation,
           "subscription" -> (paymentMethod ++ Json.obj(
-            "start" -> paymentDetails.lastPaymentDate,
+            "start" -> paymentDetails.customerAcceptanceDate,
             "end" -> endDate,
             "nextPaymentPrice" -> paymentDetails.nextPaymentPrice,
             "nextPaymentDate" -> paymentDetails.nextPaymentDate,
+            "lastPaymentDate" -> paymentDetails.lastPaymentDate,
             "renewalDate" -> paymentDetails.termEndDate,
             "cancelledAt" -> (paymentDetails.pendingAmendment || paymentDetails.pendingCancellation),
             "subscriberId" -> paymentDetails.subscriberId, // TODO remove once nothing is using this key (same time as removing old deprecated endpoints


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
To improve the accuracy and usefulness of the detailed data, largely so `manage-frontend` can present better information to the user.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
changed  'start' field in the detail response to use the 'customerAcceptanceDate' because using 'lastPaymentDate' is just plain wrong and was null in the case of new physical subs (lastPaymentDate is now exposed as its own field)
_This was using 'lastPaymentDate' because of https://github.com/guardian/members-data-api/pull/83_

### trello card/screenshot/json/related PRs etc
