### PR TITLE
Downgrade logging to warn when there is no token/cookie provided.

### DIFF
--- a/membership-attribute-service/app/services/IdentityAuthService.scala
+++ b/membership-attribute-service/app/services/IdentityAuthService.scala
@@ -22,7 +22,8 @@ class IdentityAuthService(apiConfig: IdapiConfig)(implicit ec: ExecutionContext)
       .map(user => Option(user))
       .handleError { err =>
         if(err.isInstanceOf[UserCredentialsMissingError])
-          SafeLogger.error(scrub"invalid request as no token or cookie provided - unable to authorize user - $err", err)
+          SafeLogger.warn(s"invalid request as no token or cookie provided - unable to authorize user - $err." +
+            s"We received headers ${requestHeader.headers}", err)
         else
           SafeLogger.warn(s"valid request but expired token or cookie so user must log in again - $err")
 

--- a/membership-attribute-service/app/services/IdentityAuthService.scala
+++ b/membership-attribute-service/app/services/IdentityAuthService.scala
@@ -23,7 +23,7 @@ class IdentityAuthService(apiConfig: IdapiConfig)(implicit ec: ExecutionContext)
       .handleError { err =>
         if(err.isInstanceOf[UserCredentialsMissingError])
           SafeLogger.warn(s"invalid request as no token or cookie provided - unable to authorize user - $err." +
-            s"We received headers ${requestHeader.headers}", err)
+            s"Request attempted: ${requestHeader.method} ${requestHeader.path} with headers ${requestHeader.headers}", err)
         else
           SafeLogger.warn(s"valid request but expired token or cookie so user must log in again - $err")
 

--- a/membership-attribute-service/app/services/IdentityAuthService.scala
+++ b/membership-attribute-service/app/services/IdentityAuthService.scala
@@ -22,8 +22,8 @@ class IdentityAuthService(apiConfig: IdapiConfig)(implicit ec: ExecutionContext)
       .map(user => Option(user))
       .handleError { err =>
         if(err.isInstanceOf[UserCredentialsMissingError])
-          SafeLogger.warn(s"invalid request as no token or cookie provided - unable to authorize user - $err." +
-            s"Request attempted: ${requestHeader.method} ${requestHeader.path} with headers ${requestHeader.headers}", err)
+          SafeLogger.warn(s"invalid request as no token or cookie provided - unable to authorize user. \n" +
+            s"Request attempted: ${requestHeader.method} ${requestHeader.path} with headers:\n ${requestHeader.headers.toMap.mkString("\n")}", err)
         else
           SafeLogger.warn(s"valid request but expired token or cookie so user must log in again - $err")
 


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
https://github.com/guardian/members-data-api/pull/395 moved members-data-api to use the new identity auth library

I mistakenly thought that requests to members-data-api that did not include any way to even attempt to authenticate a user would be relatively rare (since the only endpoint that doesn't need an authenticated user is the healthcheck). 

I was wrong. There are so many requests that that error logging ate up a bunch of the sentry quota. I'd like to downgrade this log line to a warn, but add some info about the request that has come in to help investigate what is happening. 

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
* Downgrades the case where the the request doesn't have a means to authenticate a user to a warn
* Adds request logging for debugging, so that I can look into it further. 

### trello card/screenshot/json/related PRs etc
