### PR TITLE
Support mobile subscriptions

### DIFF
--- a/membership-attribute-service/app/configuration/Config.scala
+++ b/membership-attribute-service/app/configuration/Config.scala
@@ -53,7 +53,6 @@ object Config {
   }
 
   object Mobile {
-    val subscriptionURL = config.getConfig("mobile.subscription.base")
     val subscriptionApiKey = config.getConfig("mobile.subscription.apiKey")
   }
 

--- a/membership-attribute-service/app/configuration/Config.scala
+++ b/membership-attribute-service/app/configuration/Config.scala
@@ -52,4 +52,9 @@ object Config {
     val enabled = Try{config.getBoolean("logstash.enabled")}.toOption.contains(true)
   }
 
+  object Mobile {
+    val subscriptionURL = config.getConfig("mobile.subscription.base")
+    val subscriptionApiKey = config.getConfig("mobile.subscription.apiKey")
+  }
+
 }

--- a/membership-attribute-service/app/configuration/Config.scala
+++ b/membership-attribute-service/app/configuration/Config.scala
@@ -53,7 +53,7 @@ object Config {
   }
 
   object Mobile {
-    val subscriptionApiKey = config.getConfig("mobile.subscription.apiKey")
+    val subscriptionApiKey: String = config.getString("mobile.subscription.apiKey")
   }
 
 }

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -86,7 +86,7 @@ class AttributeController(
     val mobileExpiryDate = mobileSubscriptionStatus.map(_.endDate.toLocalDate)
     zuoraAttributes.map(_.copy(
       OneOffContributionDate = latestOneOffDate,
-      MobileSubscriptionExpiryDate = mobileExpiryDate
+      LiveAppSubscriptionExpiryDate = mobileExpiryDate
     ))
   }
 

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -82,7 +82,7 @@ class AttributeController(
   }
 
   def enrichZuoraAttributes(zuoraAttributes: Option[Attributes], latestOneOffDate: Option[LocalDate], mobileSubscriptionStatus: Option[MobileSubscriptionStatus]): Option[Attributes] = {
-    val mobileExpiryDate = mobileSubscriptionStatus.map(_.endDate.toLocalDate)
+    val mobileExpiryDate = mobileSubscriptionStatus.map(_.to.toLocalDate)
     zuoraAttributes.map(_.copy(
       OneOffContributionDate = latestOneOffDate,
       LiveAppSubscriptionExpiryDate = mobileExpiryDate

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -72,9 +72,11 @@ class AttributeController(
   def getLatestMobileSubscription(identityId: String)(implicit executionContext: ExecutionContext): Future[Option[MobileSubscriptionStatus]] = {
     mobileSubscriptionService.getSubscriptionStatusForUser(identityId).transform {
       case Failure(NonFatal(error)) =>
+        metrics.put(s"mobile-subscription-fetch-exception", 1)
         log.warn("Exception while fetching mobile subscription, assuming none", error)
         Success(None)
       case Success(-\/(error)) =>
+        metrics.put(s"mobile-subscription-fetch-error-non-http-200", 1)
         log.warn(s"Unable to fetch mobile subscription, assuming none: $error")
         Success(None)
       case Success(\/-(status)) => Success(status)

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -85,7 +85,8 @@ class AttributeController(
     val mobileExpiryDate = mobileSubscriptionStatus.map(_.to.toLocalDate)
     zuoraAttributes.copy(
       OneOffContributionDate = latestOneOffDate,
-      LiveAppSubscriptionExpiryDate = mobileExpiryDate
+      LiveAppSubscriptionExpiryDate = mobileExpiryDate,
+
     )
   }
 

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -109,13 +109,13 @@ class AttributeController(
             (fromWhere: String, zuoraAttributes: Option[Attributes]) <- futureAttributes
             latestOneOffDate: Option[LocalDate] <- futureOneOffContribution
             latestMobileSubscription: Option[MobileSubscriptionStatus] <- futureMobileSubscriptionStatus
-            enrichedZuoraAttributes: Option[Attributes] = zuoraAttributes.map(enrichZuoraAttributes(_, latestOneOffDate, latestMobileSubscription))
-            combinedAttributes: Option[Attributes] = maybeAllowAccessToDigipackForGuardianEmployees(request.user, enrichedZuoraAttributes, user.id)
+            combinedAttributes: Option[Attributes] = maybeAllowAccessToDigipackForGuardianEmployees(request.user, zuoraAttributes, user.id)
+            enrichedZuoraAttributes: Option[Attributes] = combinedAttributes.map(enrichZuoraAttributes(_, latestOneOffDate, latestMobileSubscription))
           } yield {
 
             def customFields(supporterType: String): List[LogField] = List(LogFieldString("lookup-endpoint-description", endpointDescription), LogFieldString("supporter-type", supporterType), LogFieldString("data-source", fromWhere))
 
-            combinedAttributes match {
+            enrichedZuoraAttributes match {
               case Some(attrs @ Attributes(_, Some(tier), _, _, _, _, _, _, _, _)) =>
                 logInfoWithCustomFields(s"${user.id} is a $tier member - $endpointDescription - $attrs found via $fromWhere", customFields("member"))
                 onSuccessMember(attrs).withHeaders(

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -35,6 +35,7 @@ case class Attributes(
   DigitalSubscriptionExpiryDate: Option[LocalDate] = None,
   PaperSubscriptionExpiryDate: Option[LocalDate] = None,
   GuardianWeeklySubscriptionExpiryDate: Option[LocalDate] = None,
+  MobileSubscriptionExpiryDate: Option[LocalDate] = None,
   AlertAvailableFor: Option[String] = None) {
   lazy val isFriendTier = Tier.exists(_.equalsIgnoreCase("friend"))
   lazy val isSupporterTier = Tier.exists(_.equalsIgnoreCase("supporter"))
@@ -131,6 +132,7 @@ object Attributes {
       (__ \ "digitalSubscriptionExpiryDate").writeNullable[LocalDate] and
       (__ \ "paperSubscriptionExpiryDate").writeNullable[LocalDate] and
       (__ \ "guardianWeeklyExpiryDate").writeNullable[LocalDate] and
+      (__ \ "mobileSubscriptionExpiryDate").writeNullable[LocalDate] and
       (__ \ "alertAvailableFor").writeNullable[String]
   )(unlift(Attributes.unapply))
     .addNullableField("digitalSubscriptionExpiryDate", _.latestDigitalSubscriptionExpiryDate)

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -50,6 +50,7 @@ case class Attributes(
   lazy val digitalSubscriberHasActivePlan = latestDigitalSubscriptionExpiryDate.exists(_.isAfter(now))
   lazy val isPaperSubscriber = PaperSubscriptionExpiryDate.exists(_.isAfter(now))
   lazy val isGuardianWeeklySubscriber = GuardianWeeklySubscriptionExpiryDate.exists(_.isAfter(now))
+  lazy val isPremiumLiveAppSubscriber = LiveAppSubscriptionExpiryDate.exists(_.isAfter(now))
 
   lazy val contentAccess = ContentAccess(
     member = isPaidTier || isFriendTier,
@@ -62,8 +63,15 @@ case class Attributes(
 
   // show support messaging (in app & on dotcom) if they do NOT have any active products
   // TODO in future this could become more sophisticated (e.g. two weeks before their products expire)
-  lazy val showSupportMessaging =
-    !(isPaidTier || isRecurringContributor || isRecentOneOffContributor || digitalSubscriberHasActivePlan || isPaperSubscriber || isGuardianWeeklySubscriber)
+  lazy val showSupportMessaging = !(
+    isPaidTier
+      || isRecurringContributor
+      || isRecentOneOffContributor
+      || digitalSubscriberHasActivePlan
+      || isPaperSubscriber
+      || isGuardianWeeklySubscriber
+      || isPremiumLiveAppSubscriber
+    )
 
 }
 

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -35,7 +35,7 @@ case class Attributes(
   DigitalSubscriptionExpiryDate: Option[LocalDate] = None,
   PaperSubscriptionExpiryDate: Option[LocalDate] = None,
   GuardianWeeklySubscriptionExpiryDate: Option[LocalDate] = None,
-  MobileSubscriptionExpiryDate: Option[LocalDate] = None,
+  LiveAppSubscriptionExpiryDate: Option[LocalDate] = None,
   AlertAvailableFor: Option[String] = None) {
   lazy val isFriendTier = Tier.exists(_.equalsIgnoreCase("friend"))
   lazy val isSupporterTier = Tier.exists(_.equalsIgnoreCase("supporter"))
@@ -132,7 +132,7 @@ object Attributes {
       (__ \ "digitalSubscriptionExpiryDate").writeNullable[LocalDate] and
       (__ \ "paperSubscriptionExpiryDate").writeNullable[LocalDate] and
       (__ \ "guardianWeeklyExpiryDate").writeNullable[LocalDate] and
-      (__ \ "mobileSubscriptionExpiryDate").writeNullable[LocalDate] and
+      (__ \ "liveAppSubscriptionExpiryDate").writeNullable[LocalDate] and
       (__ \ "alertAvailableFor").writeNullable[String]
   )(unlift(Attributes.unapply))
     .addNullableField("digitalSubscriptionExpiryDate", _.latestDigitalSubscriptionExpiryDate)

--- a/membership-attribute-service/app/models/MobileSubscriptionStatus.scala
+++ b/membership-attribute-service/app/models/MobileSubscriptionStatus.scala
@@ -7,7 +7,7 @@ import scala.util.Try
 
 case class MobileSubscriptionStatus(
   valid: Boolean,
-  endDate: DateTime
+  to: DateTime
 )
 
 object MobileSubscriptionStatus {

--- a/membership-attribute-service/app/models/MobileSubscriptionStatus.scala
+++ b/membership-attribute-service/app/models/MobileSubscriptionStatus.scala
@@ -1,0 +1,21 @@
+package models
+
+import org.joda.time.DateTime
+import play.api.libs.json._
+
+import scala.util.Try
+
+case class MobileSubscriptionStatus(
+  valid: Boolean,
+  endDate: DateTime
+)
+
+object MobileSubscriptionStatus {
+  private implicit val dateTimeReads: Reads[DateTime] = new Reads[DateTime] {
+    override def reads(json: JsValue): JsResult[DateTime] = json match {
+      case JsString(date) => Try(DateTime.parse(date)).map(res => JsSuccess(res)).getOrElse(JsError(s"Unable to parse Date $date"))
+      case _ => JsError("Unable to parse date, was expecting a JsString")
+    }
+  }
+  implicit val mobileSubscriptionStatusReads: Reads[MobileSubscriptionStatus] = Json.reads[MobileSubscriptionStatus]
+}

--- a/membership-attribute-service/app/services/MobileSubscriptionService.scala
+++ b/membership-attribute-service/app/services/MobileSubscriptionService.scala
@@ -18,8 +18,8 @@ trait MobileSubscriptionService {
 class MobileSubscriptionServiceImpl(wsClient: WSClient)(implicit ec: ExecutionContext) extends MobileSubscriptionService {
 
   private val subscriptionURL = Config.stage match {
-    case "PROD" => "https://mobile-purchases.mobile-aws.guardianapis.com/"
-    case _ => "https://mobile-purchases.mobile-aws.code.dev-guardianapis.com/"
+    case "PROD" => "https://mobile-purchases.mobile-aws.guardianapis.com"
+    case _ => "https://mobile-purchases.mobile-aws.code.dev-guardianapis.com"
   }
 
   override def getSubscriptionStatusForUser(identityId: String): Future[String \/ Option[MobileSubscriptionStatus]] = {

--- a/membership-attribute-service/app/services/MobileSubscriptionService.scala
+++ b/membership-attribute-service/app/services/MobileSubscriptionService.scala
@@ -37,8 +37,8 @@ class MobileSubscriptionServiceImpl(wsClient: WSClient)(implicit ec: ExecutionCo
         parsedSubs match {
           case JsError(errors) => -\/(s"Unable to parse mobile subscription response: $errors")
           case JsSuccess(subs, _) =>
-            val mostRecentValidSub = subs.filter(_.valid).sortBy(_.endDate).lastOption
-            val mostRecentInvalidSub = subs.filterNot(_.valid).sortBy(_.endDate).lastOption
+            val mostRecentValidSub = subs.filter(_.valid).sortBy(_.to).lastOption
+            val mostRecentInvalidSub = subs.filterNot(_.valid).sortBy(_.to).lastOption
             \/-(mostRecentValidSub.orElse(mostRecentInvalidSub))
         }
       }

--- a/membership-attribute-service/app/services/MobileSubscriptionService.scala
+++ b/membership-attribute-service/app/services/MobileSubscriptionService.scala
@@ -40,9 +40,7 @@ class MobileSubscriptionServiceImpl(wsClient: WSClient)(implicit ec: ExecutionCo
           case JsSuccess(subs, _) =>
             val mostRecentValidSub = subs.filter(_.valid).sortBy(_.to).lastOption
             val mostRecentInvalidSub = subs.filterNot(_.valid).sortBy(_.to).lastOption
-            val subStatus = mostRecentValidSub.orElse(mostRecentInvalidSub)
-            log.info(s"Found subscription for user $identityId: $subStatus")
-            \/-(subStatus)
+            \/-(mostRecentValidSub.orElse(mostRecentInvalidSub))
         }
       }
     }

--- a/membership-attribute-service/app/services/MobileSubscriptionService.scala
+++ b/membership-attribute-service/app/services/MobileSubscriptionService.scala
@@ -29,7 +29,7 @@ class MobileSubscriptionServiceImpl(wsClient: WSClient)(implicit ec: ExecutionCo
 
     response.map { resp =>
       if (resp.status != 200) {
-        \/.left(s"Unable to fetch the mobile subscription status for $identityId")
+        \/.left(s"Unable to fetch the mobile subscription status for $identityId, got HTTP ${resp.status} ${resp.statusText}")
       } else {
         val parsedSubs = (resp.json \ "subscriptions")
           .validate[List[MobileSubscriptionStatus]]

--- a/membership-attribute-service/app/services/MobileSubscriptionService.scala
+++ b/membership-attribute-service/app/services/MobileSubscriptionService.scala
@@ -1,0 +1,42 @@
+package services
+
+import configuration.Config
+import models.MobileSubscriptionStatus
+import com.github.nscala_time.time.OrderingImplicits._
+import play.api.libs.json.{JsError, JsSuccess}
+import play.api.libs.ws.WSClient
+import scalaz.{-\/, \/, \/-}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MobileSubscriptionService {
+
+  def getSubscriptionStatusForUser(identityId: String): Future[\/[String, Option[MobileSubscriptionStatus]]]
+
+}
+
+class MobileSubscriptionServiceImpl(wsClient: WSClient)(implicit ec: ExecutionContext) extends MobileSubscriptionService {
+
+  override def getSubscriptionStatusForUser(identityId: String): Future[String \/ Option[MobileSubscriptionStatus]] = {
+    val response = wsClient.url(s"${Config.Mobile.subscriptionURL}/user/subscriptions/$identityId")
+      .withHttpHeaders("Authorization" -> s"Bearer ${Config.Mobile.subscriptionApiKey}")
+      .get()
+
+    response.map { resp =>
+      if (resp.status != 200) {
+        \/.left(s"Unable to fetch the mobile subscription status for $identityId")
+      } else {
+        val parsedSubs = (resp.json \ "subscriptions")
+          .validate[List[MobileSubscriptionStatus]]
+
+        parsedSubs match {
+          case JsError(errors) => -\/(s"Unable to parse mobile subscription response: $errors")
+          case JsSuccess(subs, _) =>
+            val mostRecentValidSub = subs.filter(_.valid).sortBy(_.endDate).lastOption
+            val mostRecentInvalidSub = subs.filterNot(_.valid).sortBy(_.endDate).lastOption
+            \/-(mostRecentValidSub.orElse(mostRecentInvalidSub))
+        }
+      }
+    }
+  }
+}

--- a/membership-attribute-service/app/services/MobileSubscriptionService.scala
+++ b/membership-attribute-service/app/services/MobileSubscriptionService.scala
@@ -17,8 +17,13 @@ trait MobileSubscriptionService {
 
 class MobileSubscriptionServiceImpl(wsClient: WSClient)(implicit ec: ExecutionContext) extends MobileSubscriptionService {
 
+  private val subscriptionURL = Config.stage match {
+    case "PROD" => "https://mobile-purchases.mobile-aws.guardianapis.com/"
+    case _ => "https://mobile-purchases.mobile-aws.code.dev-guardianapis.com/"
+  }
+
   override def getSubscriptionStatusForUser(identityId: String): Future[String \/ Option[MobileSubscriptionStatus]] = {
-    val response = wsClient.url(s"${Config.Mobile.subscriptionURL}/user/subscriptions/$identityId")
+    val response = wsClient.url(s"$subscriptionURL/user/subscriptions/$identityId")
       .withHttpHeaders("Authorization" -> s"Bearer ${Config.Mobile.subscriptionApiKey}")
       .get()
 

--- a/membership-attribute-service/app/wiring/AppLoader.scala
+++ b/membership-attribute-service/app/wiring/AppLoader.scala
@@ -17,7 +17,7 @@ import play.api.mvc.EssentialFilter
 import play.filters.cors.CORSFilter
 import play.filters.csrf.CSRFComponents
 import router.Routes
-import services.{AttributesFromZuora, PostgresDatabaseService}
+import services.{AttributesFromZuora, MobileSubscriptionServiceImpl, PostgresDatabaseService}
 
 import scala.concurrent.ExecutionContext
 
@@ -56,10 +56,12 @@ class MyComponents(context: Context)
     PostgresDatabaseService.fromDatabase(db)(jdbcExecutionContext)
   }
 
+  val mobileSubscriptionService = new MobileSubscriptionServiceImpl(wsClient = wsClient)
+
   lazy val router: Routes = new Routes(
     httpErrorHandler,
     new HealthCheckController(touchPointBackends, controllerComponents),
-    new AttributeController(attributesFromZuora, commonActions, controllerComponents, dbService),
+    new AttributeController(attributesFromZuora, commonActions, controllerComponents, dbService, mobileSubscriptionService),
     new ExistingPaymentOptionsController(commonActions, controllerComponents),
     new AccountController(commonActions, controllerComponents),
     new PaymentUpdateController(commonActions, controllerComponents)

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -7,7 +7,7 @@ import com.gu.identity.model.{StatusFields, User}
 import com.gu.identity.{RedirectAdviceResponse, SignedInRecently}
 import components.{TouchpointBackends, TouchpointComponents}
 import configuration.Config
-import models.{Attributes, ContributionData}
+import models.{Attributes, ContributionData, MobileSubscriptionStatus}
 import org.joda.time.LocalDate
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
@@ -18,7 +18,7 @@ import play.api.test._
 import play.api.test.Helpers._
 import scalaz.\/
 import services.OneOffContributionDatabaseService.DatabaseGetResult
-import services.{AttributesFromZuora, AuthenticationService, OneOffContributionDatabaseService}
+import services.{AttributesFromZuora, AuthenticationService, MobileSubscriptionService, OneOffContributionDatabaseService}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -126,7 +126,12 @@ class AttributeControllerTest extends Specification with AfterAll with Mockito {
       Future.successful(\/.right(None))
   }
 
-  private val controller = new AttributeController(new AttributesFromZuora(), commonActions, Helpers.stubControllerComponents(), FakePostgresService) {
+  object FakeMobileSubscriptionService extends MobileSubscriptionService {
+    override def getSubscriptionStatusForUser(identityId: String): Future[String \/ Option[MobileSubscriptionStatus]] =
+      Future.successful(\/.right(None))
+  }
+
+  private val controller = new AttributeController(new AttributesFromZuora(), commonActions, Helpers.stubControllerComponents(), FakePostgresService, FakeMobileSubscriptionService) {
     override val executionContext = scala.concurrent.ExecutionContext.global
     override def pickAttributes(identityId: String)(implicit request: AuthenticatedUserAndBackendRequest[AnyContent]): Future[(String, Option[Attributes])] = Future {
       if (identityId == validUserId || identityId == validEmployeeUser.id)


### PR DESCRIPTION
### Why do we need this? 
This will add a new field allowing the members data api to display if a user had a mobile subscription.
It will have a non trivial impact on the load (and therefore cost) of the mobile API, but I believe this is justified.

For instance, this would allow a user to see their mobile subscription in their dotcom profile, or we could have a cross platform ad-free experience.

It will be used by the mobile app as a way to provide cross device service, so long as the user is logged in.

### The changes 
 - Slightly refactor the AttributesController for readability and performance. Futures need to be triggered before a for comprehension to be executed in parallel. This might reduce latency.
 - Add a new service that queries the mobile purchases service

### TODO

- [x] Add configuration for CODE and PROD with relevant API Keys
- [x] Test on CODE
