### PR TITLE
fix cancellation errors (when chargedThroughDate > termEndDate)

### DIFF
--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -8,7 +8,7 @@ import com.gu.memsub.subsv2.reads.ChargeListReads._
 import com.gu.memsub.subsv2.reads.SubPlanReads
 import com.gu.memsub.subsv2.reads.SubPlanReads._
 import com.gu.memsub.subsv2.services.SubscriptionService
-import com.gu.memsub.subsv2.{FreeSubscriptionPlan, PaidChargeList, PaidSubscriptionPlan, Subscription, SubscriptionPlan}
+import com.gu.memsub.subsv2.{PaidChargeList, PaidSubscriptionPlan, Subscription, SubscriptionPlan}
 import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.SafeLogger._
 import com.gu.salesforce.SimpleContactRepository
@@ -98,11 +98,11 @@ class AccountController(commonActions: CommonActions, override val controllerCom
       val cancellationSteps = for {
         _ <- EitherT(tp.zuoraRestService.disableAutoPay(zuoraSubscription.accountId)).leftMap(message => s"Error while trying to disable AutoPay: $message")
         _ <- EitherT(tp.zuoraRestService.updateCancellationReason(zuoraSubscription.name, reason)).leftMap(message => s"Error while updating cancellation reason: $message")
-        subHasBeenInvoiced = zuoraSubscription.plans.list.exists{
-          case paidPlan: PaidSubscriptionPlan[_, _] => paidPlan.chargedThrough.isDefined
-          case _ => false
-        }
-        cancelResult <- EitherT(tp.zuoraRestService.cancelSubscription(zuoraSubscription.name, isEffectiveToday = !subHasBeenInvoiced)).leftMap(message => s"Error while cancelling subscription: $message")
+        maybeChargedThroughDate = zuoraSubscription.plans.list.flatMap{
+          case paidPlan: PaidSubscriptionPlan[_, _] => paidPlan.chargedThrough
+          case _ => None
+        }.headOption
+        cancelResult <- EitherT(tp.zuoraRestService.cancelSubscription(zuoraSubscription.name, zuoraSubscription.termEndDate, maybeChargedThroughDate)).leftMap(message => s"Error while cancelling subscription: $message")
       } yield cancelResult
 
       cancellationSteps.run.map {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.562"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.563"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.9"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.2"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"


### PR DESCRIPTION
#### Essentially make use of https://github.com/guardian/membership-common/pull/612

> When cancelling a sub where the `chargedThroughDate` is after the `termEndDate`, previously it would fail when using `cancellationPolicy: "EndOfLastInvoicePeriod"`...
> 
> > ![image](https://user-images.githubusercontent.com/19289579/81308142-5c2b3700-9079-11ea-8d15-3af513d741f4.png)
> 
> SO NOW, in this scenario, we renew the sub first to extend the term, immediately before the cancel call.

