### PR TITLE
Allow access to digipack for guardian employees

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -13,10 +13,12 @@ import play.api.libs.json.Json
 import play.api.mvc._
 import services._
 import cats.implicits._
+import com.gu.identity.model.User
 import org.joda.time.LocalDate
 import scalaz.{-\/, \/-}
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
 
 class AttributeController(attributesFromZuora: AttributesFromZuora, commonActions: CommonActions, override val controllerComponents: ControllerComponents, oneOffContributionDatabaseService: OneOffContributionDatabaseService) extends BaseController with LoggingWithLogstashFields {
   import attributesFromZuora._
@@ -74,7 +76,8 @@ class AttributeController(attributesFromZuora: AttributesFromZuora, commonAction
             //Fetch one-off data independently of zuora data so that we can handle users with no zuora record
             (fromWhere: String, zuoraAttributes: Option[Attributes]) <- pickAttributes(identityId)
             latestOneOffDate: Option[LocalDate] <- getLatestOneOffContributionDate(identityId, userHasValidatedEmail)
-            combinedAttributes: Option[Attributes] = zuoraAttributes.map(_.copy(OneOffContributionDate = latestOneOffDate))
+            zuoraAttribWithContrib: Option[Attributes] = zuoraAttributes.map(_.copy(OneOffContributionDate = latestOneOffDate))
+            combinedAttributes: Option[Attributes] = maybeAllowAccessToDigipackForGuardianEmployees(request.user, zuoraAttribWithContrib)
           } yield {
 
             def customFields(supporterType: String): List[LogField] = List(LogFieldString("lookup-endpoint-description", endpointDescription), LogFieldString("supporter-type", supporterType), LogFieldString("data-source", fromWhere))
@@ -144,6 +147,31 @@ class AttributeController(attributesFromZuora: AttributesFromZuora, commonAction
         }
       } else Future(unauthorized)
     }
+  }
+
+  /**
+   * Allow all validated guardian.co.uk/theguardian.com email addresses access to the digipack
+   */
+  private def maybeAllowAccessToDigipackForGuardianEmployees(
+    maybeUser: Option[User],
+    maybeAttributes: Option[Attributes]
+  ): Option[Attributes] = {
+
+    val allowDigipackAccess =
+      (for {
+        user <- maybeUser
+        email = user.primaryEmailAddress
+        userHasValidatedEmail <- user.statusFields.userEmailValidated
+        emailDomain <- Try(email.split("@")(1)).toOption
+        userHasGuardianEmail = List("guardian.co.uk, theguardian.com").contains(emailDomain)
+      } yield {
+        userHasValidatedEmail && userHasGuardianEmail
+      }).getOrElse(false)
+
+    if (allowDigipackAccess)
+      maybeAttributes.map(_.copy(DigitalSubscriptionExpiryDate = Some(LocalDate.now().plusYears(99))))
+    else
+      maybeAttributes
   }
 
 }

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -172,7 +172,7 @@ class AttributeController(attributesFromZuora: AttributesFromZuora, commonAction
     // if maybeAttributes == None, there is nothing in Zuora so we have to hack it
     lazy val mockedZuoraAttribs = Some(Attributes(identityId))
     if (allowDigiPackAccessToStaff)
-      (maybeAttributes orElse mockedZuoraAttribs).map(_.copy(DigitalSubscriptionExpiryDate = Some(LocalDate.now.plusYears(99))))
+      (maybeAttributes orElse mockedZuoraAttribs).map(_.copy(DigitalSubscriptionExpiryDate = Some(new LocalDate( 2099, 1 , 1 ))))
     else
       maybeAttributes
 

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -171,8 +171,9 @@ class AttributeController(attributesFromZuora: AttributesFromZuora, commonAction
 
     // if maybeAttributes == None, there is nothing in Zuora so we have to hack it
     lazy val mockedZuoraAttribs = Some(Attributes(identityId))
+    lazy val digipackAllowEmployeeAccessDateHack = Some(new LocalDate(2999, 1, 1))
     if (allowDigiPackAccessToStaff)
-      (maybeAttributes orElse mockedZuoraAttribs).map(_.copy(DigitalSubscriptionExpiryDate = Some(new LocalDate( 2099, 1 , 1 ))))
+      (maybeAttributes orElse mockedZuoraAttribs).map(_.copy(DigitalSubscriptionExpiryDate = digipackAllowEmployeeAccessDateHack))
     else
       maybeAttributes
 

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -163,7 +163,7 @@ class AttributeController(attributesFromZuora: AttributesFromZuora, commonAction
         user <- maybeUser
         email = user.primaryEmailAddress
         userHasValidatedEmail <- user.statusFields.userEmailValidated
-        emailDomain <- Try(email.split("@")(1)).toOption
+        emailDomain <- email.split("@").lastOption
         userHasGuardianEmail = List("guardian.co.uk", "theguardian.com").contains(emailDomain)
       } yield {
         userHasValidatedEmail && userHasGuardianEmail

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -163,7 +163,7 @@ class AttributeController(attributesFromZuora: AttributesFromZuora, commonAction
         email = user.primaryEmailAddress
         userHasValidatedEmail <- user.statusFields.userEmailValidated
         emailDomain <- Try(email.split("@")(1)).toOption
-        userHasGuardianEmail = List("guardian.co.uk, theguardian.com").contains(emailDomain)
+        userHasGuardianEmail = List("guardian.co.uk", "theguardian.com").contains(emailDomain)
       } yield {
         userHasValidatedEmail && userHasGuardianEmail
       }).getOrElse(false)


### PR DESCRIPTION
https://trello.com/c/PbfUoxwr/345-allow-all-validated-guardiancouk-theguardiancom-email-addresses-to-have-access-to-the-digipack-via-members-data-api

Granting access to staff without having to add them to google groups. They can now simply create identity account and validate their email.

