### PR TITLE
Enable members-data-api to work with the new 3 months fixed term plan

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val awsClientVersion = "1.11.286"
   //libraries
   val sentryLogback = "io.sentry" % "sentry-logback" % "1.7.5"
-  val identityAuth = "com.gu.identity" %% "identity-auth-play" % "3.184" 
+  val identityAuth = "com.gu.identity" %% "identity-auth-play" % "3.184"
   val identityTestUsers =  "com.gu" %% "identity-test-users" % "0.7"
   val postgres =  "org.postgresql" % "postgresql" % "42.2.1"
   val jdbc = PlayImport.jdbc
@@ -15,16 +15,16 @@ object Dependencies {
   val playCache = PlayImport.cache
   val playFilters = PlayImport.filters
   val specs2 = PlayImport.specs2 % "test"
-  val scanamo = "com.gu" %% "scanamo" % "1.0.0-M8"                                                                                                                                                                                                                                                        
+  val scanamo = "com.gu" %% "scanamo" % "1.0.0-M8"
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.551"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.553"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.9"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.2"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"
   val anorm = "org.playframework.anorm" %% "anorm" % "2.6.0"
-  
+
   //projects
 
   val apiDependencies = Seq(jdbc, postgres, sentryLogback, identityAuth, identityTestUsers,


### PR DESCRIPTION
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
As part of the enhancements we are making to Guardian Weekly gifting we have added a new 3 month fixed term rate plan. In order for people to be able to manage these subscriptions in manage.theguardian.com we need to make them available through the members-data-api.
This PR does that
### The changes
* Update membership-common to version 0.553
