### PR TITLE
Remove implicit conversion from Attribute to Result which caused inference problems

### DIFF
--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -146,9 +146,6 @@ object Attributes {
     .addNullableField("digitalSubscriptionExpiryDate", _.latestDigitalSubscriptionExpiryDate)
     .addField("showSupportMessaging", _.showSupportMessaging)
     .addField("contentAccess", _.contentAccess)
-
-  implicit def toResult(attrs: Attributes): Result =
-    Ok(Json.toJson(attrs))
 }
 
 case class MembershipAttributes(


### PR DESCRIPTION
Implicit conversions are discouraged. The addressed FIXME is one example. Remove

```
implicit def toResult(attrs: Attributes): Result =	
    Ok(Json.toJson(attrs))
```

---

Note typeclasses and extension methods are fine. Confusingly, all three are implemented using the underlying mechanism of implicits, but conceptually they are different things.
