### PR TITLE
Expose mandate details even if mandateId is None

### DIFF
--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -247,7 +247,7 @@ class AccountController(commonActions: CommonActions, override val controllerCom
         case _: PaidChargeList => \/.right(subscription.asInstanceOf[Subscription[SubscriptionPlan.Paid]])
         case _ => \/.left(subscription.asInstanceOf[Subscription[SubscriptionPlan.Free]])
       }
-      paymentDetails <- ListEither.liftList(tp.paymentService.paymentDetails(freeOrPaidSub).map(\/.right).recover { case x => \/.left(s"error retrieving payment details for subscription: ${subscription.name}. Reason: $x") })
+      paymentDetails <- ListEither.liftList(tp.paymentService.paymentDetails(freeOrPaidSub, defaultMandateIdIfApplicable = Some("")).map(\/.right).recover { case x => \/.left(s"error retrieving payment details for subscription: ${subscription.name}. Reason: $x") })
       upToDatePaymentDetails <- ListEither.liftList(getUpToDatePaymentDetailsFromStripe(subscription.accountId, paymentDetails).map(\/.right).recover { case x => \/.left(s"error getting up-to-date card details for payment method of account: ${subscription.accountId}. Reason: $x") })
       accountSummary <- ListEither.liftList(tp.zuoraRestService.getAccount(subscription.accountId).recover { case x => \/.left(s"error receiving account summary for subscription: ${subscription.name} with account id ${subscription.accountId}. Reason: $x") })
       stripeService = accountSummary.billToContact.country.map(RegionalStripeGateways.getGatewayForCountry).flatMap(tp.stripeServicesByPaymentGateway.get).getOrElse(tp.ukStripeService)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.534"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.537"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.9"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.2"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"


### PR DESCRIPTION
## Must be released after https://github.com/guardian/membership-common/pull/593

### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
In order to expose the mandate information on the detailed responses (to ensure for example that people with a cancelled mandate are actually able to update - see https://github.com/guardian/manage-frontend/pull/207) we must make use of https://github.com/guardian/membership-common/pull/593 and pass `Some("")` which will allow the mandate details to be exposed.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
In this repo, simply to pass `Some("")` for the `defaultMandateIdIfApplicable` when fetching the payment method for the account.
