### PR TITLE
existing-payment-options: 'currencyFilter' is now optional so it can be used in manage-frontend

### DIFF
--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -2,7 +2,7 @@ GET         /healthcheck                                                        
 
 GET         /user-attributes/me                                                 controllers.AttributeController.attributes
 
-GET         /user-attributes/me/existing-payment-options                        controllers.ExistingPaymentOptionsController.existingPaymentOptions(currencyFilter: String)
+GET         /user-attributes/me/existing-payment-options                        controllers.ExistingPaymentOptionsController.existingPaymentOptions(currencyFilter: Option[String])
 
 GET         /user-attributes/me/mma                                             controllers.AccountController.allPaymentDetails(productType: Option[String])
 GET         /user-attributes/me/mma/:subscriptionName                           controllers.AccountController.paymentDetailsSpecificSub(subscriptionName: String)


### PR DESCRIPTION
Small tweak following https://github.com/guardian/members-data-api/pull/376 to make `currencyFilter` query parameter optional for `/user-attributes/me/existing-payment-options` endpoint, so it can be consumed easily in `manage-frontend` which doesn't have geo-location detection.