### PR TITLE
Use vanialla Either in ScanamoFeatureToggleService

### DIFF
--- a/membership-attribute-service/app/prodtest/FeatureToggleDataUpdatedOnSchedule.scala
+++ b/membership-attribute-service/app/prodtest/FeatureToggleDataUpdatedOnSchedule.scala
@@ -8,7 +8,6 @@ import services.FeatureToggleService
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.DurationInt
-import scalaz.{-\/, \/-}
 
 class FeatureToggleDataUpdatedOnSchedule(featureToggleService: FeatureToggleService, stage: String)(implicit ec: ExecutionContext, system: ActorSystem) extends LazyLogging {
 
@@ -17,19 +16,17 @@ class FeatureToggleDataUpdatedOnSchedule(featureToggleService: FeatureToggleServ
     val defaultFeatureValues = ZuoraLookupFeatureData(TrafficPercentage = 0, ConcurrentZuoraCallThreshold = 10)
 
     ScheduledTask[ZuoraLookupFeatureData](featureName, defaultFeatureValues, 0.seconds, 30.seconds) {
-      featureToggleService.get(featureName) map { result =>
-        result match {
-          case \/-(feature) =>
-            val percentage = feature.TrafficPercentage.getOrElse(defaultFeatureValues.TrafficPercentage)
-            val threshold = feature.ConcurrentZuoraCallThreshold.getOrElse(defaultFeatureValues.ConcurrentZuoraCallThreshold)
-            logger.info(s"$featureName scheduled task set percentage to $percentage and zuora concurrency threshold to $threshold in $stage")
-            ZuoraLookupFeatureData(percentage, threshold)
-          case -\/(e) =>
-            logger.warn(s"Tried to update the percentage of traffic for $featureName and the zuora concurrency threshold, but that feature was not " +
-              s"found in the table. Setting traffic to ${defaultFeatureValues.TrafficPercentage}% and concurrency threshold to " +
-              s"${defaultFeatureValues.ConcurrentZuoraCallThreshold} in $stage. Error: $e")
-            defaultFeatureValues
-        }
+      featureToggleService.get(featureName) map {
+        case Right(feature) =>
+          val percentage = feature.TrafficPercentage.getOrElse(defaultFeatureValues.TrafficPercentage)
+          val threshold = feature.ConcurrentZuoraCallThreshold.getOrElse(defaultFeatureValues.ConcurrentZuoraCallThreshold)
+          logger.info(s"$featureName scheduled task set percentage to $percentage and zuora concurrency threshold to $threshold in $stage")
+          ZuoraLookupFeatureData(percentage, threshold)
+        case Left(e) =>
+          logger.warn(s"Tried to update the percentage of traffic for $featureName and the zuora concurrency threshold, but that feature was not " +
+            s"found in the table. Setting traffic to ${defaultFeatureValues.TrafficPercentage}% and concurrency threshold to " +
+            s"${defaultFeatureValues.ConcurrentZuoraCallThreshold} in $stage. Error: $e")
+          defaultFeatureValues
       }
     }
   }

--- a/membership-attribute-service/app/services/FeatureToggleService.scala
+++ b/membership-attribute-service/app/services/FeatureToggleService.scala
@@ -3,8 +3,7 @@ package services
 import models.FeatureToggle
 
 import scala.concurrent.Future
-import scalaz.\/
 
 trait FeatureToggleService extends HealthCheckableService {
-  def get(featureName: String): Future[\/[String, FeatureToggle]]
+  def get(featureName: String): Future[Either[String, FeatureToggle]]
 }

--- a/membership-attribute-service/app/services/ScanamoFeatureToggleService.scala
+++ b/membership-attribute-service/app/services/ScanamoFeatureToggleService.scala
@@ -8,26 +8,18 @@ import com.typesafe.scalalogging.LazyLogging
 import models.FeatureToggle
 
 import scala.concurrent.{ExecutionContext, Future}
-import scalaz.\/
-import scalaz.syntax.std.either._
-import scalaz.syntax.std.option._
 
 class ScanamoFeatureToggleService(client: AmazonDynamoDBAsync, table: String)(implicit executionContext: ExecutionContext) extends FeatureToggleService with LazyLogging {
 
   def checkHealth: Boolean = client.describeTable(table).getTable.getTableStatus == "ACTIVE"
 
-  private val scanamo = Table[FeatureToggle](table)
-  def run[T] = ScanamoAsync.exec[T](client) _
-
-  def get(featureName: String): Future[\/[String, FeatureToggle]] =
-    run(scanamo.get('FeatureName -> featureName).map { maybeFeatureToggle =>
-      val featureToggleDisjunction = maybeFeatureToggle map { featureToggleResult =>
-        featureToggleResult.disjunction.leftMap(DynamoReadError.describe)
-      }
-
-      val featureToggle = featureToggleDisjunction \/> "Feature toggle not found"
-
-      featureToggle.flatMap(identity)
+  def get(featureName: String): Future[Either[String, FeatureToggle]] =
+    ScanamoAsync.exec(client) {
+      Table[FeatureToggle](table)
+        .get('FeatureName -> featureName)
+        .map {
+          case Some(value) => value.left.map(DynamoReadError.describe)
+          case None => Left("Feature toggle not found")
+        }
     }
-    )
 }


### PR DESCRIPTION
Small PR to kick-off my work on https://trello.com/c/mRg9kV7T/1376-reduce-the-number-of-times-by-50-we-are-not-able-to-serve-entitlements-from-members-data-api

Whilst investigating Zuora concurrency limit handling code I stumbled against `ScanamoFeatureToggleService` and removed few indirections.