### PR TITLE
Remove unused routes and split payment update into its own controller

### DIFF
--- a/membership-attribute-service/app/controllers/PaymentUpdateController.scala
+++ b/membership-attribute-service/app/controllers/PaymentUpdateController.scala
@@ -1,0 +1,129 @@
+package controllers
+
+import actions.CommonActions
+import com.gu.memsub
+import com.gu.memsub.subsv2.SubscriptionPlan
+import com.gu.memsub.{CardUpdateFailure, CardUpdateSuccess, GoCardless, PaymentMethod}
+import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.SafeLogger._
+import com.gu.zuora.soap.models.Commands.{BankTransfer, CreatePaymentMethod}
+import json.PaymentCardUpdateResultWriters._
+import play.api.data.Form
+import play.api.data.Forms._
+import play.api.libs.json.Json
+import play.api.mvc.{BaseController, ControllerComponents}
+import services.{AuthenticationService, IdentityAuthService}
+import scala.concurrent.{ExecutionContext, Future}
+import scalaz.{-\/, EitherT, \/-}
+import scalaz.std.scalaFuture._
+import scalaz.syntax.std.option._
+
+class PaymentUpdateController(commonActions: CommonActions, override val controllerComponents: ControllerComponents) extends BaseController {
+  import commonActions._
+  import AccountHelpers._
+  implicit val executionContext: ExecutionContext= controllerComponents.executionContext
+  lazy val authenticationService: AuthenticationService = IdentityAuthService
+
+  def updateCard(subscriptionName: String) = BackendFromCookieAction.async { implicit request =>
+    // TODO - refactor to use the Zuora-only based lookup, like in AttributeController.pickAttributes - https://trello.com/c/RlESb8jG
+    val updateForm = Form { tuple("stripeToken" -> nonEmptyText, "publicKey" -> text) }
+    val tp = request.touchpoint
+    val maybeUserId = authenticationService.userId
+    SafeLogger.info(s"Attempting to update card for $maybeUserId")
+    (for {
+      user <- EitherT(Future.successful(maybeUserId \/> "no identity cookie for user"))
+      stripeDetails <- EitherT(Future.successful(updateForm.bindFromRequest().value \/> "no card token and public key submitted with request"))
+      (stripeCardToken, stripePublicKey) = stripeDetails
+      sfUser <- EitherT(tp.contactRepo.get(user).map(_.flatMap(_ \/> s"no SF user $user")))
+      subscription <- EitherT(tp.subService.current[SubscriptionPlan.AnyPlan](sfUser).map(subscriptionSelector(Some(memsub.Subscription.Name(subscriptionName)), s"the sfUser $sfUser")))
+      stripeService <- EitherT(Future.successful(tp.stripeServicesByPublicKey.get(stripePublicKey)).map(_ \/> s"No Stripe service for public key: $stripePublicKey"))
+      updateResult <- EitherT(tp.paymentService.setPaymentCardWithStripeToken(subscription.accountId, stripeCardToken, stripeService).map(_ \/> "something was missing when attempting to update payment card in Zuora"))
+    } yield updateResult match {
+      case success: CardUpdateSuccess => {
+        SafeLogger.info(s"Successfully updated card for identity user: $user")
+        Ok(Json.toJson(success))
+      }
+      case failure: CardUpdateFailure => {
+        SafeLogger.error(scrub"Failed to update card for identity user: $user due to $failure")
+        Forbidden(Json.toJson(failure))
+      }
+    }).run.map {
+      case -\/(message) =>
+        SafeLogger.warn(s"Failed to update card for user $maybeUserId, due to $message")
+        InternalServerError(s"Failed to update card for user $maybeUserId")
+      case \/-(result) => result
+    }
+  }
+
+  def updateDirectDebit(subscriptionName: String) = BackendFromCookieAction.async { implicit request =>
+    // TODO - refactor to use the Zuora-only based lookup, like in AttributeController.pickAttributes - https://trello.com/c/RlESb8jG
+
+    def checkDirectDebitUpdateResult(
+      maybeUserId: Option[String],
+      freshDefaultPaymentMethodOption: Option[PaymentMethod],
+      bankAccountName: String,
+      bankAccountNumber: String,
+      bankSortCode: String
+    ) = freshDefaultPaymentMethodOption match {
+      case Some(dd: GoCardless)
+        if bankAccountName == dd.accountName &&
+          dd.accountNumber.length>3 && bankAccountNumber.endsWith(dd.accountNumber.substring(dd.accountNumber.length - 3)) &&
+          bankSortCode == dd.sortCode =>
+        SafeLogger.info(s"Successfully updated direct debit for identity user: $maybeUserId")
+        Ok(Json.obj(
+          "accountName" -> dd.accountName,
+          "accountNumber" -> dd.accountNumber,
+          "sortCode" -> dd.sortCode
+        ))
+      case Some(_) =>
+        SafeLogger.error(scrub"New payment method for user $maybeUserId, does not match the posted Direct Debit details")
+        InternalServerError("")
+      case None =>
+        SafeLogger.error(scrub"default-payment-method-lost: Default payment method for user $maybeUserId, was set to nothing, when attempting to update Direct Debit details")
+        InternalServerError("")
+    }
+
+    val updateForm = Form { tuple(
+      "accountName" -> nonEmptyText,
+      "accountNumber" -> nonEmptyText,
+      "sortCode" -> nonEmptyText
+    ) }
+
+    val tp = request.touchpoint
+    val maybeUserId = authenticationService.userId
+    SafeLogger.info(s"Attempting to update direct debit for $maybeUserId")
+    (for {
+      user <- EitherT(Future.successful(maybeUserId \/> "no identity cookie for user"))
+      directDebitDetails <- EitherT(Future.successful(updateForm.bindFromRequest().value \/> "no direct debit details submitted with request"))
+      (bankAccountName, bankAccountNumber, bankSortCode) = directDebitDetails
+      sfUser <- EitherT(tp.contactRepo.get(user).map(_.flatMap(_ \/> s"no SF user $user")))
+      subscription <- EitherT(tp.subService.current[SubscriptionPlan.AnyPlan](sfUser).map(subscriptionSelector(Some(memsub.Subscription.Name(subscriptionName)), s"the sfUser $sfUser")))
+      account <- EitherT(annotateFailableFuture(tp.zuoraService.getAccount(subscription.accountId), s"get account with id ${subscription.accountId}"))
+      billToContact <- EitherT(annotateFailableFuture(tp.zuoraService.getContact(account.billToId), s"get billTo contact with id ${account.billToId}"))
+      bankTransferPaymentMethod = BankTransfer(
+        accountHolderName = bankAccountName,
+        accountNumber = bankAccountNumber,
+        sortCode = bankSortCode,
+        firstName = billToContact.firstName,
+        lastName = billToContact.lastName,
+        countryCode = "GB"
+      )
+      createPaymentMethod = CreatePaymentMethod(
+        accountId = subscription.accountId,
+        paymentMethod = bankTransferPaymentMethod,
+        paymentGateway = account.paymentGateway.get, // this will need to change to use this endpoint for 'payment method' SWITCH
+        billtoContact = billToContact,
+        invoiceTemplateOverride = None
+      )
+      _ <- EitherT(annotateFailableFuture(tp.zuoraService.createPaymentMethod(createPaymentMethod), "create direct debit payment method"))
+      freshDefaultPaymentMethodOption <- EitherT(annotateFailableFuture(tp.paymentService.getPaymentMethod(subscription.accountId), "get fresh default payment method"))
+    } yield checkDirectDebitUpdateResult(maybeUserId, freshDefaultPaymentMethodOption, bankAccountName, bankAccountNumber, bankSortCode)).run.map {
+      case -\/(message) =>
+        SafeLogger.warn(s"default-payment-method-lost: failed to update direct debit for user $maybeUserId, due to $message")
+        InternalServerError("")
+      case \/-(result) => result
+    }
+
+  }
+
+}

--- a/membership-attribute-service/app/wiring/AppLoader.scala
+++ b/membership-attribute-service/app/wiring/AppLoader.scala
@@ -42,7 +42,8 @@ class MyComponents(context: Context)
     httpErrorHandler,
     new HealthCheckController(touchPointBackends, controllerComponents),
     new AttributeController(attributesFromZuora, commonActions, controllerComponents),
-    new AccountController(commonActions, controllerComponents)
+    new AccountController(commonActions, controllerComponents),
+    new PaymentUpdateController(commonActions, controllerComponents)
   )
 
   val postPaths: List[String] = router.documentation.collect { case ("POST", path, _) => path }

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -7,12 +7,10 @@ GET         /user-attributes/me/mma/:subscriptionName                           
 
 POST        /user-attributes/me/cancel/:subscriptionName                        controllers.AccountController.cancelSpecificSub(subscriptionName: String)
 
-POST        /user-attributes/me/update-card/:subscriptionName                   controllers.AccountController.updateCardOnSpecificSub(subscriptionName: String)
-
-POST        /user-attributes/me/update-direct-debit/:subscriptionName           controllers.AccountController.updateDirectDebitOnSpecificSub(subscriptionName: String)
-
 POST        /user-attributes/me/contribution-update-amount/:subscriptionName    controllers.AccountController.updateAmountForSpecificContribution(subscriptionName: String)
 
+POST        /user-attributes/me/update-card/:subscriptionName                   controllers.PaymentUpdateController.updateCard(subscriptionName: String)
+POST        /user-attributes/me/update-direct-debit/:subscriptionName           controllers.PaymentUpdateController.updateDirectDebit(subscriptionName: String)
 
 # OLD ENDPOINTS below will be phased out as traffic moves over to the new endpoints above
 GET         /user-attributes/me/membership                              controllers.AttributeController.membership
@@ -22,14 +20,6 @@ GET         /user-attributes/me/mma-digitalpack                         controll
 GET         /user-attributes/me/mma-membership                          controllers.AccountController.membershipDetails
 GET         /user-attributes/me/mma-monthlycontribution                 controllers.AccountController.monthlyContributionDetails
 GET         /user-attributes/me/mma-paper                               controllers.AccountController.paperDetails
-
-POST        /user-attributes/me/membership-update-card                  controllers.AccountController.membershipUpdateCard
-POST        /user-attributes/me/digitalpack-update-card                 controllers.AccountController.digitalPackUpdateCard
-POST        /user-attributes/me/paper-update-card                       controllers.AccountController.paperUpdateCard
-POST        /user-attributes/me/contribution-update-card                controllers.AccountController.contributionUpdateCard
-
-POST        /user-attributes/me/contribution-update-direct-debit        controllers.AccountController.contributionUpdateDirectDebit
-POST        /user-attributes/me/paper-update-direct-debit               controllers.AccountController.paperUpdateDirectDebit
 
 POST        /user-attributes/me/cancel-regular-contribution             controllers.AccountController.cancelRegularContribution
 POST        /user-attributes/me/cancel-membership                       controllers.AccountController.cancelMembership


### PR DESCRIPTION
### Why do we need this? 
This PR removes some unused endpoints in order to declutter the project. I've also split the payment method update functions out into their own controller, because AccountController had become too large/unwieldy.

### The changes
* Delete product specific versions of the update card / update direct debit endpoints
* Move generic update card / update direct debit endpoints into their own controller
* Use SafeLogger throughout new controller to prevent data from leaking to Sentry

### Fastly logs show no requests in the past 2 weeks for:
- [x] /user-attributes/me/membership-update-card
- [x] /user-attributes/me/digitalpack-update-card  
- [x] /user-attributes/me/paper-update-card  
- [x] /user-attributes/me/contribution-update-card 
- [x] /user-attributes/me/contribution-update-direct-debit   
- [x] /user-attributes/me/paper-update-direct-debit  

I've also tested credit card update and direct debit update.