### PR TITLE
fix regression in test-user mode functionality

### DIFF
--- a/membership-attribute-service/app/actions/AuthAndBackendViaIdapiAction.scala
+++ b/membership-attribute-service/app/actions/AuthAndBackendViaIdapiAction.scala
@@ -21,7 +21,7 @@ class AuthAndBackendViaIdapiAction(
       request.headers.get(IdapiService.HeaderNameIdapiForwardedScope)
     ).map(redirectAdvice => {
 
-      val backendConf = if (AddGuIdentityHeaders.isTestUser(redirectAdvice.userId)) {
+      val backendConf = if (AddGuIdentityHeaders.isTestUser(redirectAdvice.displayName)) {
         touchpointBackends.test
       } else {
         touchpointBackends.normal


### PR DESCRIPTION
`userId` field was being passed to the `TestUsernames` checker, rather than the `displayName` 😢

Regression introduced to some endpoints in https://github.com/guardian/members-data-api/pull/384
