### PR TITLE
upgrading version of identity client to fix a bug in http4s

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val awsClientVersion = "1.11.286"
   //libraries
   val sentryLogback = "io.sentry" % "sentry-logback" % "1.7.5"
-  val identityAuth = "com.gu.identity" %% "identity-auth-play" % "3.184"
+  val identityAuth = "com.gu.identity" %% "identity-auth-play" % "3.195"
   val identityTestUsers =  "com.gu" %% "identity-test-users" % "0.7"
   val postgres =  "org.postgresql" % "postgresql" % "42.2.1"
   val jdbc = PlayImport.jdbc


### PR DESCRIPTION
### Why do we need this?

upgrading version of identity client to fix a bug in http4s
See the following for more details https://github.com/guardian/identity/pull/1682