### PR TITLE
add more granular 'Voucher' and 'HomeDelivery' to the options for 'productType' query param

### DIFF
--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -209,7 +209,8 @@ class AccountController(commonActions: CommonActions, override val controllerCom
     product match {
       // this ordering prevents Weekly subs from coming back when Paper is requested (which is different from the type hierarchy where Weekly extends Paper)
       case _: Product.Weekly => requestedProductType == "Weekly" || requestedProductTypeIsContentSubscription
-      case _: Product.Paper => requestedProductType == "Paper" || requestedProductTypeIsContentSubscription
+      case _: Product.Voucher => requestedProductType == "Voucher" || requestedProductType == "Paper" || requestedProductTypeIsContentSubscription
+      case _: Product.Delivery => requestedProductType == "HomeDelivery" || requestedProductType == "Paper" || requestedProductTypeIsContentSubscription
       case _: Product.Contribution => requestedProductType == "Contribution"
       case _: Product.Membership => requestedProductType == "Membership"
       case _: Product.ZDigipack => requestedProductType == "Digipack" || requestedProductTypeIsContentSubscription


### PR DESCRIPTION
This `productType` query param was originally introduced to make the tab based groupings of products in `manage-frontend` easier. For some reason I thought it wise at the time to combine 'voucher' and 'home delivery' as a single product 'paper'... however NOW to support _Voucher holiday stops_ independently of _home delivery holiday stops_ I am now splitting 'paper' in `manage-frontend` (see https://github.com/guardian/manage-frontend/pull/302) and this change is therefore necessary.

**_It still supports `Paper` as a value and behaves the same - this is an additive change._**