### PR TITLE
Remove unused routes

### DIFF
--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -299,8 +299,6 @@ class AccountController(commonActions: CommonActions, override val controllerCom
     }
   }
 
-  @Deprecated def cancelRegularContribution = cancelSubscription[SubscriptionPlan.Contributor](None)
-  @Deprecated def cancelMembership = cancelSubscription[SubscriptionPlan.Member](None)
   def cancelSpecificSub(subscriptionName: String) = cancelSubscription[SubscriptionPlan.AnyPlan](Some(memsub.Subscription.Name(subscriptionName)))
 
   @Deprecated def contributionUpdateAmount = updateContributionAmount(None)

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -21,7 +21,4 @@ GET         /user-attributes/me/mma-membership                          controll
 GET         /user-attributes/me/mma-monthlycontribution                 controllers.AccountController.monthlyContributionDetails
 GET         /user-attributes/me/mma-paper                               controllers.AccountController.paperDetails
 
-POST        /user-attributes/me/cancel-regular-contribution             controllers.AccountController.cancelRegularContribution
-POST        /user-attributes/me/cancel-membership                       controllers.AccountController.cancelMembership
-
 POST        /user-attributes/me/contribution-update-amount              controllers.AccountController.contributionUpdateAmount


### PR DESCRIPTION
### Why do we need this? 

These routes are unused (there have been 0 requests in the last 14 days according to Fastly logs). I believe `manage-frontend` was the only client using these previously, and this was changed over to the new url here: https://github.com/guardian/manage-frontend/pull/171.

Just to be sure, I've also checked GitHub for the url part (e.g. `cancel-regular-contribution`) and I can't find any other references to them.

