### PR TITLE
Mitigate new acquisitions not having anything in cache whilst Zuora times out by retrying Zuora call

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import actions._
+import akka.actor.ActorSystem
 import com.gu.memsub.subsv2.SubscriptionPlan.AnyPlan
 import loghandling.LoggingField.{LogField, LogFieldString}
 import loghandling.{DeprecatedRequestLogger, LoggingWithLogstashFields, ZuoraRequestCounter}
@@ -27,7 +28,7 @@ class AttributeController(
   override val controllerComponents: ControllerComponents,
   oneOffContributionDatabaseService: OneOffContributionDatabaseService,
   mobileSubscriptionService: MobileSubscriptionService
-) extends BaseController with LoggingWithLogstashFields {
+)(implicit system: ActorSystem) extends BaseController with LoggingWithLogstashFields {
   import attributesFromZuora._
   import commonActions._
   implicit val executionContext: ExecutionContext = controllerComponents.executionContext

--- a/membership-attribute-service/app/utils/FutureRetry.scala
+++ b/membership-attribute-service/app/utils/FutureRetry.scala
@@ -1,16 +1,16 @@
 package utils
 
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import akka.pattern.after
+import akka.actor.Scheduler
+
 /**
  * retry implementation from Scala Future contributor
  * https://gist.github.com/viktorklang/9414163
  */
 object FutureRetry {
-  import scala.concurrent.duration._
-  import scala.concurrent.ExecutionContext
-  import scala.concurrent.Future
-  import akka.pattern.after
-  import akka.actor.Scheduler
-
   /**
    * Given an operation that produces a T, returns a Future containing the result of T, unless an exception is thrown,
    * in which case the operation will be retried after _delay_ time, if there are more possible retries, which is configured through
@@ -20,5 +20,5 @@ object FutureRetry {
     op recoverWith { case _ if retries > 0 => after(delay, s)(retry(op, delay, retries - 1)) }
 
   def retry[T](op: => Future[T])(implicit ec: ExecutionContext, s: Scheduler): Future[T] =
-    retry(op, delay = 200.milliseconds, retries = 1)
+    retry(op, delay = 200.milliseconds, retries = 2)
 }

--- a/membership-attribute-service/app/utils/FutureRetry.scala
+++ b/membership-attribute-service/app/utils/FutureRetry.scala
@@ -1,0 +1,24 @@
+package utils
+
+/**
+ * retry implementation from Scala Future contributor
+ * https://gist.github.com/viktorklang/9414163
+ */
+object FutureRetry {
+  import scala.concurrent.duration._
+  import scala.concurrent.ExecutionContext
+  import scala.concurrent.Future
+  import akka.pattern.after
+  import akka.actor.Scheduler
+
+  /**
+   * Given an operation that produces a T, returns a Future containing the result of T, unless an exception is thrown,
+   * in which case the operation will be retried after _delay_ time, if there are more possible retries, which is configured through
+   * the _retries_ parameter. If the operation does not succeed and there is no retries left, the resulting Future will contain the last failure.
+   **/
+  def retry[T](op: => Future[T], delay: FiniteDuration, retries: Int)(implicit ec: ExecutionContext, s: Scheduler): Future[T] =
+    op recoverWith { case _ if retries > 0 => after(delay, s)(retry(op, delay, retries - 1)) }
+
+  def retry[T](op: => Future[T])(implicit ec: ExecutionContext, s: Scheduler): Future[T] =
+    retry(op, delay = 200.milliseconds, retries = 1)
+}

--- a/membership-attribute-service/app/wiring/AppLoader.scala
+++ b/membership-attribute-service/app/wiring/AppLoader.scala
@@ -53,6 +53,7 @@ class MyComponents(context: Context)
       Some(router),
       touchPointBackends.normal.identityAuthService
     )
+  implicit val system: ActorSystem = actorSystem
   val attributesFromZuora = new AttributesFromZuora()
 
   val dbService = {


### PR DESCRIPTION
See https://github.com/guardian/members-data-api/pull/451#discussion_r439428016

Implement retry at client level in membership-common for all requests is more difficult because 
it may not be safe to retry POST requests. 