### PR TITLE
filter out non CreditCardReferenceTransaction for existing payment options

### DIFF
--- a/membership-attribute-service/app/controllers/ExistingPaymentOptionsController.scala
+++ b/membership-attribute-service/app/controllers/ExistingPaymentOptionsController.scala
@@ -81,7 +81,7 @@ class ExistingPaymentOptionsController(commonActions: CommonActions, override va
     val defaultMandateIdIfApplicable = "CLEARED"
 
     def paymentMethodStillValid(paymentMethodOption: Option[PaymentMethod]) = paymentMethodOption match {
-      case Some(card: PaymentCard) => card.paymentCardDetails.exists(cardThatWontBeExpiredOnFirstTransaction)
+      case Some(card: PaymentCard) => card.isReferenceTransaction && card.paymentCardDetails.exists(cardThatWontBeExpiredOnFirstTransaction)
       case Some(dd: GoCardless) => dd.mandateId != defaultMandateIdIfApplicable //i.e. mandateId a real reference and hasn't been cleared in Zuora because of mandate failure
       case _ => false
     }

--- a/membership-attribute-service/app/controllers/ExistingPaymentOptionsController.scala
+++ b/membership-attribute-service/app/controllers/ExistingPaymentOptionsController.scala
@@ -101,7 +101,7 @@ class ExistingPaymentOptionsController(commonActions: CommonActions, override va
 
     logger.info(s"Attempting to retrieve existing payment options for identity user: ${maybeUserId.mkString}")
     (for {
-      isFreshlySignedIn <- ListEither.liftList(tp.idapiService.RedirectAdvice.redirectUrl(request.headers.get("Cookie").getOrElse("")).map(urlOption => \/-(urlOption.isEmpty)).recover { case x => \/.left(s"error getting idapi redirect for identity user $maybeUserId Reason: $x") })
+      isFreshlySignedIn <- ListEither.liftList(tp.idapiService.RedirectAdvice.getRedirectAdvice(request.headers.get("Cookie").getOrElse("")).map(advice => \/-(advice.redirect.isEmpty)).recover { case x => \/.left(s"error getting idapi redirect for identity user $maybeUserId Reason: $x") })
       groupedSubsList <- ListEither.fromOptionEither(allSubscriptionsSince(eligibilityDate)(tp.contactRepo, tp.subService)(maybeUserId))
       (accountId, subscriptions) = groupedSubsList
       objectAccount <- ListEither.liftList(tp.zuoraRestService.getObjectAccount(accountId).recover { case x => \/.left(s"error receiving OBJECT account with account id $accountId. Reason: $x") })

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.544"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.546"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.9"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.2"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
It turns out that card details entered directly into Zuora (`CreditCard` rather than `CreditCardReferenceTransaction`) are NOT clone-able and so break `support-workers`, hence these rare but valid payment method should not be available to select as an 'existing payment method'

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->

- Following https://github.com/guardian/membership-common/pull/597 make use of `isReferenceTransaction` to make sure for card payments we only allow CreditCardReferenceTransaction through.
- Also given that `membership-common` had moved on in https://github.com/guardian/membership-common/pull/596 but the accompanying https://github.com/guardian/members-data-api/pull/384 is not yet complete a minor tweak needed to be made to the use of `IdapiService` in order for things to compile.

### trello card/screenshot/json/related PRs etc
