### PR TITLE
correct 'start' date exposed on each sub

### DIFF
--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -8,6 +8,7 @@ import com.gu.memsub.{GoCardless, PayPalMethod, PaymentCard, Product}
 import com.gu.services.model.PaymentDetails
 import com.typesafe.scalalogging.LazyLogging
 import json.localDateWrites
+import org.joda.time.LocalDate
 import play.api.libs.json.{Json, _}
 import org.joda.time.LocalDate.now
 
@@ -109,6 +110,8 @@ object AccountDetails {
       val currentPlans = sortedPlans.filter(plan => !plan.start.isAfter(now) && plan.end.isAfter(now))
       val futurePlans = sortedPlans.filter(plan => plan.start.isAfter(now))
 
+      val startDate: LocalDate = sortedPlans.headOption.map(_.start).getOrElse(paymentDetails.customerAcceptanceDate)
+
       if(currentPlans.length > 1) logger.warn(s"More than one 'current plan' on sub with id: ${subscription.id}")
 
       Json.obj(
@@ -123,7 +126,7 @@ object AccountDetails {
             "contactId" -> accountDetails.contactId,
             "deliveryAddress" -> accountDetails.deliveryAddress,
             "safeToUpdatePaymentMethod" -> safeToUpdatePaymentMethod,
-            "start" -> paymentDetails.customerAcceptanceDate,
+            "start" -> startDate,
             "end" -> endDate,
             "nextPaymentPrice" -> paymentDetails.nextPaymentPrice,
             "nextPaymentDate" -> paymentDetails.nextPaymentDate,


### PR DESCRIPTION
Previously the `start` date was just the `customerAcceptanceDate` (because https://github.com/guardian/members-data-api/pull/369) but for _Guardian Weekly 6for6_ (at least) the customer acceptance date is when the full price plan starts 😢 - so NOW we use the first paid plan start date, falling back to customerAcceptanceDate if there are no plans.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/19289579/71415484-d7a0c480-2653-11ea-88e0-40ce68b99e19.png) | ![image](https://user-images.githubusercontent.com/19289579/71415461-c35cc780-2653-11ea-8b08-64eff82c3978.png) |

_...`manage-frontend` screenshot which uses the output of `members-data-api`._

https://trello.com/c/fAYU3wRS/770-correct-start-date-for-gw-6for6
