### PR TITLE
use username to check if test user

### DIFF
--- a/membership-attribute-service/app/actions/AuthAndBackendViaAuthLibAction.scala
+++ b/membership-attribute-service/app/actions/AuthAndBackendViaAuthLibAction.scala
@@ -15,7 +15,7 @@ class AuthAndBackendViaAuthLibAction(touchpointBackends: TouchpointBackends)(imp
     // The test config and the normal config are the same for IDAPI.
     touchpointBackends.normal.identityAuthService.user(request) map { user: Option[User] =>
 
-      val backendConf: TouchpointComponents = if (AddGuIdentityHeaders.isTestUser(user.flatMap(_.publicFields.displayName))) {
+      val backendConf: TouchpointComponents = if (AddGuIdentityHeaders.isTestUser(user.flatMap(_.publicFields.username))) {
         touchpointBackends.test
       } else {
         touchpointBackends.normal

--- a/membership-attribute-service/app/filters/AddGuIdentityHeaders.scala
+++ b/membership-attribute-service/app/filters/AddGuIdentityHeaders.scala
@@ -20,15 +20,15 @@ class AddGuIdentityHeaders(identityAuthService: IdentityAuthService) (implicit v
 }
 object AddGuIdentityHeaders {
 
-  //Identity checks for test users by first name
-  def isTestUser(displayName: Option[String]) =
-    displayName.flatMap(_.split(' ').headOption).exists(Config.testUsernames.isValid)
+  //Identity checks for test users by username
+  def isTestUser(username: Option[String]) =
+    username.exists(Config.testUsernames.isValid)
 
   def headersFor(request: RequestHeader, result: Result, identityAuthService: IdentityAuthService)(implicit ec: ExecutionContext): Future[Result] = {
     identityAuthService.user(request) map {
       case Some(user) => result.withHeaders(
         "X-Gu-Identity-Id" -> user.id,
-        "X-Gu-Membership-Test-User" -> isTestUser(user.publicFields.displayName).toString
+        "X-Gu-Membership-Test-User" -> isTestUser(user.publicFields.username).toString
       )
       case None => result
     }


### PR DESCRIPTION



<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->

We are removing the publicFields.displayName field for security reasons

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->

Username can be used instead to determine if a user is a test user.
Changes to the generate username endpoint will need to be released first

### trello card/screenshot/json/related PRs etc
