### PR TITLE
expose new `currentPlans` and `futurePlans` arrays in the response of the detailed endpoint(s)

### DIFF
--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -182,7 +182,7 @@ class AccountController(commonActions: CommonActions, override val controllerCom
     } yield AccountDetails(
       regNumber = contact.regNumber,
       email = accountSummary.billToContact.email,
-      plans = sub.plans,
+      subscription = sub,
       paymentDetails = upToDatePaymentDetails,
       stripePublicKey = stripeService.publicKey,
       accountHasMissedRecentPayments = false,
@@ -256,7 +256,7 @@ class AccountController(commonActions: CommonActions, override val controllerCom
     } yield AccountDetails(
       regNumber = None,
       email = accountSummary.billToContact.email,
-      plans = subscription.plans,
+      subscription = subscription,
       paymentDetails = upToDatePaymentDetails,
       stripePublicKey = stripeService.publicKey,
       accountHasMissedRecentPayments = freeOrPaidSub.isRight && accountHasMissedPayments(subscription.accountId, accountSummary.invoices, accountSummary.payments),

--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -180,14 +180,15 @@ class AccountController(commonActions: CommonActions, override val controllerCom
       alertText <- OptionEither.liftEitherOption(alertText(accountSummary, sub, getPaymentMethod))
       isAutoRenew = sub.autoRenew
     } yield AccountDetails(
-      contact.regNumber,
-      accountSummary.billToContact.email,
-      upToDatePaymentDetails,
-      stripeService.publicKey,
+      regNumber = contact.regNumber,
+      email = accountSummary.billToContact.email,
+      plans = sub.plans,
+      paymentDetails = upToDatePaymentDetails,
+      stripePublicKey = stripeService.publicKey,
       accountHasMissedRecentPayments = false,
       safeToUpdatePaymentMethod = true,
       isAutoRenew = isAutoRenew,
-      alertText
+      alertText = alertText
     ).toJson).run.run.map {
       case \/-(Some(result)) =>
         logger.info(s"Successfully retrieved payment details result for identity user: ${maybeUserId.mkString}")
@@ -255,12 +256,13 @@ class AccountController(commonActions: CommonActions, override val controllerCom
     } yield AccountDetails(
       regNumber = None,
       email = accountSummary.billToContact.email,
+      plans = subscription.plans,
       paymentDetails = upToDatePaymentDetails,
       stripePublicKey = stripeService.publicKey,
       accountHasMissedRecentPayments = freeOrPaidSub.isRight && accountHasMissedPayments(subscription.accountId, accountSummary.invoices, accountSummary.payments),
       safeToUpdatePaymentMethod = safeToAllowPaymentUpdate(subscription.accountId, accountSummary.invoices),
       isAutoRenew = isAutoRenew,
-      membershipAlertText = alertText
+      alertText = alertText
     ).toJson).run.run.map {
       case \/-(subscriptionJSONs) =>
         logger.info(s"Successfully retrieved payment details result for identity user: ${maybeUserId.mkString}")

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -69,8 +69,6 @@ object AccountDetails {
       })
 
       def jsonifyPlan(plan: SubscriptionPlan.AnyPlan) = Json.obj(
-        "productRatePlanId" -> plan.productRatePlanId.get, // consider exposing hash of this to avoid exposing internal IDs
-        "productName" -> plan.productName,
         "name" -> plan.name,
         "start" -> plan.start,
         // if the customer acceptance date is future dated (e.g. 6for6) then always display, otherwise only show if starting less than 30 days from today

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -1,6 +1,6 @@
 package models
 import com.gu.memsub.subsv2.{Subscription, SubscriptionPlan}
-import com.gu.memsub.{GoCardless, PayPalMethod, PaymentCard}
+import com.gu.memsub.{GoCardless, PayPalMethod, PaymentCard, Product}
 import com.gu.services.model.PaymentDetails
 import json.localDateWrites
 import play.api.libs.json.{Json, _}
@@ -68,8 +68,14 @@ object AccountDetails {
         case _ => true
       })
 
+      def externalisePlanName(plan: SubscriptionPlan.AnyPlan): Option[String] = plan.product match {
+        case _: Product.Weekly => if(plan.name.contains("Six for Six")) Some("currently on '6 for 6'") else None
+        case _: Product.Paper => Some(plan.name.replace("+",  " plus Digital Pack"))
+        case _ => None
+      }
+
       def jsonifyPlan(plan: SubscriptionPlan.AnyPlan) = Json.obj(
-        "name" -> plan.name,
+        "name" -> externalisePlanName(plan),
         "start" -> plan.start,
         // if the customer acceptance date is future dated (e.g. 6for6) then always display, otherwise only show if starting less than 30 days from today
         "shouldBeVisible" -> (subscription.acceptanceDate.isAfter(now) || plan.start.isBefore(now.plusDays(30)))

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -74,7 +74,7 @@ object AccountDetails {
         "name" -> plan.name,
         "start" -> plan.start,
         // if the customer acceptance date is future dated (e.g. 6for6) then always display, otherwise only show if starting less than 30 days from today
-        "startsBeforeXDaysFromToday" -> (subscription.acceptanceDate.isAfter(now) || plan.start.isBefore(now.plusDays(30)))
+        "shouldBeVisible" -> (subscription.acceptanceDate.isAfter(now) || plan.start.isBefore(now.plusDays(30)))
       ) ++ (plan match {
         case paidPlan: SubscriptionPlan.Paid => Json.obj(
           "end" -> paidPlan.end,

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -1,18 +1,21 @@
 package models
+import com.gu.memsub.subsv2.{CovariantNonEmptyList, SubscriptionPlan}
 import com.gu.memsub.{GoCardless, PayPalMethod, PaymentCard}
 import com.gu.services.model.PaymentDetails
 import json.localDateWrites
 import play.api.libs.json.{Json, _}
+import org.joda.time.LocalDate.now
 
 case class AccountDetails(
   regNumber: Option[String],
   email: Option[String],
+  plans : CovariantNonEmptyList[SubscriptionPlan.AnyPlan],
   paymentDetails: PaymentDetails,
   stripePublicKey: String,
   accountHasMissedRecentPayments: Boolean,
   safeToUpdatePaymentMethod: Boolean,
   isAutoRenew: Boolean,
-  membershipAlertText: Option[String]
+  alertText: Option[String]
 )
 
 object AccountDetails {
@@ -60,16 +63,29 @@ object AccountDetails {
         case _ => Json.obj()
       }
 
-      val alertText = membershipAlertText match {
-        case Some(text) => Json.obj("alertText" -> text)
-        case None => Json.obj()
-      }
+      def jsonifyPlan(plan: SubscriptionPlan.AnyPlan) = Json.obj(
+        "productRatePlanId" -> plan.productRatePlanId.get, // consider exposing hash of this to avoid exposing internal IDs
+        "productName" -> plan.productName,
+        "name" -> plan.name,
+        "start" -> plan.start,
+        "startsBeforeXDaysFromToday" -> plan.start.isBefore(now.plusDays(30))
+      ) ++ (plan match {
+        case paidPlan: SubscriptionPlan.Paid => Json.obj(
+          "end" -> paidPlan.end,
+          "chargedThrough" -> paidPlan.chargedThrough,
+          "amount" -> paidPlan.charges.price.prices.head.amount * 100,
+          "currency" -> paidPlan.charges.price.prices.head.currency.glyph,
+          "currencyISO" -> paidPlan.charges.price.prices.head.currency.iso,
+          "interval" -> paidPlan.charges.billingPeriod.noun
+        )
+        case _ => Json.obj()
+      })
 
       Json.obj(
         "tier" -> paymentDetails.plan.name,
         "isPaidTier" -> (paymentDetails.plan.price.amount > 0f)
       ) ++
-        regNumber.fold(Json.obj())({reg => Json.obj("regNumber" -> reg)}) ++
+        regNumber.fold(Json.obj())({ reg => Json.obj("regNumber" -> reg) }) ++
         Json.obj(
           "joinDate" -> paymentDetails.startDate,
           "optIn" -> !paymentDetails.pendingCancellation,
@@ -82,18 +98,21 @@ object AccountDetails {
             "lastPaymentDate" -> paymentDetails.lastPaymentDate,
             "renewalDate" -> paymentDetails.termEndDate,
             "cancelledAt" -> (paymentDetails.pendingAmendment || paymentDetails.pendingCancellation),
-            "subscriberId" -> paymentDetails.subscriberId, // TODO remove once nothing is using this key (same time as removing old deprecated endpoints
+            "subscriberId" -> paymentDetails.subscriberId, // TODO remove once nothing is using this key (same time as removing old deprecated endpoints)
             "subscriptionId" -> paymentDetails.subscriberId,
             "trialLength" -> paymentDetails.remainingTrialLength,
             "autoRenew" -> isAutoRenew,
-            "plan" -> Json.obj(
+            "plan" -> Json.obj( // TODO remove once nothing is using this key (same time as removing old deprecated endpoints)
               "name" -> paymentDetails.plan.name,
               "amount" -> paymentDetails.plan.price.amount * 100,
               "currency" -> paymentDetails.plan.price.currency.glyph,
               "currencyISO" -> paymentDetails.plan.price.currency.iso,
               "interval" -> paymentDetails.plan.interval.mkString
-            )))
-        ) ++ alertText
+            ),
+            "currentPlans" -> plans.list.filter(p => p.start == now || p.start.isBefore(now)).sortBy(_.start.toDate).map(jsonifyPlan),
+            "futurePlans" -> plans.list.filter(_.start.isAfter(now)).sortBy(_.start.toDate).map(jsonifyPlan)
+          )),
+        ) ++ alertText.map(text => Json.obj("alertText" -> text)).getOrElse(Json.obj())
 
     }
   }


### PR DESCRIPTION
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
Currently `members-data-api` doesn't expose enough information about plans to correctly show price rise information nor which type of physical subscription people have - so this needs to be exposed for the likes of `manage-frontend` to display things correctly (see https://github.com/guardian/manage-frontend/pull/196).

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
Expose new `currentPlans` and `futurePlans` arrays in the response of the detailed endpoint(s)...

- `currentPlans` is all the plans which `start` today or in the past and end after today (where applicable)
- `futurePlans` is all the plans which `start` after today

... each is an array of objects representing the plans, including notable fields like...

- `name` which is only present if provides extra information, for example the delivery day(s), if a +Digipack or if '6 for 6' Guardian Weekly
 _NOTE this is different from the `name` field on the old `plan` entry which should've been labelled `productName` (but is redundant anyway)_
- `shouldBeVisible`- which is `true` if the acceptanceDate is in the future (e.g. like with 6for6 Guardian Weekly), else it is `true` if the rate plan starts in the next 30 days (just like https://github.com/guardian/subscriptions-frontend/pull/1246) - this field is then used to determine whether to display the price rise in `manage-frontend` (see https://github.com/guardian/manage-frontend/pull/196)

### trello card/screenshot/json/related PRs etc
https://trello.com/c/nBLEUyKI
![image](https://user-images.githubusercontent.com/19289579/53433949-71282700-39ed-11e9-8e61-4b4ff3ad0fab.png)
![image](https://user-images.githubusercontent.com/19289579/53434394-691cb700-39ee-11e9-8f6e-49d372f82077.png)

####  Examples of where `name` is not null...
![image](https://user-images.githubusercontent.com/19289579/53435161-1643ff00-39f0-11e9-9985-7da41a42f1dc.png)
![image](https://user-images.githubusercontent.com/19289579/53435182-222fc100-39f0-11e9-91a2-d37a061612eb.png)
![image](https://user-images.githubusercontent.com/19289579/53435202-307ddd00-39f0-11e9-8982-0990dbb0adca.png)

