### PR TITLE
Add a metric filter for a full http client queue

### DIFF
--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -283,6 +283,16 @@ Resources:
       - MetricValue: 1
         MetricNamespace: "members-data-api"
         MetricName: !Sub "${Stage} - Default Payment Method set to nothing"
+  MembersDataHttpQueuesFullMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    DependsOn: MembersDataApiLogGroup
+    Properties:
+      FilterPattern: "\"Max wait queue limit of 256 reached, not scheduling.\""
+      LogGroupName: !Sub members-data-api-${Stage}
+      MetricTransformations:
+        - MetricValue: 1
+          MetricNamespace: "members-data-api"
+          MetricName: !Sub "${Stage} - Http Client Queue full"
   MembersDataDefaultPaymentMethodLeftEmptyAlarm:
     Type: AWS::CloudWatch::Alarm
     DependsOn:
@@ -306,7 +316,29 @@ Resources:
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Threshold: 1
       TreatMissingData: notBreaching
-
+  MembersDataHttpQueuesFullAlarm:
+    Type: AWS::CloudWatch::Alarm
+    DependsOn:
+      - MembersDataHttpQueuesFullMetricFilter
+      - MembersDataApiLogGroup
+    Condition: CreateProdMonitoring
+    Properties:
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
+      AlarmName: !Sub "Http Client Queue is full : members-data-api ${Stage}"
+      Dimensions:
+        - Name: LogGroup
+          Value: !Sub members-data-api-${Stage}
+        - Name: Stage
+          Value: !Sub ${Stage}
+      EvaluationPeriods: 1
+      MetricName: !Sub "${Stage} - Http Client Queue is full"
+      Namespace: "members-data-api"
+      Period: 3600
+      Statistic: Sum
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Threshold: 20
+      TreatMissingData: notBreaching
   ExpiredTtlAlarm:
         Type: AWS::CloudWatch::Alarm
         Condition: CreateProdMonitoring


### PR DESCRIPTION
I'm adding an alarm on a metric filter, this provides us with a more refined metric and alarm. Currently we have a generic alarm on 400s - this frequently fires as a result of downstream bottlenecks.

### Why do we need this? 
It would be preferable to have this type of alarm as the current 400s alarm was put in tactically and the regular (and valid) 400s trigger the alarm causing initially a mild panic and now don't register with people.

### The changes

New metric filter on the log string `Max wait queue limit of 256 reached, not scheduling.` and an alarm with a low threshold as the condition is very different to having the app respond with 400s.
The threshold may need tweaking as time goes on.
