### PR TITLE
Tidy up logging when incoming requests cause a UserCredentialsMissingError

### DIFF
--- a/membership-attribute-service/app/services/IdentityAuthService.scala
+++ b/membership-attribute-service/app/services/IdentityAuthService.scala
@@ -22,8 +22,9 @@ class IdentityAuthService(apiConfig: IdapiConfig)(implicit ec: ExecutionContext)
       .map(user => Option(user))
       .handleError { err =>
         if(err.isInstanceOf[UserCredentialsMissingError])
-          SafeLogger.warn(s"invalid request as no token or cookie provided - unable to authorize user. \n" +
-            s"Request attempted: ${requestHeader.method} ${requestHeader.path} with headers:\n ${requestHeader.headers.toMap.mkString("\n")}", err)
+          //IdentityPlayAuthService throws an error if there is no SC_GU_U cookie or crypto auth token
+          //frontend decides to make a request based on the existence of a GU_U cookie, so this case is expected.
+          SafeLogger.info(s"unable to authorize user - no token or cookie provided")
         else
           SafeLogger.warn(s"valid request but expired token or cookie so user must log in again - $err")
 


### PR DESCRIPTION
As of https://github.com/guardian/members-data-api/pull/395 members-data-api authenticates users using the new library identity-auth-play. As part of those changes, we logged when a request came in that didn't contain either a SC_GU_U cookie or a crypto access token. To get any meaningful response from members-data-api, we need an authenticated user so it seemed like those errors should have been relatively sparse.

They weren't.

It's because frontend doesn't bother calling members-data-api if the user is clearly not logged in, but the js code is unable to check if SC_GU_U is present. The best check that's available is to check for a GU_U cookie. So, this is not an error but actually expected behaviour. I've made this info logging, and removed the logging that logged the request headers. 

<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
- The logging should be updated to make it clearer that this is expected behaviour.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
- When we attempt to authenticate a user but this creates a UserCredentialsMissingError, this is now an info log because it's actually expected behaviour. 
- We are no longer logging request headers in that case because that was some temporary logging adding for debugging.

### trello card/screenshot/json/related PRs etc
https://trello.com/c/DjF6XvBE/1539-members-data-api-uses-identity-auth

https://github.com/guardian/members-data-api/pull/395
https://github.com/guardian/members-data-api/pull/397