### PR TITLE
Transition Members Data API to t3 instances

### DIFF
--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -8,14 +8,10 @@ Parameters:
   InstanceType:
     Description: EC2 instance type
     Type: String
-    Default: t2.small
+    Default: t3.small
     AllowedValues:
-    - t2.micro
     - t2.small
-    - t2.medium
-    - m3.medium
-    - m3.large
-    - m3.xlarge
+    - t3.small
     ConstraintDescription: must be a valid EC2 instance type.
   VpcId:
     Description: ID of the VPC onto which to launch the application


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
Transition Members Data API to use t3 EC2 instance types, in preparation for 2019-20 reservations.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
Cloudformation config.
