### PR TITLE
FIX test-user mode functionality on /user-attributes/me endpoint

### DIFF
--- a/membership-attribute-service/app/actions/AuthAndBackendViaAuthLibAction.scala
+++ b/membership-attribute-service/app/actions/AuthAndBackendViaAuthLibAction.scala
@@ -15,7 +15,7 @@ class AuthAndBackendViaAuthLibAction(touchpointBackends: TouchpointBackends)(imp
     // The test config and the normal config are the same for IDAPI.
     touchpointBackends.normal.identityAuthService.user(request) map { user: Option[User] =>
 
-      val backendConf: TouchpointComponents = if (AddGuIdentityHeaders.isTestUser(user.flatMap(_.publicFields.username))) {
+      val backendConf: TouchpointComponents = if (AddGuIdentityHeaders.isTestUser(user.flatMap(_.publicFields.displayName))) {
         touchpointBackends.test
       } else {
         touchpointBackends.normal


### PR DESCRIPTION
With the move to `identity-auth-play` a new 'Action' was introduced entitled `AuthAndBackendViaAuthLibAction` (see https://github.com/guardian/members-data-api/pull/395) which mistakenly uses the `username` field (which is the user's public profile username for commenting etc) rather than their `displayName` in order to then extract the firstName to then evaluate against the `Config.testUsernames.isValid` function (in the `identity-test-users` lib). 

This PR puts that right.


#### trello card/screenshot/json/related PRs etc
https://trello.com/c/QFrRVNX9 
_which then unblocks https://trello.com/c/GiEPzPgL/587-activation-flow-trial-subscription-not-honoured_ (FYI @RichieAHB @blishen)
