### PR TITLE
remove 'pendingAmendment' from calculation of "cancelledAt" field in the output 

### DIFF
--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -110,7 +110,7 @@ object AccountDetails {
             "nextPaymentDate" -> paymentDetails.nextPaymentDate,
             "lastPaymentDate" -> paymentDetails.lastPaymentDate,
             "renewalDate" -> paymentDetails.termEndDate,
-            "cancelledAt" -> (paymentDetails.pendingAmendment || paymentDetails.pendingCancellation),
+            "cancelledAt" -> paymentDetails.pendingCancellation,
             "subscriberId" -> paymentDetails.subscriberId, // TODO remove once nothing is using this key (same time as removing old deprecated endpoints)
             "subscriptionId" -> paymentDetails.subscriberId,
             "trialLength" -> paymentDetails.remainingTrialLength,


### PR DESCRIPTION
no historical PR description to explain why (https://github.com/guardian/members-data-api/pull/66) - but is clearly wrong and was causing misinformation (identified by a userhelp case)
