### PR TITLE
expose new selfServiceCancellation object field on the detailed mma endpoint

### DIFF
--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -193,6 +193,7 @@ class AccountController(commonActions: CommonActions, override val controllerCom
       deliveryAddress = None,
       subscription = sub,
       paymentDetails = upToDatePaymentDetails,
+      billingCountry = accountSummary.billToContact.country,
       stripePublicKey = stripeService.publicKey,
       accountHasMissedRecentPayments = false,
       safeToUpdatePaymentMethod = true,
@@ -284,6 +285,7 @@ class AccountController(commonActions: CommonActions, override val controllerCom
       deliveryAddress = Some(DeliveryAddress.fromContact(contactAndSubscription.contact)),
       subscription = contactAndSubscription.subscription,
       paymentDetails = upToDatePaymentDetails,
+      billingCountry = accountSummary.billToContact.country,
       stripePublicKey = stripeService.publicKey,
       accountHasMissedRecentPayments =
         freeOrPaidSub.isRight &&

--- a/membership-attribute-service/app/models/SelfServiceCancellation.scala
+++ b/membership-attribute-service/app/models/SelfServiceCancellation.scala
@@ -20,43 +20,42 @@ object SelfServiceCancellation {
   private val ausPhone = "AUS"
   private val allPhones = List(ukRowPhone, usaPhone, ausPhone)
 
-  def apply(product: Product, billingCountry: Option[Country]): SelfServiceCancellation = {
+  def apply(product: Product, billingCountry: Option[Country]): SelfServiceCancellation = (product, billingCountry) match {
 
-    if(product.isInstanceOf[Product.Membership] || product.isInstanceOf[Product.Contribution]){
+    case (Product.Membership | Product.Contribution, _) =>
       SelfServiceCancellation(
         isAllowed = true,
         shouldDisplayEmail = true,
         phoneRegionsToDisplay = allPhones
       )
-    }
-    else if (billingCountry.contains(Country.UK)) {
+
+    case (_, Some(Country.UK)) =>
       SelfServiceCancellation(
         isAllowed = false,
         shouldDisplayEmail = false,
         phoneRegionsToDisplay = List(ukRowPhone)
       )
-    }
-    else if (billingCountry.contains(Country.US) || billingCountry.contains(Country.Canada)) {
+
+    case (_, Some(Country.US) | Some(Country.Canada)) =>
       SelfServiceCancellation(
         isAllowed = true,
         shouldDisplayEmail = true,
         phoneRegionsToDisplay = List(usaPhone)
       )
-    }
-    else if (billingCountry.contains(Country.Australia) || billingCountry.contains(Country.NewZealand)) {
+
+    case (_, Some(Country.Australia) | Some(Country.NewZealand)) =>
       SelfServiceCancellation(
         isAllowed = true,
         shouldDisplayEmail = true,
         phoneRegionsToDisplay = allPhones
       )
-    }
-    else { // ROW
+
+    case _ => // ROW
       SelfServiceCancellation(
         isAllowed = true,
         shouldDisplayEmail = true,
         phoneRegionsToDisplay = allPhones
       )
-    }
 
   }
 }

--- a/membership-attribute-service/app/models/SelfServiceCancellation.scala
+++ b/membership-attribute-service/app/models/SelfServiceCancellation.scala
@@ -1,0 +1,62 @@
+package models
+
+import com.gu.i18n.Country
+import com.gu.memsub.Product
+
+/*
+* this file aims to model https://docs.google.com/spreadsheets/d/1GydjiURBMRk8S_xD4iwbbIBpuXXYI5h3_M87DtRDV8I
+* */
+
+case class SelfServiceCancellation(
+  isAllowed: Boolean,
+  shouldDisplayEmail: Boolean,
+  phoneRegionsToDisplay: List[String]
+)
+
+object SelfServiceCancellation {
+
+  private val ukRowPhone = "UK & ROW"
+  private val usaPhone = "US"
+  private val ausPhone = "AUS"
+  private val allPhones = List(ukRowPhone, usaPhone, ausPhone)
+
+  def apply(product: Product, billingCountry: Option[Country]): SelfServiceCancellation = {
+
+    if(product.isInstanceOf[Product.Membership] || product.isInstanceOf[Product.Contribution]){
+      SelfServiceCancellation(
+        isAllowed = true,
+        shouldDisplayEmail = true,
+        phoneRegionsToDisplay = allPhones
+      )
+    }
+    else if (billingCountry.contains(Country.UK)) {
+      SelfServiceCancellation(
+        isAllowed = false,
+        shouldDisplayEmail = false,
+        phoneRegionsToDisplay = List(ukRowPhone)
+      )
+    }
+    else if (billingCountry.contains(Country.US) || billingCountry.contains(Country.Canada)) {
+      SelfServiceCancellation(
+        isAllowed = true,
+        shouldDisplayEmail = true,
+        phoneRegionsToDisplay = List(usaPhone)
+      )
+    }
+    else if (billingCountry.contains(Country.Australia) || billingCountry.contains(Country.NewZealand)) {
+      SelfServiceCancellation(
+        isAllowed = true,
+        shouldDisplayEmail = true,
+        phoneRegionsToDisplay = allPhones
+      )
+    }
+    else { // ROW
+      SelfServiceCancellation(
+        isAllowed = true,
+        shouldDisplayEmail = true,
+        phoneRegionsToDisplay = allPhones
+      )
+    }
+
+  }
+}


### PR DESCRIPTION
expose new selfServiceCancellation object field on the detailed `/user-attributes/me/mma` response which models https://docs.google.com/spreadsheets/d/1GydjiURBMRk8S_xD4iwbbIBpuXXYI5h3_M87DtRDV8I and will drive MMA

e.g. for a voucher 
![image](https://user-images.githubusercontent.com/19289579/85118061-ab878a00-b217-11ea-8851-0b18c455f6b1.png)

**_Current state of that spreadsheet at this point (that is modelled in this PR)..._**
![image](https://user-images.githubusercontent.com/19289579/85117344-a118c080-b216-11ea-8db4-67a5b4a1459a.png)
![image](https://user-images.githubusercontent.com/19289579/85117358-a5dd7480-b216-11ea-89d5-9e90c94f3e56.png)

