### PR TITLE
Return last single contribution date

### DIFF
--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -126,7 +126,7 @@ object Attributes {
     (__ \ "userId").write[String] and
       (__ \ "tier").writeNullable[String] and
       (__ \ "recurringContributionPaymentPlan").writeNullable[String] and
-      (__ \ "oneOffContributionDate").writeNullable[LocalDate].contramap[Option[LocalDate]](_ => None) and  //omit
+      (__ \ "oneOffContributionDate").writeNullable[LocalDate] and
       (__ \ "membershipJoinDate").writeNullable[LocalDate] and
       (__ \ "digitalSubscriptionExpiryDate").writeNullable[LocalDate] and
       (__ \ "paperSubscriptionExpiryDate").writeNullable[LocalDate] and


### PR DESCRIPTION
Makes the /me endpoint return a `oneOffContributionDate` field, which is the date of the last single contribution. Note - this is for email-validated users only.
This is useful for showing different messaging on the website after users have passed their 6 month ask-pause.

Tested in CODE:
<img width="534" alt="Screenshot 2019-08-16 at 11 43 46" src="https://user-images.githubusercontent.com/1513454/63162698-28a40a80-c01b-11e9-96b9-db581de5875b.png">
