### PR TITLE
Increase Zuora rest client timeout

### DIFF
--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -65,7 +65,7 @@ class TouchpointComponents(stage: String)(implicit  system: ActorSystem, executi
   private lazy val zuoraSoapClient = new ClientWithFeatureSupplier(Set.empty, tpConfig.zuoraSoap, RequestRunners.futureRunner, RequestRunners.futureRunner)
   lazy val zuoraService = new ZuoraSoapService(zuoraSoapClient)
 
-  private lazy val zuoraRestClient = new SimpleClient[Future](tpConfig.zuoraRest, ZuoraRequestCounter.withZuoraRequestCounter(RequestRunners.configurableFutureRunner(60.seconds)))
+  private lazy val zuoraRestClient = new SimpleClient[Future](tpConfig.zuoraRest, ZuoraRequestCounter.withZuoraRequestCounter(RequestRunners.configurableFutureRunner(30.seconds)))
   lazy val zuoraRestService = new ZuoraRestService[Future]()(futureInstance(ec), zuoraRestClient)
 
   lazy val catalogRestClient = new SimpleClient[Future](tpConfig.zuoraRest, RequestRunners.configurableFutureRunner(60.seconds))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.563"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.564"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.9"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.2"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"


### PR DESCRIPTION
Part of https://trello.com/c/mRg9kV7T/1376-reduce-the-number-of-times-by-50-we-are-not-able-to-serve-entitlements-from-members-data-api

membership-common uses okhttp client which has 10 seconds default timeout. Increase timeout from 10 to 30 seconds to address following frequent error

```
java.net.SocketTimeoutException: timeout
	at okio.Okio$3.newTimeoutException(Okio.java:210)
	at okio.AsyncTimeout.exit(AsyncTimeout.java:288)
	at okio.AsyncTimeout$2.read(AsyncTimeout.java:242)
```

----

This PR also pulls the following unrelated membership-common change

https://github.com/guardian/membership-common/pull/613/files

This me just refreshing on how publishing membership-common library works.
