### PR TITLE
Provide more information about bad payment states to clients

### DIFF
--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -270,7 +270,16 @@ class AccountController(commonActions: CommonActions, override val controllerCom
       stripeService = accountSummary.billToContact.country.map(RegionalStripeGateways.getGatewayForCountry).flatMap(tp.stripeServicesByPaymentGateway.get).getOrElse(tp.ukStripeService)
       alertText <- OptionEither.liftEitherOption(alertText(accountSummary, sub, getPaymentMethod))
       isAutoRenew = sub.autoRenew
-    } yield AccountDetails(contact.regNumber, accountSummary.billToContact.email, upToDatePaymentDetails, stripeService.publicKey, isAutoRenew, alertText).toJson).run.run.map {
+    } yield AccountDetails(
+      contact.regNumber,
+      accountSummary.billToContact.email,
+      upToDatePaymentDetails,
+      stripeService.publicKey,
+      accountHasMissedRecentPayments = false,
+      safeToUpdatePaymentMethod = true,
+      isAutoRenew = isAutoRenew,
+      alertText
+    ).toJson).run.run.map {
       case \/-(Some(result)) =>
         logger.info(s"Successfully retrieved payment details result for identity user: ${maybeUserId.mkString}")
         Ok(result)
@@ -339,7 +348,16 @@ class AccountController(commonActions: CommonActions, override val controllerCom
       stripeService = accountSummary.billToContact.country.map(RegionalStripeGateways.getGatewayForCountry).flatMap(tp.stripeServicesByPaymentGateway.get).getOrElse(tp.ukStripeService)
       alertText <- ListEither.liftEitherList(alertText(accountSummary, subscription, getPaymentMethod))
       isAutoRenew = subscription.autoRenew
-    } yield AccountDetails(None, accountSummary.billToContact.email, upToDatePaymentDetails, stripeService.publicKey, isAutoRenew, alertText).toJson).run.run.map {
+    } yield AccountDetails(
+      regNumber = None,
+      email = accountSummary.billToContact.email,
+      paymentDetails = upToDatePaymentDetails,
+      stripePublicKey = stripeService.publicKey,
+      accountHasMissedRecentPayments = accountHasMissedRecentPayments(subscription.accountId, freeOrPaidSub.isRight, accountSummary.invoices, accountSummary.payments),
+      safeToUpdatePaymentMethod = safeToAllowPaymentUpdate(subscription.accountId, accountSummary.invoices),
+      isAutoRenew = isAutoRenew,
+      membershipAlertText = alertText
+    ).toJson).run.run.map {
       case \/-(subscriptionJSONs) =>
         logger.info(s"Successfully retrieved payment details result for identity user: ${maybeUserId.mkString}")
         Ok(Json.toJson(subscriptionJSONs))

--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -353,7 +353,7 @@ class AccountController(commonActions: CommonActions, override val controllerCom
       email = accountSummary.billToContact.email,
       paymentDetails = upToDatePaymentDetails,
       stripePublicKey = stripeService.publicKey,
-      accountHasMissedRecentPayments = accountHasMissedPayments(subscription.accountId, freeOrPaidSub.isRight, accountSummary.invoices, accountSummary.payments),
+      accountHasMissedRecentPayments = if (freeOrPaidSub.isRight) accountHasMissedPayments(subscription.accountId, accountSummary.invoices, accountSummary.payments) else false,
       safeToUpdatePaymentMethod = safeToAllowPaymentUpdate(subscription.accountId, accountSummary.invoices),
       isAutoRenew = isAutoRenew,
       membershipAlertText = alertText

--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -353,7 +353,7 @@ class AccountController(commonActions: CommonActions, override val controllerCom
       email = accountSummary.billToContact.email,
       paymentDetails = upToDatePaymentDetails,
       stripePublicKey = stripeService.publicKey,
-      accountHasMissedRecentPayments = accountHasMissedRecentPayments(subscription.accountId, freeOrPaidSub.isRight, accountSummary.invoices, accountSummary.payments),
+      accountHasMissedRecentPayments = accountHasMissedPayments(subscription.accountId, freeOrPaidSub.isRight, accountSummary.invoices, accountSummary.payments),
       safeToUpdatePaymentMethod = safeToAllowPaymentUpdate(subscription.accountId, accountSummary.invoices),
       isAutoRenew = isAutoRenew,
       membershipAlertText = alertText

--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -353,7 +353,7 @@ class AccountController(commonActions: CommonActions, override val controllerCom
       email = accountSummary.billToContact.email,
       paymentDetails = upToDatePaymentDetails,
       stripePublicKey = stripeService.publicKey,
-      accountHasMissedRecentPayments = if (freeOrPaidSub.isRight) accountHasMissedPayments(subscription.accountId, accountSummary.invoices, accountSummary.payments) else false,
+      accountHasMissedRecentPayments = freeOrPaidSub.isRight && accountHasMissedPayments(subscription.accountId, accountSummary.invoices, accountSummary.payments),
       safeToUpdatePaymentMethod = safeToAllowPaymentUpdate(subscription.accountId, accountSummary.invoices),
       isAutoRenew = isAutoRenew,
       membershipAlertText = alertText

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -4,7 +4,16 @@ import com.gu.services.model.PaymentDetails
 import json.localDateWrites
 import play.api.libs.json.{Json, _}
 
-case class AccountDetails(regNumber: Option[String], email: Option[String], paymentDetails: PaymentDetails, stripePublicKey: String, isAutoRenew: Boolean, membershipAlertText: Option[String])
+case class AccountDetails(
+  regNumber: Option[String],
+  email: Option[String],
+  paymentDetails: PaymentDetails,
+  stripePublicKey: String,
+  accountHasMissedRecentPayments: Boolean,
+  safeToUpdatePaymentMethod: Boolean,
+  isAutoRenew: Boolean,
+  membershipAlertText: Option[String]
+)
 
 object AccountDetails {
 
@@ -17,12 +26,12 @@ object AccountDetails {
       val endDate = paymentDetails.chargedThroughDate
         .getOrElse(paymentDetails.termEndDate)
 
-      val paymentMethod = paymentDetails.paymentMethod.fold(Json.obj()) {
-        case payPal: PayPalMethod => Json.obj(
+      val paymentMethod = paymentDetails.paymentMethod match {
+        case Some(payPal: PayPalMethod) => Json.obj(
           "paymentMethod" -> "PayPal",
           "payPalEmail" -> payPal.email
         )
-        case card: PaymentCard => Json.obj(
+        case Some(card: PaymentCard) => Json.obj(
           "paymentMethod" -> "Card",
           "card" -> {
             Json.obj(
@@ -33,7 +42,7 @@ object AccountDetails {
             )
           }
         )
-        case dd: GoCardless => Json.obj(
+        case Some(dd: GoCardless) => Json.obj(
           "paymentMethod" -> "DirectDebit",
           "account" -> Json.obj( // DEPRECATED
             "accountName" -> dd.accountName
@@ -44,6 +53,16 @@ object AccountDetails {
             "sortCode" -> dd.sortCode
           )
         )
+        case _ if accountHasMissedRecentPayments && safeToUpdatePaymentMethod => Json.obj(
+          "paymentMethod" -> "ResetRequired",
+          "stripePublicKeyForCardAddition" -> stripePublicKey
+        )
+        case _ => Json.obj()
+      }
+
+      val alertText = membershipAlertText match {
+        case Some(text) => Json.obj("alertText" -> text)
+        case None => Json.obj()
       }
 
       Json.obj(
@@ -55,6 +74,7 @@ object AccountDetails {
           "joinDate" -> paymentDetails.startDate,
           "optIn" -> !paymentDetails.pendingCancellation,
           "subscription" -> (paymentMethod ++ Json.obj(
+            "safeToUpdatePaymentMethod" -> safeToUpdatePaymentMethod,
             "start" -> paymentDetails.lastPaymentDate,
             "end" -> endDate,
             "nextPaymentPrice" -> paymentDetails.nextPaymentPrice,
@@ -72,7 +92,7 @@ object AccountDetails {
               "currencyISO" -> paymentDetails.plan.price.currency.iso,
               "interval" -> paymentDetails.plan.interval.mkString
             )))
-        ) ++ membershipAlertText.fold(Json.obj())({text => Json.obj("alertText" -> text)})
+        ) ++ alertText
 
     }
   }

--- a/membership-attribute-service/app/services/PaymentFailureAlerter.scala
+++ b/membership-attribute-service/app/services/PaymentFailureAlerter.scala
@@ -135,15 +135,14 @@ object PaymentFailureAlerter extends LoggingWithLogstashFields {
     nonZeroInvoicesOlderThanOneMonth.sortBy(_.invoiceDate).take(2)
   }
 
-  def accountHasMissedPayments(accountId: AccountId, isPaidSub: Boolean, recentInvoices: List[Invoice], recentPayments: List[Payment]): Boolean = {
+  def accountHasMissedPayments(accountId: AccountId, recentInvoices: List[Invoice], recentPayments: List[Payment]): Boolean = {
     val paidInvoiceNumbers = recentPayments.filter(_.status == "Processed").flatMap(_.paidInvoices).map(_.invoiceNumber)
     val unpaidPayableInvoiceOlderThanOneMonth = mostRecentPayableInvoicesOlderThanOneMonth(recentInvoices) match {
       case Nil => false
       case invoices => !invoices.forall(invoice => paidInvoiceNumbers.contains(invoice.invoiceNumber))
     }
-    val result = isPaidSub && unpaidPayableInvoiceOlderThanOneMonth
-    SafeLogger.info(s"${accountId.get} | accountHasMissedRecentPayments: ${result}")
-    result
+    SafeLogger.info(s"${accountId.get} | accountHasMissedPayments: ${unpaidPayableInvoiceOlderThanOneMonth}")
+    unpaidPayableInvoiceOlderThanOneMonth
   }
 
   def safeToAllowPaymentUpdate(accountId: AccountId, recentInvoices: List[Invoice]): Boolean = {

--- a/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
+++ b/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
@@ -280,38 +280,33 @@ class PaymentFailureAlerterTest(implicit ee: ExecutionEnv)  extends Specificatio
 
       val accountId = AccountId("id123")
 
-      "return false if the user has a free sub" in {
-        PaymentFailureAlerter.accountHasMissedPayments(accountId, isPaidSub = false, List(), List()) === false
-      }
-
       "return false if the user has 0 amount invoices and no payments (i.e. sub which should be paid but has 100% discount)" in {
-        PaymentFailureAlerter.accountHasMissedPayments(accountId, isPaidSub = true, List(oldFreeInvoice), List()) === false
+        PaymentFailureAlerter.accountHasMissedPayments(accountId, List(oldFreeInvoice), List()) === false
       }
 
       "return false if the user has no payments or invoices for a paid sub (e.g. brand new sub)" in {
-        PaymentFailureAlerter.accountHasMissedPayments(accountId, isPaidSub = true, List(), List()) === false
+        PaymentFailureAlerter.accountHasMissedPayments(accountId, List(), List()) === false
       }
 
       "return false if the user has a single paid invoice" in {
-        PaymentFailureAlerter.accountHasMissedPayments(accountId, isPaidSub = true, List(paidInvoice), List(paymentForPaidInvoice)) === false
+        PaymentFailureAlerter.accountHasMissedPayments(accountId, List(paidInvoice), List(paymentForPaidInvoice)) === false
       }
 
       "return false if the user has a recent unpaid invoice (where invoice is unpaid due to no payment attempts)" in {
-        PaymentFailureAlerter.accountHasMissedPayments(accountId, isPaidSub = true, List(recentUnpaidInvoice), List()) === false
+        PaymentFailureAlerter.accountHasMissedPayments(accountId, List(recentUnpaidInvoice), List()) === false
       }
 
       "return false if the user has a recent unpaid invoice (where invoice is unpaid due to payment failures)" in {
-        PaymentFailureAlerter.accountHasMissedPayments(accountId, isPaidSub = true, List(recentUnpaidInvoice), List(failedPaymentForRecentUnpaidInvoice)) === false
+        PaymentFailureAlerter.accountHasMissedPayments(accountId, List(recentUnpaidInvoice), List(failedPaymentForRecentUnpaidInvoice)) === false
       }
 
       "return true if the user has never paid an invoice, despite having a single invoice which is more than 30 days old" in {
-        PaymentFailureAlerter.accountHasMissedPayments(accountId, isPaidSub = true, List(oldUnpaidInvoice), List()) === true
+        PaymentFailureAlerter.accountHasMissedPayments(accountId, List(oldUnpaidInvoice), List()) === true
       }
 
       "return true if the user has never paid an invoice, despite having two old invoices" in {
         val result = PaymentFailureAlerter.accountHasMissedPayments(
           accountId,
-          isPaidSub = true,
           List(oldUnpaidInvoice, oldUnpaidInvoice.copy(invoiceDate = moreThanTwoMonthsAgo, dueDate = moreThanTwoMonthsAgo)),
           List()
         )
@@ -319,7 +314,7 @@ class PaymentFailureAlerterTest(implicit ee: ExecutionEnv)  extends Specificatio
       }
 
       "return true if the user hasn't paid a recent invoice, even if they have paid in the past" in {
-        PaymentFailureAlerter.accountHasMissedPayments(accountId, isPaidSub = true, List(oldUnpaidInvoice, paidInvoice), List(paymentForPaidInvoice)) === true
+        PaymentFailureAlerter.accountHasMissedPayments(accountId, List(oldUnpaidInvoice, paidInvoice), List(paymentForPaidInvoice)) === true
       }
 
     }

--- a/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
+++ b/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
@@ -2,6 +2,7 @@ package services
 
 import java.util.Locale
 
+import com.gu.memsub.Subscription.AccountId
 import com.gu.zuora.rest.ZuoraRestService.{Invoice, InvoiceId, PaymentMethodId, PaymentMethodResponse}
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.{DateTime, LocalDate}
@@ -9,7 +10,7 @@ import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mutable.Specification
 import testdata.AccountObjectTestData._
 import testdata.AccountSummaryTestData.{accountSummaryWithBalance, accountSummaryWithZeroBalance}
-import testdata.SubscriptionTestData
+import testdata.{InvoiceAndPaymentTestData, SubscriptionTestData}
 
 import scala.concurrent.Future
 import scalaz.\/
@@ -132,8 +133,10 @@ class PaymentFailureAlerterTest(implicit ee: ExecutionEnv)  extends Specificatio
       "return None if there's one invoice and it has no balance" in {
         val freshNoBalanceInvoice = Invoice(
           InvoiceId("someId"),
+          "INV123",
           DateTime.now().minusDays(14),
           DateTime.now().minusDays(7),
+          amount = 12.34,
           balance = 0,
           status = "Posted"
         )
@@ -148,8 +151,10 @@ class PaymentFailureAlerterTest(implicit ee: ExecutionEnv)  extends Specificatio
 
         val freshInvoiceWithABalance = Invoice(
           InvoiceId("someId"),
+          "INV123",
           invoiceDate,
           DateTime.now().minusDays(7),
+          amount = 12.34,
           balance = 12.34,
           status = "Posted"
         )
@@ -164,16 +169,20 @@ class PaymentFailureAlerterTest(implicit ee: ExecutionEnv)  extends Specificatio
 
         val latestInvoiceWithABalance = Invoice(
           InvoiceId("someId"),
+          "INV123",
           invoiceDateLatest,
           DateTime.now().minusDays(7),
+          amount = 12.34,
           balance = 12.34,
           status = "Posted"
         )
 
         val oldInvoiceWithABalance = Invoice(
           InvoiceId("someId2"),
+          "INV123",
           invoiceDateOlder,
           DateTime.now().minusDays(14),
+          amount = 12.34,
           balance = 12.34,
           status = "Posted"
         )
@@ -181,45 +190,151 @@ class PaymentFailureAlerterTest(implicit ee: ExecutionEnv)  extends Specificatio
 
         lastUnpaidInvoiceDate === Some(invoiceDateLatest)
       }
+
+      "return the latest unpaid invoice date if there is a more recent paid invoice too" in {
+        val invoiceDateLatest = DateTime.now().minusDays(14).withTimeAtStartOfDay()
+        val invoiceDateOlder = DateTime.now().minusDays(21).withTimeAtStartOfDay()
+
+        val latestInvoiceWithNoBalance = Invoice(
+          InvoiceId("someId"),
+          "INV123",
+          invoiceDateLatest,
+          DateTime.now().minusDays(7),
+          amount = 11.99,
+          balance = 0,
+          status = "Posted"
+        )
+
+        val oldInvoiceWithABalance = Invoice(
+          InvoiceId("someId2"),
+          "INV123",
+          invoiceDateOlder,
+          DateTime.now().minusDays(14),
+          amount = 12.34,
+          balance = 12.34,
+          status = "Posted"
+        )
+        val lastUnpaidInvoiceDate = PaymentFailureAlerter.latestUnpaidInvoiceDate(invoices = List(latestInvoiceWithNoBalance, oldInvoiceWithABalance))
+
+        lastUnpaidInvoiceDate === Some(invoiceDateOlder)
+      }
+
+      "ignore an invoice that isn't posted" in {
+        val invoiceDate = DateTime.now().minusDays(14).withTimeAtStartOfDay()
+
+        val freshDraftInvoiceWithABalance = Invoice(
+          InvoiceId("someId"),
+          "INV123",
+          invoiceDate,
+          DateTime.now().minusDays(7),
+          amount = 12.34,
+          balance = 12.34,
+          status = "Draft"
+        )
+        val lastUnpaidInvoiceDate = PaymentFailureAlerter.latestUnpaidInvoiceDate(invoices = List(freshDraftInvoiceWithABalance))
+
+        lastUnpaidInvoiceDate === None
+      }
     }
 
-    "return the latest unpaid invoice date if there is a more recent paid invoice too" in {
-      val invoiceDateLatest = DateTime.now().minusDays(14).withTimeAtStartOfDay()
-      val invoiceDateOlder = DateTime.now().minusDays(21).withTimeAtStartOfDay()
+    "mostRecentPayableInvoicesOlderThanOneMonth" should {
 
-      val latestInvoiceWithNoBalance = Invoice(
-        InvoiceId("someId"),
-        invoiceDateLatest,
-        DateTime.now().minusDays(7),
-        balance = 0,
-        status = "Posted"
-      )
+      import InvoiceAndPaymentTestData._
 
-      val oldInvoiceWithABalance = Invoice(
-        InvoiceId("someId2"),
-        invoiceDateOlder,
-        DateTime.now().minusDays(14),
-        balance = 12.34,
-        status = "Posted"
-      )
-      val lastUnpaidInvoiceDate = PaymentFailureAlerter.latestUnpaidInvoiceDate(invoices = List(latestInvoiceWithNoBalance, oldInvoiceWithABalance))
+      "return an empty list if the user's invoices all have amount = 0" in {
+        val result = PaymentFailureAlerter.mostRecentPayableInvoicesOlderThanOneMonth(
+          List(
+            oldFreeInvoice,
+            oldFreeInvoice.copy(invoiceDate = moreThanTwoMonthsAgo, dueDate = moreThanTwoMonthsAgo),
+            oldFreeInvoice.copy(invoiceDate = moreThanThreeMonthsAgo, dueDate = moreThanThreeMonthsAgo)
+          )
+        )
+        result === Nil
+      }
 
-      lastUnpaidInvoiceDate === Some(invoiceDateOlder)
+      "return an empty list if the user only has a new invoice" in {
+        val result = PaymentFailureAlerter.mostRecentPayableInvoicesOlderThanOneMonth(List(recentUnpaidInvoice))
+        result === Nil
+      }
+
+      "return the most recent two invoices older than one month if they are present" in {
+
+        val twoMonthOldInvoice = oldUnpaidInvoice.copy(invoiceDate = moreThanTwoMonthsAgo, dueDate = moreThanTwoMonthsAgo)
+        val threeMonthOldInvoice = oldUnpaidInvoice.copy(invoiceDate = moreThanThreeMonthsAgo, dueDate = moreThanThreeMonthsAgo)
+
+        val result = PaymentFailureAlerter.mostRecentPayableInvoicesOlderThanOneMonth(
+          List(
+            oldUnpaidInvoice,
+            twoMonthOldInvoice,
+            threeMonthOldInvoice
+          )
+        )
+        result === List(oldUnpaidInvoice, twoMonthOldInvoice)
+      }
+
     }
 
-    "ignore an invoice that isn't posted" in {
-      val invoiceDate = DateTime.now().minusDays(14).withTimeAtStartOfDay()
+    "accountHasMissedRecentPayments" should {
 
-      val freshDraftInvoiceWithABalance = Invoice(
-        InvoiceId("someId"),
-        invoiceDate,
-        DateTime.now().minusDays(7),
-        balance = 12.34,
-        status = "Draft"
-      )
-      val lastUnpaidInvoiceDate = PaymentFailureAlerter.latestUnpaidInvoiceDate(invoices = List(freshDraftInvoiceWithABalance))
+      import InvoiceAndPaymentTestData._
 
-      lastUnpaidInvoiceDate === None
+      val accountId = AccountId("id123")
+
+      "return false if the user has a free sub" in {
+        PaymentFailureAlerter.accountHasMissedRecentPayments(accountId, isPaidSub = false, List(), List()) === false
+      }
+
+      "return false if the user has 0 amount invoices and no payments (i.e. sub which should be paid but has 100% discount)" in {
+        PaymentFailureAlerter.accountHasMissedRecentPayments(accountId, isPaidSub = true, List(oldFreeInvoice), List()) === false
+      }
+
+      "return false if the user has no payments or invoices for a paid sub (e.g. brand new sub)" in {
+        PaymentFailureAlerter.accountHasMissedRecentPayments(accountId, isPaidSub = true, List(), List()) === false
+      }
+
+      "return false if the user has a single paid invoice" in {
+        PaymentFailureAlerter.accountHasMissedRecentPayments(accountId, isPaidSub = true, List(paidInvoice), List(paymentForPaidInvoice)) === false
+      }
+
+      "return false if the user has a recent unpaid invoice" in {
+        PaymentFailureAlerter.accountHasMissedRecentPayments(accountId, isPaidSub = true, List(recentUnpaidInvoice), List()) === false
+        PaymentFailureAlerter.accountHasMissedRecentPayments(accountId, isPaidSub = true, List(recentUnpaidInvoice), List(failedPaymentForRecentUnpaidInvoice)) === false
+      }
+
+      "return true if the user has never paid an invoice, despite having a single invoice which is more than 30 days old" in {
+        PaymentFailureAlerter.accountHasMissedRecentPayments(accountId, isPaidSub = true, List(oldUnpaidInvoice), List()) === true
+      }
+
+      "return true if the user has never paid an invoice, despite having two old invoices" in {
+        val result = PaymentFailureAlerter.accountHasMissedRecentPayments(
+          accountId,
+          isPaidSub = true,
+          List(oldUnpaidInvoice, oldUnpaidInvoice.copy(invoiceDate = moreThanTwoMonthsAgo, dueDate = moreThanTwoMonthsAgo)),
+          List()
+        )
+        result === true
+      }
+
+      "return true if the user hasn't paid a recent invoice, even if they have paid in the past" in {
+        PaymentFailureAlerter.accountHasMissedRecentPayments(accountId, isPaidSub = true, List(oldUnpaidInvoice, paidInvoice), List(paymentForPaidInvoice)) === true
+      }
+
     }
+
+  "safeToAllowPaymentUpdate" should {
+
+    import InvoiceAndPaymentTestData._
+
+    val accountId = AccountId("id123")
+
+    "return false if the user has an outstanding balance from an invoice older than 31 days" in {
+      PaymentFailureAlerter.safeToAllowPaymentUpdate(accountId, List(oldUnpaidInvoice)) === false
+    }
+
+    "return true if the user has failed to pay for an invoice within the last month (normal payment failure scenario)" in {
+      PaymentFailureAlerter.safeToAllowPaymentUpdate(accountId, List(recentUnpaidInvoice)) === true
+    }
+  }
+
   }
 }

--- a/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
+++ b/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
@@ -274,39 +274,42 @@ class PaymentFailureAlerterTest(implicit ee: ExecutionEnv)  extends Specificatio
 
     }
 
-    "accountHasMissedRecentPayments" should {
+    "accountHasMissedPayments" should {
 
       import InvoiceAndPaymentTestData._
 
       val accountId = AccountId("id123")
 
       "return false if the user has a free sub" in {
-        PaymentFailureAlerter.accountHasMissedRecentPayments(accountId, isPaidSub = false, List(), List()) === false
+        PaymentFailureAlerter.accountHasMissedPayments(accountId, isPaidSub = false, List(), List()) === false
       }
 
       "return false if the user has 0 amount invoices and no payments (i.e. sub which should be paid but has 100% discount)" in {
-        PaymentFailureAlerter.accountHasMissedRecentPayments(accountId, isPaidSub = true, List(oldFreeInvoice), List()) === false
+        PaymentFailureAlerter.accountHasMissedPayments(accountId, isPaidSub = true, List(oldFreeInvoice), List()) === false
       }
 
       "return false if the user has no payments or invoices for a paid sub (e.g. brand new sub)" in {
-        PaymentFailureAlerter.accountHasMissedRecentPayments(accountId, isPaidSub = true, List(), List()) === false
+        PaymentFailureAlerter.accountHasMissedPayments(accountId, isPaidSub = true, List(), List()) === false
       }
 
       "return false if the user has a single paid invoice" in {
-        PaymentFailureAlerter.accountHasMissedRecentPayments(accountId, isPaidSub = true, List(paidInvoice), List(paymentForPaidInvoice)) === false
+        PaymentFailureAlerter.accountHasMissedPayments(accountId, isPaidSub = true, List(paidInvoice), List(paymentForPaidInvoice)) === false
       }
 
-      "return false if the user has a recent unpaid invoice" in {
-        PaymentFailureAlerter.accountHasMissedRecentPayments(accountId, isPaidSub = true, List(recentUnpaidInvoice), List()) === false
-        PaymentFailureAlerter.accountHasMissedRecentPayments(accountId, isPaidSub = true, List(recentUnpaidInvoice), List(failedPaymentForRecentUnpaidInvoice)) === false
+      "return false if the user has a recent unpaid invoice (where invoice is unpaid due to no payment attempts)" in {
+        PaymentFailureAlerter.accountHasMissedPayments(accountId, isPaidSub = true, List(recentUnpaidInvoice), List()) === false
+      }
+
+      "return false if the user has a recent unpaid invoice (where invoice is unpaid due to payment failures)" in {
+        PaymentFailureAlerter.accountHasMissedPayments(accountId, isPaidSub = true, List(recentUnpaidInvoice), List(failedPaymentForRecentUnpaidInvoice)) === false
       }
 
       "return true if the user has never paid an invoice, despite having a single invoice which is more than 30 days old" in {
-        PaymentFailureAlerter.accountHasMissedRecentPayments(accountId, isPaidSub = true, List(oldUnpaidInvoice), List()) === true
+        PaymentFailureAlerter.accountHasMissedPayments(accountId, isPaidSub = true, List(oldUnpaidInvoice), List()) === true
       }
 
       "return true if the user has never paid an invoice, despite having two old invoices" in {
-        val result = PaymentFailureAlerter.accountHasMissedRecentPayments(
+        val result = PaymentFailureAlerter.accountHasMissedPayments(
           accountId,
           isPaidSub = true,
           List(oldUnpaidInvoice, oldUnpaidInvoice.copy(invoiceDate = moreThanTwoMonthsAgo, dueDate = moreThanTwoMonthsAgo)),
@@ -316,7 +319,7 @@ class PaymentFailureAlerterTest(implicit ee: ExecutionEnv)  extends Specificatio
       }
 
       "return true if the user hasn't paid a recent invoice, even if they have paid in the past" in {
-        PaymentFailureAlerter.accountHasMissedRecentPayments(accountId, isPaidSub = true, List(oldUnpaidInvoice, paidInvoice), List(paymentForPaidInvoice)) === true
+        PaymentFailureAlerter.accountHasMissedPayments(accountId, isPaidSub = true, List(oldUnpaidInvoice, paidInvoice), List(paymentForPaidInvoice)) === true
       }
 
     }

--- a/membership-attribute-service/test/testdata/AccountObjectTestData.scala
+++ b/membership-attribute-service/test/testdata/AccountObjectTestData.scala
@@ -42,11 +42,14 @@ object AccountSummaryTestData {
       ),
       invoices = List(Invoice(
         id = InvoiceId("someid"),
+        invoiceNumber = "INV123",
         invoiceDate = DateTime.now().minusDays(14),
         dueDate = DateTime.now().minusDays(7),
+        amount = 11.99,
         balance = balance,
         status = "Posted"
       )),
+      payments = List(),
       currency = None,
       balance = balance,
       defaultPaymentMethod = Some(DefaultPaymentMethod(paymentMethodId)),
@@ -55,4 +58,56 @@ object AccountSummaryTestData {
 
   val accountSummaryWithBalance = accountSummaryWith(20.0, testPaymentMethodId, testAccountId)
   val accountSummaryWithZeroBalance = accountSummaryWith(0, testPaymentMethodId, testAccountId)
+}
+
+object InvoiceAndPaymentTestData {
+
+  val lessThanAWeekAgo = DateTime.now().minusDays(5)
+  val moreThanAMonthAgo = DateTime.now().minusDays(32)
+  val moreThanTwoMonthsAgo = DateTime.now().minusDays(62)
+  val moreThanThreeMonthsAgo = DateTime.now().minusDays(92)
+
+  val oldFreeInvoice = Invoice(
+    id = InvoiceId("123"),
+    invoiceNumber = "INV123",
+    invoiceDate = DateTime.now().minusDays(32),
+    dueDate = DateTime.now().minusDays(32),
+    amount = 0,
+    balance = 0,
+    status = "Posted"
+  )
+
+  val oldUnpaidInvoice = Invoice(
+    id = InvoiceId("123"),
+    invoiceNumber = "INV123",
+    invoiceDate = moreThanAMonthAgo,
+    dueDate = moreThanAMonthAgo,
+    amount = 11.99,
+    balance = 11.99,
+    status = "Posted"
+  )
+
+  val recentUnpaidInvoice = Invoice(
+    id = InvoiceId("123"),
+    invoiceNumber = "INV124",
+    invoiceDate = lessThanAWeekAgo,
+    dueDate = lessThanAWeekAgo,
+    amount = 11.99,
+    balance = 11.99,
+    status = "Posted"
+  )
+
+  val paidInvoice = Invoice(
+    id = InvoiceId("123"),
+    invoiceNumber = "INV111",
+    invoiceDate = moreThanAMonthAgo,
+    dueDate = moreThanAMonthAgo,
+    amount = 11.99,
+    balance = 0,
+    status = "Posted"
+  )
+
+  val failedPaymentForRecentUnpaidInvoice = Payment(status = "Failure", paidInvoices = List(PaidInvoice("INV111", 11.99)))
+  val paymentForPaidInvoice = Payment(status = "Processed", paidInvoices = List(PaidInvoice("INV111", 11.99)))
+
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.529"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.533"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.9"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.2"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"


### PR DESCRIPTION
### Why do we need this?

_Note: This will not pass CI until https://github.com/guardian/membership-common/pull/589 is merged._

When a payment method is not correctly linked to a Zuora account _and_ the prerequisites for auto-cancellation are not met, it's possible for users to build up 'debts' whilst continuing to receive their subscription benefits. Currently many users in this bad state are unable to add a new payment method to fix the situation (which means that we cannot recover them easily). For other users, it _is_ possible to add a new payment method, but if they choose to do so this will inadvertently cause the payment for several invoices to be collected at once.

This PR adds a boolean to the (new) MMA responses, so that clients know if its unsafe to process a payment method update.

If a user doesn't have a correctly linked payment method (and it's safe to collect one), the response has also been updated to advise clients that a new payment method should be collected (and an appropriate Stripe key is included to allow them to do so).

### The changes
* Inform clients whether or not it is 'safe' for a payment method to be updated
* Inform clients that the user's payment method should be 'reset' if it is necessary and safe to do so
* Add unit tests
* Update existing code due to a change in the model (see related membership-common PR)

### trello card/screenshot/json/related PRs etc
