### PR TITLE
un-invoiced subs should be cancelled effective today

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.555"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.556"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.9"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.2"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"


### PR DESCRIPTION
_Utilising the new functionality in https://github.com/guardian/membership-common/pull/607, we can now choose to cancel a sub 'effective today'._

Un-invoiced subs would error when cancelling, because the default was to cancel effective `EndOfLastInvoicePeriod`... makes sense.

To **facilitate cancelling digipacks during trial period** (i.e. un-invoiced) we now cancel 'effective today' - which works nicely 🙂