### PR TITLE
made the card update support both card token OR New Stripe Payment Method

### DIFF
--- a/membership-attribute-service/app/controllers/ExistingPaymentOptionsController.scala
+++ b/membership-attribute-service/app/controllers/ExistingPaymentOptionsController.scala
@@ -66,7 +66,7 @@ class ExistingPaymentOptionsController(commonActions: CommonActions, override va
     existingPaymentOptions.groupBy(extractConsolidationPart).filterKeys(_.isDefined).values.map(mapConsolidatedBackToSingle)
   }
 
-
+  // TODO should probably fetch upToDate details from Stripe to determine this (rather than relying on Zuora) - see getUpToDatePaymentDetailsFromStripe in AccountController
   def cardThatWontBeExpiredOnFirstTransaction(cardDetails: PaymentCardDetails) =
     new LocalDate(cardDetails.expiryYear, cardDetails.expiryMonth, 1).isAfter(now.plusMonths(1))
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.550"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.551"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.9"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.2"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"


### PR DESCRIPTION
## MUST be released after https://github.com/guardian/membership-common/pull/602
![image](https://user-images.githubusercontent.com/19289579/64797446-537d7200-d579-11e9-8506-90e1110133f0.png)

**This PR facilitates https://github.com/guardian/manage-frontend/pull/241 using the new functions in https://github.com/guardian/membership-common/pull/602.**

Essentially these changes accept new key-values for the 'Stripe Payment Method' (which facilitates SCA) and selects the correct function from `membership-common` (see https://github.com/guardian/membership-common/pull/602).

### Old _(still supported)_ 
![image](https://user-images.githubusercontent.com/19289579/64798237-955ae800-d57a-11e9-89b0-3612557e37d6.png) 

### New
![image](https://user-images.githubusercontent.com/19289579/64798290-ac013f00-d57a-11e9-8402-43993676c53d.png)
_sent by `manage-frontend` (see https://github.com/guardian/manage-frontend/pull/241)_

