### PR TITLE
updating nginx scripts to use dev-nginx scripts

### DIFF
--- a/nginx/members-data-api.conf
+++ b/nginx/members-data-api.conf
@@ -1,14 +1,12 @@
 server {
-    listen 443;
+    listen 443 ssl;
     server_name members-data-api.thegulocal.com;
+    proxy_http_version 1.1; # this is essential for chunked responses to work
 
-    ssl on;
-    ssl_certificate STAR_thegulocal_com_exp2020-01-09.crt; ## Supplied by https://github.com/guardian/identity-platform#setup-nginx-for-local-development
-    ssl_certificate_key STAR_thegulocal_com_exp2020-01-09.key; ## ditto
-
+    ssl_certificate members-data-api.thegulocal.com.crt;
+    ssl_certificate_key members-data-api.thegulocal.com.key;
     ssl_session_timeout 5m;
-
-    ssl_protocols TLSv1;
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
     ssl_ciphers HIGH:!aNULL:!MD5;
     ssl_prefer_server_ciphers on;
 

--- a/nginx/setup.sh
+++ b/nginx/setup.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
+# Setup Nginx proxies for local development with valid SSL
 
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-NGINX_HOME=$(nginx -V 2>&1 | grep 'configure arguments:' | sed 's#.*conf-path=\([^ ]*\)/nginx\.conf.*#\1#g')
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-printf "\nUsing NGINX_HOME=$NGINX_HOME\n\n"
-printf "Note that you need to have already completed the Identity Platform setup:\n"
-printf "https://github.com/guardian/identity-platform#setup-nginx-for-local-development\n\n"
+SITE_CONF=${SCRIPT_DIR}/members-data-api.conf
 
-sudo ln -fs $DIR/members-data-api.conf $NGINX_HOME/sites-enabled/members-data-api.conf
+dev-nginx setup-cert members-data-api.thegulocal.com
 
-printf "\n\nNow restart Nginx!\n\n"
+dev-nginx link-config ${SITE_CONF}
+dev-nginx restart-nginx

--- a/nginx/setup.sh
+++ b/nginx/setup.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
-# Setup Nginx proxies for local development with valid SSL
+#Clean up legacy config
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NGINX_HOME=$(nginx -V 2>&1 | grep 'configure arguments:' | sed 's#.*conf-path=\([^ ]*\)/nginx\.conf.*#\1#g')
+sudo rm -f $NGINX_HOME/sites-enabled/members-data-api.conf
 
+# Setup Nginx proxies for local development with valid SSL
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 SITE_CONF=${SCRIPT_DIR}/members-data-api.conf


### PR DESCRIPTION
This PR contains changes to the scripts in /nginx which configure your local nginx instance to support running the app locally.

The scripts no longer worked as they referenced certificates in intentity-platform that no longer exist, as that project has been refactored to use the dev-nginx tool.

These changes refactor the scripts to create their own certificates and configure nginx using the dev-nginx tool.