### PR TITLE
Update to latest scala 2.12.x version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ def buildInfoSettings = Seq(
 val commonSettings = Seq(
   organization := "com.gu",
   version := appVersion,
-  scalaVersion := "2.12.6",
+  scalaVersion := "2.12.10",
   resolvers ++= Seq(
     "Guardian Github Releases" at "https://guardian.github.io/maven/repo-releases",
     "Guardian Github Snapshots" at "http://guardian.github.com/maven/repo-snapshots",


### PR DESCRIPTION
## Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->

Keeping dependencies up to date

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->

- Upgrade to latest version of scala 2.12.x
   - [2.12.10 Changelog](https://github.com/scala/scala/releases/tag/v2.12.10) 
   - [2.12.9 Changelog](https://github.com/scala/scala/releases/tag/v2.12.9)
   - [2.12.8 Changelog](https://github.com/scala/scala/releases/tag/v2.12.8)
   - [2.12.7 Changelog](https://github.com/scala/scala/releases/tag/v2.12.7)
