### PR TITLE
Inline logic to fetch attributes from zuora or cache

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -40,8 +40,8 @@ class AttributeController(
    * 1. Count Zuora concurrent requests
    * 1. Get the concurrency limit set in `AttributesFromZuoraLookup` dynamodb table
    * 1. If the count is greater than limit, then hit cache
-   * 1. If the count is less than limit, then hit Zuora if Zuora is healthy
-   * 1. If the count is less than limit, then hit cache if Zuora is unhealthy
+   * 1. If the count is less than limit and Zuora is healthy, then hit Zuora
+   * 1. If the count is less than limit and Zuora is unhealthy, then hit cache
    */
   def getAttributesWithConcurrencyLimitHandling(identityId: String) (implicit request: AuthenticatedUserAndBackendRequest[AnyContent]): Future[(String, Option[Attributes])] = {
     val dynamoService = request.touchpoint.attrService

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -40,7 +40,7 @@ class AttributeController(
 
     if (ZuoraRequestCounter.get < concurrentCallThreshold) {
       metrics.put(s"zuora-hit", 1)
-      getAttributes(
+      getAttributesFromZuoraWithCacheFallback(
         identityId = identityId,
         identityIdToAccounts = request.touchpoint.zuoraRestService.getAccounts,
         subscriptionsForAccountId = accountId => reads => request.touchpoint.subService.subscriptionsForAccountId[AnyPlan](accountId)(reads),

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -133,7 +133,7 @@ class AttributeControllerTest extends Specification with AfterAll with Mockito {
 
   private val controller = new AttributeController(new AttributesFromZuora(), commonActions, Helpers.stubControllerComponents(), FakePostgresService, FakeMobileSubscriptionService) {
     override val executionContext = scala.concurrent.ExecutionContext.global
-    override def pickAttributes(identityId: String)(implicit request: AuthenticatedUserAndBackendRequest[AnyContent]): Future[(String, Option[Attributes])] = Future {
+    override def getAttributesWithConcurrencyLimitHandling(identityId: String)(implicit request: AuthenticatedUserAndBackendRequest[AnyContent]): Future[(String, Option[Attributes])] = Future {
       if (identityId == validUserId || identityId == validEmployeeUser.id)
         ("Zuora", Some(testAttributes))
       else


### PR DESCRIPTION
No changes in behaviour in this PR. Just trying to make the logic easer to follow by having a single inlined for comprehension.

It seems the overall Zuora concurrency limit handling logic is as follows

1. Count Zuora concurrent requests 
1. Get the concurrency limit set in `AttributesFromZuoraLookup` dynamodb table
1. If the count is greater than limit, then hit cache
1. If the count is less than limit and Zuora is healthy, then hit Zuora
1. If the count is less than limit and Zuora is unhealthy, then hit cache