### PR TITLE
Changing connectionTimeout and documenting socketTimeout

### DIFF
--- a/membership-attribute-service/conf/application.conf
+++ b/membership-attribute-service/conf/application.conf
@@ -41,5 +41,8 @@ db.oneOffStore {
   username=null
 }
 
+# Wait up to 2 seconds for DB connection
+play.db.prototype.hikaricp.connectionTimeout = 2000
+
 
 include file("/etc/gu/members-data-api.private.conf")

--- a/membership-attribute-service/conf/application.conf
+++ b/membership-attribute-service/conf/application.conf
@@ -35,7 +35,7 @@ contexts {
 }
 
 db.oneOffStore {
-  url=null
+  url=null #This is overloaded by the conf loaded from the bucket below and includes a socketTimeout query string param set to 30 seconds
   driver="org.postgresql.Driver"
   password=null
   username=null


### PR DESCRIPTION
### Why do we need this?
The contributions RDS restarted and caused members-data-api [to have an outage](https://docs.google.com/document/d/1JqPOrC0YGNJre6q6hx8gPzMd8R0qzWGqhoMjjybZj0U/edit) that it was unable to recover from due to hikari/jdbc/postgres not terminating the stale connections.

### The changes 

1) Reducing the connectionTimeout:
Any time jdbc is taking too long to connect to postgres the connection will be killed. We are taking a fail fast approach instead of allowing the limited number of connections in the pool to spend a long time waiting to establish a connection.

2) Adding socketTimeout:
_done via a queryString in the private config, due to play & hikari not directly supporting it_

This will mean that if the db is terminated & restarted any open connections to the old db instance will timeout resulting in hikari refreshing the connections in the pool. 

Further reading:
https://jdbc.postgresql.org/documentation/94/connect.html
https://github.com/brettwooldridge/HikariCP

### trello card/screenshot/json/related PRs etc

https://trello.com/c/BtykG7Vr/1825-members-data-api-issues-with-contributions-store-should-not-cause-requests-to-fail
