### PR TITLE
expose `chargedThroughDate` on detailed response

### DIFF
--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -43,8 +43,7 @@ object AccountDetails {
         case _ => product.name // fallback
       }
 
-      val endDate = paymentDetails.chargedThroughDate
-        .getOrElse(paymentDetails.termEndDate)
+      val endDate = paymentDetails.chargedThroughDate.getOrElse(paymentDetails.termEndDate)
 
       val paymentMethod = paymentDetails.paymentMethod match {
         case Some(payPal: PayPalMethod) => Json.obj(
@@ -145,6 +144,7 @@ object AccountDetails {
             "nextPaymentPrice" -> paymentDetails.nextPaymentPrice,
             "nextPaymentDate" -> paymentDetails.nextPaymentDate,
             "lastPaymentDate" -> paymentDetails.lastPaymentDate,
+            "chargedThroughDate" -> paymentDetails.chargedThroughDate,
             "renewalDate" -> paymentDetails.termEndDate,
             "cancelledAt" -> paymentDetails.pendingCancellation,
             "subscriberId" -> paymentDetails.subscriberId, // TODO remove once nothing is using this key (same time as removing old deprecated endpoints)


### PR DESCRIPTION
The self-service cancellation flow for Voucher subscriptions in MMA is going to offer a choice of cancellation effective date, one of the options is `EndOfLastInvoicePeriod` and for usability we need to expose what that date will be (so they can make an informed choice). 

The Zuora date which is equivalent is `chargedThroughDate`, which fortunately we already have available, this PR exposes it on the detailed response.