### PR TITLE
Add reader type field into /me/mma

### DIFF
--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -142,7 +142,8 @@ object AccountDetails {
               "interval" -> paymentDetails.plan.interval.mkString
             ),
             "currentPlans" -> currentPlans.map(jsonifyPlan),
-            "futurePlans" -> futurePlans.map(jsonifyPlan)
+            "futurePlans" -> futurePlans.map(jsonifyPlan),
+            "readerType" -> accountDetails.subscription.readerType.value
           )),
         ) ++ alertText.map(text => Json.obj("alertText" -> text)).getOrElse(Json.obj())
 


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
This PR adds the `ReaderType` of a subscription into the `/me/mma` endpoint. This will be either 'Gift', 'Direct, 'Agent' or 'Complementary' and will allow us to highlight that a subscription is a gift in the MMA page.

### New Output:
![Screen Shot 2019-12-18 at 14 54 32](https://user-images.githubusercontent.com/181371/71097102-61114c00-21a7-11ea-93d5-d620f623d762.png)
