### PR TITLE
Add a logline on each call to a deprecated endpoint.

### DIFF
--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -277,7 +277,10 @@ class AccountController(commonActions: CommonActions, override val controllerCom
   }
 
   private def updateContributionAmount(subscriptionNameOption: Option[memsub.Subscription.Name]) = BackendFromCookieAction.async { implicit request =>
-    DeprecatedRequestLogger.logDeprecatedRequest(request)
+    if(subscriptionNameOption.isEmpty){
+      DeprecatedRequestLogger.logDeprecatedRequest(request)
+    }
+
     val updateForm = Form { single("newPaymentAmount" -> bigDecimal(5, 2)) }
     val tp = request.touchpoint
     val maybeUserId = authenticationService.userId

--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -19,6 +19,7 @@ import com.gu.zuora.api.RegionalStripeGateways
 import com.gu.zuora.rest.ZuoraRestService.PaymentMethodId
 import com.typesafe.scalalogging.LazyLogging
 import components.TouchpointComponents
+import loghandling.DeprecatedRequestLogger
 import models.AccountDetails._
 import models.ApiErrors._
 import models.{AccountDetails, ApiError}
@@ -163,6 +164,8 @@ class AccountController(commonActions: CommonActions, override val controllerCom
 
   @Deprecated
   private def paymentDetails[P <: SubscriptionPlan.Paid : SubPlanReads, F <: SubscriptionPlan.Free : SubPlanReads] = BackendFromCookieAction.async { implicit request =>
+    DeprecatedRequestLogger.logDeprecatedRequest(request)
+
     implicit val tp = request.touchpoint
     def getPaymentMethod(id: PaymentMethodId) = tp.zuoraRestService.getPaymentMethod(id.get)
     val maybeUserId = authenticationService.userId
@@ -274,6 +277,7 @@ class AccountController(commonActions: CommonActions, override val controllerCom
   }
 
   private def updateContributionAmount(subscriptionNameOption: Option[memsub.Subscription.Name]) = BackendFromCookieAction.async { implicit request =>
+    DeprecatedRequestLogger.logDeprecatedRequest(request)
     val updateForm = Form { single("newPaymentAmount" -> bigDecimal(5, 2)) }
     val tp = request.touchpoint
     val maybeUserId = authenticationService.userId

--- a/membership-attribute-service/app/loghandling/DeprecatedRequestLogger.scala
+++ b/membership-attribute-service/app/loghandling/DeprecatedRequestLogger.scala
@@ -1,0 +1,13 @@
+package loghandling
+
+import com.gu.monitoring.SafeLogger
+import play.api.mvc.{AnyContent, WrappedRequest}
+
+object DeprecatedRequestLogger {
+
+  val deprecatedSearchPhrase = "DeprecatedEndpointCalled"
+
+  def logDeprecatedRequest(request: WrappedRequest[AnyContent]): Unit = {
+    SafeLogger.info(s"$deprecatedSearchPhrase ${request.method} ${request.path} with headers ${request.headers.toMap} with body ${request.body}")
+  }
+}


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
We have a number of deprecated endpoints in members-data-api. 

I'd like to make it so that we can search `DeprecatedEndpointCalled` in cloudwatch and see which endpoints are still in use.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
* Adds a logline that logs `DeprecatedEndpointCalled`, the request method and path, the request headers and the request body for each deprecated endpoint

### trello card/screenshot/json/related PRs etc
There is going to be some work to follow that changes how we know cookies and tokens are valid in identity (see: https://trello.com/c/DjF6XvBE/1539-members-data-api-uses-identity-auth). We will need to eventually decide if 
1) deprecated endpoints be updated with this new definition of validity
2) we should remove the deprecated endpoints

So, we might as well start logging now. 
