### PR TITLE
Document database ssh tunnel for running locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Get Janus credentials for membership.
 
 Create an ssh tunnel to the CODE one-off contributions database:
 1. Clone https://github.com/guardian/contributions-platform
-2. From the contributions-platform project, Run `./contributions-store/contributions-store-bastion/scripts/open_ssh_tunnel.sh -s CODE`
+2. From the contributions-platform project, Run `./contributions-store/contributions-store-bastion/scripts/open_ssh_tunnel.sh -s CODE` (requires [marauder](https://github.com/guardian/prism/tree/master/marauder))
 
 To start the service run ./start-api.sh
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Download the config (you may need to `brew install awscli` to get the command.
 
 Get Janus credentials for membership.
 
+Create an ssh tunnel to the CODE one-off contributions database:
+1. Clone https://github.com/guardian/contributions-platform
+2. From the contributions-platform project, Run `./contributions-store/contributions-store-bastion/scripts/open_ssh_tunnel.sh -s CODE`
+
 To start the service run ./start-api.sh
 
 The service will be running on 9400 and use the SupporterAttributesFallback-DEV DynamoDB table.


### PR DESCRIPTION
[This PR](https://github.com/guardian/members-data-api/pull/388) changed members-data-api to fetch one-off contributions from a Postgres database.
This means that in order to run members-data-api locally you now need to be able to connect to the database.