### PR TITLE
Integrate IDAPI as action wrapper

### DIFF
--- a/membership-attribute-service/app/actions/AuthAndBackendViaIdapiAction.scala
+++ b/membership-attribute-service/app/actions/AuthAndBackendViaIdapiAction.scala
@@ -30,7 +30,9 @@ class AuthAndBackendViaIdapiAction(
 
       howToHandleRecencyOfSignedIn match {
         case Return401IfNotSignedInRecently if redirectAdvice.signInStatus != SignedInRecently =>
-          Left(Results.Unauthorized) //TODO add Location header containing returnUrl
+          Left(Results.Unauthorized.withHeaders(
+            ("X-GU-IDAPI-Redirect", redirectAdvice.redirect.map(_.url).getOrElse(""))
+          ))
         case _ =>
           Right(new AuthAndBackendRequest[A](redirectAdvice, backendConf, request))
       }

--- a/membership-attribute-service/app/actions/AuthAndBackendViaIdapiAction.scala
+++ b/membership-attribute-service/app/actions/AuthAndBackendViaIdapiAction.scala
@@ -1,6 +1,6 @@
 package actions
 
-import com.gu.identity.SignedInRecently
+import com.gu.identity.{IdapiService, SignedInRecently}
 import components.TouchpointBackends
 import filters.AddGuIdentityHeaders
 import play.api.mvc.{ActionRefiner, Request, Result, Results}
@@ -9,8 +9,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class AuthAndBackendViaIdapiAction(
   touchpointBackends: TouchpointBackends,
-  howToHandleRecencyOfSignedIn: HowToHandleRecencyOfSignedIn,
-  scope: Option[String]
+  howToHandleRecencyOfSignedIn: HowToHandleRecencyOfSignedIn
 )(
   implicit ex: ExecutionContext
 ) extends ActionRefiner[Request, AuthAndBackendRequest] {
@@ -18,8 +17,8 @@ class AuthAndBackendViaIdapiAction(
   override val executionContext = ex
   override protected def refine[A](request: Request[A]): Future[Either[Result, AuthAndBackendRequest[A]]] =
     touchpointBackends.normal.idapiService.RedirectAdvice.getRedirectAdvice(
-      request.headers.get("Cookie").getOrElse(""),
-      scope
+      request.headers.get(IdapiService.HeaderNameCookie).getOrElse(""),
+      request.headers.get(IdapiService.HeaderNameIdapiForwardedScope)
     ).map(redirectAdvice => {
 
       val backendConf = if (AddGuIdentityHeaders.isTestUser(redirectAdvice.userId)) {

--- a/membership-attribute-service/app/actions/AuthAndBackendViaIdapiAction.scala
+++ b/membership-attribute-service/app/actions/AuthAndBackendViaIdapiAction.scala
@@ -1,0 +1,39 @@
+package actions
+
+import com.gu.identity.SignedInRecently
+import components.TouchpointBackends
+import filters.AddGuIdentityHeaders
+import play.api.mvc.{ActionRefiner, Request, Result, Results}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class AuthAndBackendViaIdapiAction(
+  touchpointBackends: TouchpointBackends,
+  howToHandleRecencyOfSignedIn: HowToHandleRecencyOfSignedIn,
+  scope: Option[String]
+)(
+  implicit ex: ExecutionContext
+) extends ActionRefiner[Request, AuthAndBackendRequest] {
+
+  override val executionContext = ex
+  override protected def refine[A](request: Request[A]): Future[Either[Result, AuthAndBackendRequest[A]]] =
+    touchpointBackends.normal.idapiService.RedirectAdvice.getRedirectAdvice(
+      request.headers.get("Cookie").getOrElse(""),
+      scope
+    ).map(redirectAdvice => {
+
+      val backendConf = if (AddGuIdentityHeaders.isTestUser(redirectAdvice.userId)) {
+        touchpointBackends.test
+      } else {
+        touchpointBackends.normal
+      }
+
+      howToHandleRecencyOfSignedIn match {
+        case Return401IfNotSignedInRecently if redirectAdvice.signInStatus != SignedInRecently =>
+          Left(Results.Unauthorized) //TODO add Location header containing returnUrl
+        case _ =>
+          Right(new AuthAndBackendRequest[A](redirectAdvice, backendConf, request))
+      }
+
+    })
+}

--- a/membership-attribute-service/app/actions/CommonActions.scala
+++ b/membership-attribute-service/app/actions/CommonActions.scala
@@ -16,10 +16,10 @@ class CommonActions(touchpointBackends: TouchpointBackends, bodyParser: BodyPars
 
   val NoCacheAction = resultModifier(noCache)
   val BackendFromCookieAction = NoCacheAction andThen new WithBackendFromCookieAction(touchpointBackends)
-  def AuthAndBackendViaIdapiAction(howToHandleRecencyOfSignedIn: HowToHandleRecencyOfSignedIn, scope: Option[String] = None) =
-    NoCacheAction andThen new AuthAndBackendViaIdapiAction(touchpointBackends, howToHandleRecencyOfSignedIn, scope)
-  def AuthAndBackendViaIdapiAction(scope: String): ActionBuilder[AuthAndBackendRequest, AnyContent] =
-    AuthAndBackendViaIdapiAction(Return401IfNotSignedInRecently, Some(scope))
+  def AuthAndBackendViaIdapiAction(howToHandleRecencyOfSignedIn: HowToHandleRecencyOfSignedIn) =
+    NoCacheAction andThen new AuthAndBackendViaIdapiAction(touchpointBackends, howToHandleRecencyOfSignedIn)
+  def AuthAndBackendViaIdapiAction: ActionBuilder[AuthAndBackendRequest, AnyContent] =
+    AuthAndBackendViaIdapiAction(Return401IfNotSignedInRecently)
 
   private def resultModifier(f: Result => Result) = new ActionBuilder[Request, AnyContent] {
     override val parser = bodyParser

--- a/membership-attribute-service/app/actions/CommonActions.scala
+++ b/membership-attribute-service/app/actions/CommonActions.scala
@@ -1,15 +1,25 @@
 package actions
 import akka.stream.Materializer
+import com.gu.identity.RedirectAdviceResponse
 import components.{TouchpointBackends, TouchpointComponents}
 import controllers.NoCache
 import play.api.mvc._
+
 import scala.concurrent.{ExecutionContext, Future}
+
+sealed trait HowToHandleRecencyOfSignedIn
+case object Return401IfNotSignedInRecently extends HowToHandleRecencyOfSignedIn
+case object ContinueRegardlessOfSignInRecency extends HowToHandleRecencyOfSignedIn
 
 class CommonActions(touchpointBackends: TouchpointBackends, bodyParser: BodyParser[AnyContent])(implicit ex: ExecutionContext, mat:Materializer) {
   def noCache(result: Result): Result = NoCache(result)
 
   val NoCacheAction = resultModifier(noCache)
   val BackendFromCookieAction = NoCacheAction andThen new WithBackendFromCookieAction(touchpointBackends)
+  def AuthAndBackendViaIdapiAction(howToHandleRecencyOfSignedIn: HowToHandleRecencyOfSignedIn, scope: Option[String] = None) =
+    NoCacheAction andThen new AuthAndBackendViaIdapiAction(touchpointBackends, howToHandleRecencyOfSignedIn, scope)
+  def AuthAndBackendViaIdapiAction(scope: String): ActionBuilder[AuthAndBackendRequest, AnyContent] =
+    AuthAndBackendViaIdapiAction(Return401IfNotSignedInRecently, Some(scope))
 
   private def resultModifier(f: Result => Result) = new ActionBuilder[Request, AnyContent] {
     override val parser = bodyParser
@@ -19,3 +29,8 @@ class CommonActions(touchpointBackends: TouchpointBackends, bodyParser: BodyPars
 }
 
 class BackendRequest[A](val touchpoint: TouchpointComponents, request: Request[A]) extends WrappedRequest[A](request)
+class AuthAndBackendRequest[A](
+  val redirectAdvice: RedirectAdviceResponse,
+  val touchpoint: TouchpointComponents,
+  request: Request[A]
+) extends WrappedRequest[A](request)

--- a/membership-attribute-service/app/actions/CommonActions.scala
+++ b/membership-attribute-service/app/actions/CommonActions.scala
@@ -18,8 +18,6 @@ class CommonActions(touchpointBackends: TouchpointBackends, bodyParser: BodyPars
   val BackendFromCookieAction = NoCacheAction andThen new WithBackendFromCookieAction(touchpointBackends)
   def AuthAndBackendViaIdapiAction(howToHandleRecencyOfSignedIn: HowToHandleRecencyOfSignedIn) =
     NoCacheAction andThen new AuthAndBackendViaIdapiAction(touchpointBackends, howToHandleRecencyOfSignedIn)
-  def AuthAndBackendViaIdapiAction: ActionBuilder[AuthAndBackendRequest, AnyContent] =
-    AuthAndBackendViaIdapiAction(Return401IfNotSignedInRecently)
 
   private def resultModifier(f: Result => Result) = new ActionBuilder[Request, AnyContent] {
     override val parser = bodyParser

--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -235,10 +235,10 @@ class AccountController(commonActions: CommonActions, override val controllerCom
     }
   } yield filteredIfApplicable
 
-  def anyPaymentDetails(filter: OptionalSubscriptionsFilter) = BackendFromCookieAction.async { implicit request =>
+  def anyPaymentDetails(filter: OptionalSubscriptionsFilter) = AuthAndBackendViaIdapiAction.async { implicit request =>
     implicit val tp = request.touchpoint
     def getPaymentMethod(id: PaymentMethodId) = tp.zuoraRestService.getPaymentMethod(id.get)
-    val maybeUserId = authenticationService.userId
+    val maybeUserId = request.redirectAdvice.userId
 
     logger.info(s"Attempting to retrieve payment details for identity user: ${maybeUserId.mkString}")
     (for {

--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -235,7 +235,7 @@ class AccountController(commonActions: CommonActions, override val controllerCom
     }
   } yield filteredIfApplicable
 
-  def anyPaymentDetails(filter: OptionalSubscriptionsFilter) = AuthAndBackendViaIdapiAction.async { implicit request =>
+  def anyPaymentDetails(filter: OptionalSubscriptionsFilter) = AuthAndBackendViaIdapiAction(Return401IfNotSignedInRecently).async { implicit request =>
     implicit val tp = request.touchpoint
     def getPaymentMethod(id: PaymentMethodId) = tp.zuoraRestService.getPaymentMethod(id.get)
     val maybeUserId = request.redirectAdvice.userId

--- a/membership-attribute-service/app/controllers/ExistingPaymentOptionsController.scala
+++ b/membership-attribute-service/app/controllers/ExistingPaymentOptionsController.scala
@@ -73,7 +73,7 @@ class ExistingPaymentOptionsController(commonActions: CommonActions, override va
   def existingPaymentOptions(currencyFilter: Option[String]) = AuthAndBackendViaIdapiAction(ContinueRegardlessOfSignInRecency).async { implicit request =>
     implicit val tp = request.touchpoint
     val maybeUserId = request.redirectAdvice.userId
-    val isFreshlySignedIn = request.redirectAdvice.status == SignedInRecently
+    val isFreshlySignedIn = request.redirectAdvice.signInStatus == SignedInRecently
 
     val eligibilityDate = now.minusMonths(3)
 

--- a/membership-attribute-service/app/controllers/ExistingPaymentOptionsController.scala
+++ b/membership-attribute-service/app/controllers/ExistingPaymentOptionsController.scala
@@ -73,7 +73,7 @@ class ExistingPaymentOptionsController(commonActions: CommonActions, override va
   def existingPaymentOptions(currencyFilter: Option[String]) = AuthAndBackendViaIdapiAction(ContinueRegardlessOfSignInRecency).async { implicit request =>
     implicit val tp = request.touchpoint
     val maybeUserId = request.redirectAdvice.userId
-    val isFreshlySignedIn = request.redirectAdvice.signInStatus == SignedInRecently
+    val isSignedInRecently = request.redirectAdvice.signInStatus == SignedInRecently
 
     val eligibilityDate = now.minusMonths(3)
 
@@ -109,7 +109,7 @@ class ExistingPaymentOptionsController(commonActions: CommonActions, override va
       if paymentMethodStillValid(paymentMethodOption) &&
          paymentMethodHasNoFailures(paymentMethodOption) &&
          paymentMethodIsActive(paymentMethodOption)
-    } yield ExistingPaymentOption(isFreshlySignedIn, objectAccount, paymentMethodOption, subscriptions)).run.run.map {
+    } yield ExistingPaymentOption(isSignedInRecently, objectAccount, paymentMethodOption, subscriptions)).run.run.map {
       case \/-(existingPaymentOptions) =>
         logger.info(s"Successfully retrieved eligible existing payment options for identity user: ${maybeUserId.mkString}")
         Ok(Json.toJson(consolidatePaymentMethod(existingPaymentOptions).map(_.toJson)))

--- a/membership-attribute-service/app/controllers/PaymentUpdateController.scala
+++ b/membership-attribute-service/app/controllers/PaymentUpdateController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import actions.CommonActions
+import actions.{CommonActions, Return401IfNotSignedInRecently}
 import com.gu.memsub
 import com.gu.memsub.subsv2.SubscriptionPlan
 import com.gu.memsub.{CardUpdateFailure, CardUpdateSuccess, GoCardless, PaymentMethod}
@@ -23,7 +23,7 @@ class PaymentUpdateController(commonActions: CommonActions, override val control
   import AccountHelpers._
   implicit val executionContext: ExecutionContext= controllerComponents.executionContext
 
-  def updateCard(subscriptionName: String) = AuthAndBackendViaIdapiAction.async { implicit request =>
+  def updateCard(subscriptionName: String) = AuthAndBackendViaIdapiAction(Return401IfNotSignedInRecently).async { implicit request =>
     // TODO - refactor to use the Zuora-only based lookup, like in AttributeController.pickAttributes - https://trello.com/c/RlESb8jG
     val updateForm = Form { tuple("stripeToken" -> nonEmptyText, "publicKey" -> text) }
     val tp = request.touchpoint
@@ -54,7 +54,7 @@ class PaymentUpdateController(commonActions: CommonActions, override val control
     }
   }
 
-  def updateDirectDebit(subscriptionName: String) = AuthAndBackendViaIdapiAction.async { implicit request =>
+  def updateDirectDebit(subscriptionName: String) = AuthAndBackendViaIdapiAction(Return401IfNotSignedInRecently).async { implicit request =>
     // TODO - refactor to use the Zuora-only based lookup, like in AttributeController.pickAttributes - https://trello.com/c/RlESb8jG
 
     def checkDirectDebitUpdateResult(

--- a/membership-attribute-service/app/controllers/PaymentUpdateController.scala
+++ b/membership-attribute-service/app/controllers/PaymentUpdateController.scala
@@ -12,7 +12,7 @@ import play.api.data.Form
 import play.api.data.Forms._
 import play.api.libs.json.Json
 import play.api.mvc.{BaseController, ControllerComponents}
-import services.{AuthenticationService, IdentityAuthService}
+
 import scala.concurrent.{ExecutionContext, Future}
 import scalaz.{-\/, EitherT, \/-}
 import scalaz.std.scalaFuture._
@@ -22,13 +22,14 @@ class PaymentUpdateController(commonActions: CommonActions, override val control
   import commonActions._
   import AccountHelpers._
   implicit val executionContext: ExecutionContext= controllerComponents.executionContext
-  lazy val authenticationService: AuthenticationService = IdentityAuthService
 
-  def updateCard(subscriptionName: String) = BackendFromCookieAction.async { implicit request =>
+  val IDAPI_SCOPE = "payment-flow"
+
+  def updateCard(subscriptionName: String) = AuthAndBackendViaIdapiAction(IDAPI_SCOPE).async { implicit request =>
     // TODO - refactor to use the Zuora-only based lookup, like in AttributeController.pickAttributes - https://trello.com/c/RlESb8jG
     val updateForm = Form { tuple("stripeToken" -> nonEmptyText, "publicKey" -> text) }
     val tp = request.touchpoint
-    val maybeUserId = authenticationService.userId
+    val maybeUserId = request.redirectAdvice.userId
     SafeLogger.info(s"Attempting to update card for $maybeUserId")
     (for {
       user <- EitherT(Future.successful(maybeUserId \/> "no identity cookie for user"))
@@ -55,7 +56,7 @@ class PaymentUpdateController(commonActions: CommonActions, override val control
     }
   }
 
-  def updateDirectDebit(subscriptionName: String) = BackendFromCookieAction.async { implicit request =>
+  def updateDirectDebit(subscriptionName: String) = AuthAndBackendViaIdapiAction(IDAPI_SCOPE).async { implicit request =>
     // TODO - refactor to use the Zuora-only based lookup, like in AttributeController.pickAttributes - https://trello.com/c/RlESb8jG
 
     def checkDirectDebitUpdateResult(
@@ -90,7 +91,7 @@ class PaymentUpdateController(commonActions: CommonActions, override val control
     ) }
 
     val tp = request.touchpoint
-    val maybeUserId = authenticationService.userId
+    val maybeUserId = request.redirectAdvice.userId
     SafeLogger.info(s"Attempting to update direct debit for $maybeUserId")
     (for {
       user <- EitherT(Future.successful(maybeUserId \/> "no identity cookie for user"))

--- a/membership-attribute-service/app/controllers/PaymentUpdateController.scala
+++ b/membership-attribute-service/app/controllers/PaymentUpdateController.scala
@@ -23,9 +23,7 @@ class PaymentUpdateController(commonActions: CommonActions, override val control
   import AccountHelpers._
   implicit val executionContext: ExecutionContext= controllerComponents.executionContext
 
-  val IDAPI_SCOPE = "payment-flow"
-
-  def updateCard(subscriptionName: String) = AuthAndBackendViaIdapiAction(IDAPI_SCOPE).async { implicit request =>
+  def updateCard(subscriptionName: String) = AuthAndBackendViaIdapiAction.async { implicit request =>
     // TODO - refactor to use the Zuora-only based lookup, like in AttributeController.pickAttributes - https://trello.com/c/RlESb8jG
     val updateForm = Form { tuple("stripeToken" -> nonEmptyText, "publicKey" -> text) }
     val tp = request.touchpoint
@@ -56,7 +54,7 @@ class PaymentUpdateController(commonActions: CommonActions, override val control
     }
   }
 
-  def updateDirectDebit(subscriptionName: String) = AuthAndBackendViaIdapiAction(IDAPI_SCOPE).async { implicit request =>
+  def updateDirectDebit(subscriptionName: String) = AuthAndBackendViaIdapiAction.async { implicit request =>
     // TODO - refactor to use the Zuora-only based lookup, like in AttributeController.pickAttributes - https://trello.com/c/RlESb8jG
 
     def checkDirectDebitUpdateResult(


### PR DESCRIPTION
## Requires https://github.com/guardian/membership-common/pull/596 ✅ 

<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
In order to facilitate 'auto sign-in tokens' (aka magic links) for the payment update flow (following CC Expiry, Direct Debit Mandate Failure and Payment Failure emails) `members-data-api` needs to be able to handle the new `SC_GU_RS` cookie (see https://github.com/guardian/identity/pull/1527) which is a 'scoped' sign-in cookie. With the accompanying `X_GU_ID_FORWARDED_SCOPE` header, the IDAPI redirect service is capable of interpreting this new cookie, the service also checks the recency of sign-in and checks for invalidated sessions (something that the existing cookie check mechanism in `members-data-api` cannot do) - so there are additional but very important side benefits to this work, beyond just facilitating  'auto sign-in tokens' (aka magic links).

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
Introduced `AuthAndBackendViaIdapiAction` which calls the IDAPI redirect service before processing the request and makes available some of the useful information that comes back. This will eventually replace the existing 'BackendFromCookieAction' (which just checks the cookie locally - using an identity library).
This new `AuthAndBackendViaIdapiAction` takes an ADT parameter (which informs it how to handle the redirect advice back from IDAPI), either...

- **`Return401IfNotSignedInRecently`** which if the `signInStatus` back from IDAPI is not `signedInRecently` then will return a 401 response (with the redirect URL in a new header `X-GU-IDAPI-Redirect`)
- **`ContinueRegardlessOfSignInRecency`** as in the case of `ExistingPaymentOptionsController.scala` where the recency of the sign-in is just used to limit the level of detail in the response.