### PR TITLE
From EitherT[Future, A, Future[Option[B]]] to EitherT[Future, A, Option[B]]

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -49,8 +49,10 @@ class AttributeController(
       )
     } else {
       metrics.put(s"cache-hit", 1)
-      val attributes: Future[Option[Attributes]] = dynamoService.get(identityId).map(maybeDynamoAttributes => maybeDynamoAttributes.map(DynamoAttributes.asAttributes(_, None)))(executionContext)
-      attributes.map(("Dynamo - too many concurrent calls to Zuora", _))(executionContext)
+      dynamoService
+        .get(identityId)
+        .map(maybeDynamoAttributes => maybeDynamoAttributes.map(DynamoAttributes.asAttributes(_, None)))(executionContext)
+        .map(("Dynamo - too many concurrent calls to Zuora", _))(executionContext)
     }
   }
 


### PR DESCRIPTION
Part of https://trello.com/c/mRg9kV7T/1376-reduce-the-number-of-times-by-50-we-are-not-able-to-serve-entitlements-from-members-data-api

Rewrite 

```
EitherT[Future, String, Future[Option[ZuoraAttributes]]]
```

to 

```
EitherT[Future, String, Option[ZuoraAttributes]]
```

There is no need for inner `Future`.

---

This PR also removes `withTimer`. If we need to measure at this level, membership-common seems to have facilities for it. Also I could not find where are these values actually recorded - they do not seem to be in cloudwatch.