### PR TITLE
Separate public/private subnets

### DIFF
--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -17,10 +17,12 @@ Parameters:
     Description: ID of the VPC onto which to launch the application
     Type: AWS::EC2::VPC::Id
     Default: vpc-e6e00183
-  VpcSubnets:
-    Description: Subnets to use in VPC
-    Type: CommaDelimitedList
-    Default: subnet-cb91ae8d,subnet-a7b74ac2,subnet-179e8063
+  PrivateVpcSubnets:
+    Description: Private subnets to use for EC2 instances
+    Type: List<AWS::EC2::Subnet::Id>
+  PublicVpcSubnets:
+    Description: Public subnets to use for the ELB
+    Type: List<AWS::EC2::Subnet::Id>
   AmiId:
     Description: Custom AMI to use for instances
     Type: String
@@ -157,14 +159,12 @@ Resources:
         Interval: '10'
         Timeout: '5'
       Subnets:
-        Ref: VpcSubnets
+        Ref: PublicVpcSubnets
       SecurityGroups:
       - Ref: LoadBalancerSecurityGroup
   AutoscalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
-      AvailabilityZones:
-        Fn::GetAZs: ''
       LaunchConfigurationName:
         Ref: LaunchConfig
       MinSize: !FindInMap [ StageVariables, !Ref Stage, MinInstances ]
@@ -195,7 +195,7 @@ Resources:
         Value: membership-attribute-service
         PropagateAtLaunch: 'true'
       VPCZoneIdentifier:
-        Ref: VpcSubnets
+        Ref: PrivateVpcSubnets
   LaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:


### PR DESCRIPTION
As part of reconfiguring the Membership VPC to have public & private subnets, I'm going to placing load balancers in the public subnet and instances in the private subnet, as per best security practices. (The original motivation for this was to give [lambdas access to the internet as well as entities within the VPC](https://aws.amazon.com/premiumsupport/knowledge-center/internet-access-lambda-function/), but having a subnet which is unreachable from the internet has other security benefits too, and is in fact how the Subscriptions VPC is set up.)

As a first step for this, I need to separate out these params in CloudFormation for all of our apps. I'll need to manually upload the new CloudFormation in the console because I need to supply values for these params.

Since this is an ELB classic, I can't simply swap subnets - behind the scenes, it seems to add before it removes, which violates the condition that there be only one subnet per availability zone. So I will initially supply the same subnets used currently for both public & private.

Then, one AZ at a time, I have to remove the subnet for that AZ, update the stack, then add back in the new subnet for that AZ.

Once I've done this for all our ASGs (the process for ALBs is a bit simpler), the final step is to attach new routing tables to the current public subnets, making them private (i.e. the default route goes to a NAT gateway rather than an internet gateway).

- [x] Stack updated for CODE
- [x] Stack updated for PROD