### PR TITLE
change 5XX Alarm to ELB (rather than backend) and codify NoHealthyInstancesAlarm

### DIFF
--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -411,6 +411,68 @@ Resources:
             Unit: Count
           ReturnData: false
 
+  NoHealthyInstancesAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: CreateProdMonitoring
+    Properties:
+      AlarmActions:
+        - !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev'
+      AlarmName: !Sub No healthy instances for members-data-api in ${Stage}
+      MetricName: HealthyHostCount
+      Namespace: AWS/ELB
+      Dimensions:
+          - Name: LoadBalancerName
+            Value: !Ref LoadBalancer
+      ComparisonOperator: LessThanOrEqualToThreshold
+      Threshold: 0.5
+      Period: 60
+      EvaluationPeriods: 10
+      Statistic: Average
+    DependsOn:
+      - LoadBalancer
+
+  High5XXRateAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: CreateProdMonitoring
+    Properties:
+      AlarmActions:
+        - !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev'
+      AlarmName: !Sub High 5XX rate for members-data-api in ${Stage}
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Threshold: 10
+      EvaluationPeriods: 1
+      TreatMissingData: notBreaching
+      Metrics:
+        - Id: total5XX
+          Expression: backend5XX + elb5XX
+          Label: "Count of Backend AND ELB 5XX"
+        - Id: backend5XX
+          MetricStat:
+            Metric:
+              Namespace: AWS/ELB
+              MetricName: HTTPCode_Backend_5XX
+              Dimensions:
+                - Name: LoadBalancerName
+                  Value: !Ref LoadBalancer
+            Period: 300
+            Stat: Sum
+            Unit: Count
+          ReturnData: false
+        - Id: elb5XX
+          MetricStat:
+            Metric:
+              Namespace: AWS/ELB
+              MetricName: HTTPCode_ELB_5XX
+              Dimensions:
+                - Name: LoadBalancerName
+                  Value: !Ref LoadBalancer
+            Period: 300 # ELB sample rate appears to not work with a Period of 60 (i.e. 1min)
+            Stat: Sum
+            Unit: Count
+          ReturnData: false
+    DependsOn:
+      - LoadBalancer
+
 Outputs:
   LoadBalancerUrl:
     Value:


### PR DESCRIPTION
We had an [incident recently](https://docs.google.com/document/d/1JqPOrC0YGNJre6q6hx8gPzMd8R0qzWGqhoMjjybZj0U/edit).

First off neither the 'High 5XX' alarm or the 'No Healthy Instances' alarm were in the CloudFormation (manually created in AWS Console by the looks of it). So this PR adds those, with the same `Threshold`, `Period`, `EvaluationPeriods`, `ComparisonOperator` and `Statistic` as the existing.

**Crucially** though, the 5XX alarm now uses  the **SUM** of `HTTPCode_ELB_5XX` and `HTTPCode_Backend_5XX` because during the incident the backend was unresponsive so the ELB was serving `504 Gateway Timeout` to consumers/clients, but no alarm fired because it was based on `HTTPCode_Backend_5XX` count and the backend was unresponsive (OutOfMemory). See...
![image](https://user-images.githubusercontent.com/19289579/75031054-51f79480-549d-11ea-8e9b-e536743d521e.png)

There will be subsequent PRs for the other alarms improvements, just doing this one in isolation to keep the PR manageable. One of the subsequent PRs will be to adopt the naming convention of most of our other alarms, see https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk