### PR TITLE
Expose delivery address in subscription response

### DIFF
--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -183,6 +183,7 @@ class AccountController(commonActions: CommonActions, override val controllerCom
       alertText <- OptionEither.liftEitherOption(alertText(accountSummary, sub, getPaymentMethod))
       isAutoRenew = sub.autoRenew
     } yield AccountDetails(
+      contactId = contact.salesforceContactId,
       regNumber = contact.regNumber,
       email = accountSummary.billToContact.email,
       deliveryAddress = None,
@@ -272,6 +273,7 @@ class AccountController(commonActions: CommonActions, override val controllerCom
       alertText <- ListEither.liftEitherList(alertText(accountSummary, contactAndSubscription.subscription, getPaymentMethod))
       isAutoRenew = contactAndSubscription.subscription.autoRenew
     } yield AccountDetails(
+      contactId = contactAndSubscription.contact.salesforceContactId,
       regNumber = None,
       email = accountSummary.billToContact.email,
       deliveryAddress = Some(DeliveryAddress.fromContact(contactAndSubscription.contact)),

--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -229,7 +229,7 @@ class AccountController(commonActions: CommonActions, override val controllerCom
   ): OptionT[OptionEither.FutureEither, List[ContactAndSubscription]] = for {
       user <- OptionEither.liftFutureEither(maybeUserId)
       contact <- OptionEither(contactRepo.get(user))
-      subscriptions <-
+      contactAndSubscriptions <-
         OptionEither.liftEitherOption(
           subService.current[SubscriptionPlan.AnyPlan](contact) map {
             _ map { subscription =>
@@ -239,17 +239,17 @@ class AccountController(commonActions: CommonActions, override val controllerCom
         ) // TODO are we happy with an empty list in case of error ?!?!
       filteredIfApplicable = filter match {
         case FilterBySubName(subscriptionName) =>
-          subscriptions.find(_.subscription.name == subscriptionName).toList
+          contactAndSubscriptions.find(_.subscription.name == subscriptionName).toList
         case FilterByProductType(productType) =>
-          subscriptions.filter(
-            subscription =>
+          contactAndSubscriptions.filter(
+            contactAndSubscription =>
               productIsInstanceOfProductType(
-                subscription.subscription.plan.product,
+                contactAndSubscription.subscription.plan.product,
                 productType
               )
           )
         case NoFilter =>
-          subscriptions
+          contactAndSubscriptions
       }
     } yield filteredIfApplicable
 

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -8,6 +8,7 @@ import play.api.libs.json.{Json, _}
 import org.joda.time.LocalDate.now
 
 case class AccountDetails(
+  contactId: String,
   regNumber: Option[String],
   email: Option[String],
   deliveryAddress: Option[DeliveryAddress],
@@ -104,6 +105,7 @@ object AccountDetails {
           "joinDate" -> paymentDetails.startDate,
           "optIn" -> !paymentDetails.pendingCancellation,
           "subscription" -> (paymentMethod ++ Json.obj(
+            "contactId" -> accountDetails.contactId,
             "deliveryAddress" -> accountDetails.deliveryAddress,
             "safeToUpdatePaymentMethod" -> safeToUpdatePaymentMethod,
             "start" -> paymentDetails.customerAcceptanceDate,

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -10,6 +10,7 @@ import org.joda.time.LocalDate.now
 case class AccountDetails(
   regNumber: Option[String],
   email: Option[String],
+  deliveryAddress: Option[DeliveryAddress],
   subscription : Subscription[SubscriptionPlan.AnyPlan],
   paymentDetails: PaymentDetails,
   stripePublicKey: String,
@@ -103,6 +104,7 @@ object AccountDetails {
           "joinDate" -> paymentDetails.startDate,
           "optIn" -> !paymentDetails.pendingCancellation,
           "subscription" -> (paymentMethod ++ Json.obj(
+            "deliveryAddress" -> accountDetails.deliveryAddress,
             "safeToUpdatePaymentMethod" -> safeToUpdatePaymentMethod,
             "start" -> paymentDetails.customerAcceptanceDate,
             "end" -> endDate,

--- a/membership-attribute-service/app/models/ContactAndSubscription.scala
+++ b/membership-attribute-service/app/models/ContactAndSubscription.scala
@@ -1,0 +1,10 @@
+package models
+
+import com.gu.memsub.subsv2.Subscription
+import com.gu.memsub.subsv2.SubscriptionPlan.AnyPlan
+import com.gu.salesforce.Contact
+
+case class ContactAndSubscription(
+    contact: Contact,
+    subscription: Subscription[AnyPlan]
+)

--- a/membership-attribute-service/app/models/DeliveryAddress.scala
+++ b/membership-attribute-service/app/models/DeliveryAddress.scala
@@ -1,0 +1,36 @@
+package models
+
+import com.gu.salesforce.Contact
+import play.api.libs.json.{Json, Writes}
+
+case class DeliveryAddress(
+    addressLine1: Option[String],
+    addressLine2: Option[String],
+    town: Option[String],
+    region: Option[String],
+    postcode: Option[String],
+    country: Option[String]
+)
+
+object DeliveryAddress {
+  implicit val writes: Writes[DeliveryAddress] = Json.writes[DeliveryAddress]
+
+  def fromContact(contact: Contact): DeliveryAddress = {
+    val addressLines = splitAddressLines(contact.mailingStreet)
+    DeliveryAddress(
+      addressLine1 = addressLines.map(_._1),
+      addressLine2 = addressLines.map(_._2),
+      town = contact.mailingCity,
+      region = contact.mailingState,
+      postcode = contact.mailingPostcode,
+      country = contact.mailingCountry
+    )
+  }
+
+  def splitAddressLines(addressLine: Option[String]): Option[(String, String)] =
+    addressLine map { line =>
+      val n = line.lastIndexOf(',')
+      if (n == -1) (line, "")
+      else (line.take(n).trim, line.drop(n + 1).trim)
+    }
+}

--- a/membership-attribute-service/test/models/DeliveryAddressTest.scala
+++ b/membership-attribute-service/test/models/DeliveryAddressTest.scala
@@ -1,0 +1,35 @@
+package models
+
+import org.specs2.mutable.Specification
+
+class DeliveryAddressTest extends Specification {
+
+  "splitAddressLines" should {
+    "split address line into two at comma" in {
+      DeliveryAddress.splitAddressLines(
+        Some("25, Low Road")
+      ) should_=== Some(("25", "Low Road"))
+    }
+    "split address line into two at last comma" in {
+      DeliveryAddress.splitAddressLines(
+        Some("Flat 4, Floor 7, 25, Low Road, Halfmoon Street")
+      ) should_=== Some(("Flat 4, Floor 7, 25, Low Road", "Halfmoon Street"))
+    }
+    "leave address line alone if has no comma" in {
+      DeliveryAddress.splitAddressLines(
+        Some("25 Low Road")
+      ) should_=== Some(("25 Low Road", ""))
+    }
+    "leave address line alone if empty" in {
+      DeliveryAddress.splitAddressLines(Some("")) should_=== Some(("", ""))
+    }
+    "leave address line alone if not defined" in {
+      DeliveryAddress.splitAddressLines(None) should_=== None
+    }
+    "trim whitespace" in {
+      DeliveryAddress.splitAddressLines(
+        Some("Flat 4, Floor 7, 25, Low Road,  Halfmoon Street")
+      ) should_=== Some(("Flat 4, Floor 7, 25, Low Road", "Halfmoon Street"))
+    }
+  }
+}


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
This change adds a `deliveryAddress` object beneath the `subscription` object in the response body of a `user-attributes/me/mma` request, so that a subscriber's delivery address can be populated in MMA.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
The `AccountController.allCurrentSubscriptions` method now returns a `List[ContactAndSubscription]` instead of a `List[Subscription]` which allows us to populate a new `deliveryAddress` object in the output json using the mailing address fields from the contact.

TODO:
I have not considered the case where the buyer and recipient have different addresses yet, ie in the case of a gift.

### trello card/screenshot/json/related PRs etc

* https://trello.com/c/GhHtFhg4
* https://trello.com/c/MZJqIC1H

The json will look something like this:
<img width="365" alt="image" src="https://user-images.githubusercontent.com/1722550/70061022-7a2cd100-15db-11ea-889b-0d633a3475ed.png">


Tested in Code.
