### PR TITLE
Enable digipack access for staff after business decision

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -76,11 +76,8 @@ class AttributeController(attributesFromZuora: AttributesFromZuora, commonAction
             //Fetch one-off data independently of zuora data so that we can handle users with no zuora record
             (fromWhere: String, zuoraAttributes: Option[Attributes]) <- pickAttributes(identityId)
             latestOneOffDate: Option[LocalDate] <- getLatestOneOffContributionDate(identityId, userHasValidatedEmail)
-            combinedAttributes: Option[Attributes] = zuoraAttributes.map(_.copy(OneOffContributionDate = latestOneOffDate))
-
-            //FIXME: Temporarily disabled pending decision by The Business
-//            zuoraAttribWithContrib: Option[Attributes] = zuoraAttributes.map(_.copy(OneOffContributionDate = latestOneOffDate))
-//            combinedAttributes: Option[Attributes] = maybeAllowAccessToDigipackForGuardianEmployees(request.user, zuoraAttribWithContrib, identityId)
+            zuoraAttribWithContrib: Option[Attributes] = zuoraAttributes.map(_.copy(OneOffContributionDate = latestOneOffDate))
+            combinedAttributes: Option[Attributes] = maybeAllowAccessToDigipackForGuardianEmployees(request.user, zuoraAttribWithContrib, identityId)
           } yield {
 
             def customFields(supporterType: String): List[LogField] = List(LogFieldString("lookup-endpoint-description", endpointDescription), LogFieldString("supporter-type", supporterType), LogFieldString("data-source", fromWhere))

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -271,9 +271,8 @@ class AttributeControllerTest extends Specification with AfterAll with Mockito {
       verifySuccessfullAttributesResult(result)
     }
 
-    // FIXME: Enable these by removing pending once business is happy
     val digipackAllowEmployeeAccessDateHack = Some(new LocalDate(2999, 1, 1))
-    "allow DigiPack access via hack to guardian employees with validated guardian.co.uk email" in pending {
+    "allow DigiPack access via hack to guardian employees with validated guardian.co.uk email" in {
       val req = FakeRequest().withCookies(guardianEmployeeCookie)
       val defaultAttribsWithDigipackOverride =
         Attributes(guardianEmployeeUser.id)
@@ -281,7 +280,7 @@ class AttributeControllerTest extends Specification with AfterAll with Mockito {
       contentAsJson(controller.attributes(req)) shouldEqual Json.toJson(defaultAttribsWithDigipackOverride)
     }
 
-    "allow DigiPack access via hack to guardian employees with validated theguardian.com email" in pending {
+    "allow DigiPack access via hack to guardian employees with validated theguardian.com email" in {
       val req = FakeRequest().withCookies(guardianEmployeeCookieTheguardian)
       val defaultAttribsWithDigipackOverride =
         Attributes(guardianEmployeeUserTheguardian.id)
@@ -289,7 +288,7 @@ class AttributeControllerTest extends Specification with AfterAll with Mockito {
       contentAsJson(controller.attributes(req)) shouldEqual Json.toJson(defaultAttribsWithDigipackOverride)
     }
 
-    "allow DigiPack access via hack to guardian employees with affecting other products" in pending {
+    "allow DigiPack access via hack to guardian employees with affecting other products" in {
       val req = FakeRequest().withCookies(validEmployeeUserCookie)
       contentAsJson(controller.attributes(req)) shouldEqual
         Json.toJson(testAttributes.copy(DigitalSubscriptionExpiryDate = digipackAllowEmployeeAccessDateHack))


### PR DESCRIPTION
Enable: https://github.com/guardian/members-data-api/pull/406/

@JessL123