### PR TITLE
delivery address : capture/store new 'Address_Change_Information_Last_Quoted__c'

### DIFF
--- a/membership-attribute-service/app/controllers/ContactController.scala
+++ b/membership-attribute-service/app/controllers/ContactController.scala
@@ -81,7 +81,8 @@ class ContactController(
         contactField("MailingCity", address.town) ++
         contactField("MailingState", address.region) ++
         contactField("MailingPostalCode", address.postcode) ++
-        contactField("MailingCountry", address.country)
+        contactField("MailingCountry", address.country) ++
+        contactField("Address_Change_Information_Last_Quoted__c", address.addressChangeInformation)
     }
     contactRepo.salesforce.Contact.update(SFContactId(contactId), contactFields)
   }

--- a/membership-attribute-service/app/models/DeliveryAddress.scala
+++ b/membership-attribute-service/app/models/DeliveryAddress.scala
@@ -9,7 +9,8 @@ case class DeliveryAddress(
     town: Option[String],
     region: Option[String],
     postcode: Option[String],
-    country: Option[String]
+    country: Option[String],
+    addressChangeInformation: Option[String]
 )
 
 object DeliveryAddress {
@@ -23,7 +24,8 @@ object DeliveryAddress {
       town = contact.mailingCity,
       region = contact.mailingState,
       postcode = contact.mailingPostcode,
-      country = contact.mailingCountry
+      country = contact.mailingCountry,
+      addressChangeInformation = None
     )
   }
 


### PR DESCRIPTION
## MUST be released after https://github.com/guardian/salesforce/pull/163

In order to...
- accurately report on self-service delivery address changes (vs CSR changes)
- send confirmation emails 
- provide visibility to CSRs of what effective dates had previously been quoted to users

We have a new field **`Address_Change_Information_Last_Quoted__c`** (see https://github.com/guardian/salesforce/pull/163) to contain such information (as one big string) which can be specified with **`addressChangeInformation`** on the PUT endpoint used for delivery address changes.