### PR TITLE
Add endpoint for updating delivery addresses

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,1 @@
+maxColumn = 100

--- a/membership-attribute-service/app/controllers/ContactController.scala
+++ b/membership-attribute-service/app/controllers/ContactController.scala
@@ -1,0 +1,56 @@
+package controllers
+
+import actions.CommonActions
+import com.gu.salesforce.SFContactId
+import models.DeliveryAddress
+import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.control.Exception
+
+class ContactController(
+    commonActions: CommonActions,
+    override val controllerComponents: ControllerComponents
+) extends BaseController {
+
+  import commonActions._
+
+  private implicit val ec: ExecutionContext = controllerComponents.executionContext
+
+  def updateDeliveryAddress(contactId: String): Action[AnyContent] =
+    AuthAndBackendViaAuthLibAction.async { request =>
+      val contactRepo = request.touchpoint.contactRepo
+
+      val submitted = Exception.allCatch.either {
+        request.body.asJson map (_.as[DeliveryAddress])
+      }
+
+      submitted match {
+        case Left(parsingFailure) => Future.successful(BadRequest(parsingFailure.getMessage))
+        case Right(None)          => Future.successful(BadRequest(s"Not json: ${request.body}"))
+        case Right(Some(address)) =>
+
+          val contactFields = {
+            def contactField(name: String, optValue: Option[String]): Map[String, String] =
+              optValue map { value =>
+                Map(name -> value.trim)
+              } getOrElse Map()
+            val mergedAddressLines = DeliveryAddress.mergeAddressLines(address)
+            Map() ++
+              contactField("MailingStreet", mergedAddressLines) ++
+              contactField("MailingCity", address.town) ++
+              contactField("MailingState", address.region) ++
+              contactField("MailingPostalCode", address.postcode) ++
+              contactField("MailingCountry", address.country)
+          }
+
+          val update = contactRepo.salesforce.Contact.update(SFContactId(contactId), contactFields)
+
+          update map { _ =>
+            NoContent
+          } recover {
+            case updateFailure => BadGateway(updateFailure.getMessage)
+          }
+      }
+    }
+}

--- a/membership-attribute-service/app/models/DeliveryAddress.scala
+++ b/membership-attribute-service/app/models/DeliveryAddress.scala
@@ -1,7 +1,7 @@
 package models
 
 import com.gu.salesforce.Contact
-import play.api.libs.json.{Json, Writes}
+import play.api.libs.json.{Format, Json}
 
 case class DeliveryAddress(
     addressLine1: Option[String],
@@ -13,7 +13,7 @@ case class DeliveryAddress(
 )
 
 object DeliveryAddress {
-  implicit val writes: Writes[DeliveryAddress] = Json.writes[DeliveryAddress]
+  implicit val format: Format[DeliveryAddress] = Json.format[DeliveryAddress]
 
   def fromContact(contact: Contact): DeliveryAddress = {
     val addressLines = splitAddressLines(contact.mailingStreet)
@@ -32,5 +32,13 @@ object DeliveryAddress {
       val n = line.lastIndexOf(',')
       if (n == -1) (line, "")
       else (line.take(n).trim, line.drop(n + 1).trim)
+    }
+
+  def mergeAddressLines(address: DeliveryAddress): Option[String] =
+    (address.addressLine1, address.addressLine2) match {
+      case (Some(line1), Some(line2)) => Some(s"${line1.trim},${line2.trim}")
+      case (Some(line1), None)        => Some(line1.trim)
+      case (None, Some(line2))        => Some(line2.trim)
+      case (None, None)               => None
     }
 }

--- a/membership-attribute-service/app/monitoring/SentryLogging.scala
+++ b/membership-attribute-service/app/monitoring/SentryLogging.scala
@@ -1,15 +1,14 @@
 package monitoring
 
-import com.gu.monitoring.SafeLogger
-import com.gu.monitoring.SafeLogger._
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.filter.Filter
 import ch.qos.logback.core.spi.FilterReply
 import com.gu.monitoring.SafeLogger
-import io.sentry.Sentry
+import com.gu.monitoring.SafeLogger._
 import configuration.Config
+import io.sentry.Sentry
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
 
 object SentryLogging {
@@ -22,7 +21,7 @@ object SentryLogging {
             val sentryClient = Sentry.init(sentryDSN)
             val buildInfo: Map[String, String] = app.BuildInfo.toMap.mapValues(_.toString)
             val tags = Map("stage" -> Config.stage) ++ buildInfo
-            sentryClient.setTags(tags)
+            sentryClient.setTags(tags.asJava)
           } match {
             case Success(_) => SafeLogger.debug("Sentry logging configured.")
             case Failure(e) => SafeLogger.error(scrub"Something went wrong when setting up Sentry logging ${e.getStackTrace}")

--- a/membership-attribute-service/app/wiring/AppLoader.scala
+++ b/membership-attribute-service/app/wiring/AppLoader.scala
@@ -64,7 +64,8 @@ class MyComponents(context: Context)
     new AttributeController(attributesFromZuora, commonActions, controllerComponents, dbService, mobileSubscriptionService),
     new ExistingPaymentOptionsController(commonActions, controllerComponents),
     new AccountController(commonActions, controllerComponents),
-    new PaymentUpdateController(commonActions, controllerComponents)
+    new PaymentUpdateController(commonActions, controllerComponents),
+    new ContactController(commonActions, controllerComponents)
   )
 
   val postPaths: List[String] = router.documentation.collect { case ("POST", path, _) => path }

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -16,6 +16,9 @@ POST        /user-attributes/me/update-direct-debit/:subscriptionName           
 
 GET         /user-attributes/me/one-off-contributions                           controllers.AttributeController.oneOffContributions
 
+PUT         /user-attributes/me/delivery-address/:contactId                     controllers.ContactController.updateDeliveryAddress(contactId: String)
+
+
 # OLD ENDPOINTS below will be phased out as traffic moves over to the new endpoints above
 GET         /user-attributes/me/membership                              controllers.AttributeController.membership
 GET         /user-attributes/me/features                                controllers.AttributeController.features

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.553"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.554"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.9"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.2"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
This change allows us to save updated delivery addresses from MMA to Salesforce.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
I've added a new route taking a contact ID in the URL and the updated delivery address as the json body of the request.  This is sent on to Salesforce as a patch request on the Contact record.

### trello card/screenshot/json/related PRs etc
* https://trello.com/c/GhHtFhg4
* https://trello.com/c/kW8RPfW9

Depends on release 0.554 of membership-common, incorporating [this change](https://github.com/guardian/membership-common/pull/605).
