### PR TITLE
Revert "Revert "Transition Members Data API to t3 instances""

### DIFF
--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -8,14 +8,10 @@ Parameters:
   InstanceType:
     Description: EC2 instance type
     Type: String
-    Default: t2.small
+    Default: t3.small
     AllowedValues:
-    - t2.micro
     - t2.small
-    - t2.medium
-    - m3.medium
-    - m3.large
-    - m3.xlarge
+    - t3.small
     ConstraintDescription: must be a valid EC2 instance type.
   VpcId:
     Description: ID of the VPC onto which to launch the application


### PR DESCRIPTION
Reverts guardian/members-data-api#381

This limit has been increased now, although it may take 30 mins to propagate, so let's have another go at this after lunch.