### PR TITLE
remove copy from payment failure alertText (as per TODO)

### DIFF
--- a/membership-attribute-service/app/services/PaymentFailureAlerter.scala
+++ b/membership-attribute-service/app/services/PaymentFailureAlerter.scala
@@ -78,8 +78,7 @@ object PaymentFailureAlerter extends LoggingWithLogstashFields {
           val fields = customFields(accountSummary.identityId, latestDate.toString(formatter), productName)
           logInfoWithCustomFields(s"Logging an alert for identityId: ${accountSummary.identityId} accountId: ${accountSummary.id}. Payment failed on ${latestDate.toString(formatter)}", fields)
 
-          //TODO remove the "Please check that the card details shown are up to date." part of the below string once manage-frontend is the only consumer of this.
-          s"Our attempt to take payment for your $productDescription failed on ${latestDate.toString(formatter)}. Please check that the card details shown are up to date."
+          s"Our attempt to take payment for your $productDescription failed on ${latestDate.toString(formatter)}."
         }
       }
     }

--- a/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
+++ b/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
@@ -43,7 +43,7 @@ class PaymentFailureAlerterTest(implicit ee: ExecutionEnv)  extends Specificatio
 
         val attemptDateTime = DateTime.now().minusDays(1)
         val formatter = DateTimeFormat.forPattern("d MMMM yyyy").withLocale(Locale.ENGLISH)
-        val expectedActionText = s"Our attempt to take payment for your Supporter membership failed on ${attemptDateTime.toString(formatter)}. Please check that the card details shown are up to date."
+        val expectedActionText = s"Our attempt to take payment for your Supporter membership failed on ${attemptDateTime.toString(formatter)}."
 
         result must be_==(Some(expectedActionText)).await
       }
@@ -53,7 +53,7 @@ class PaymentFailureAlerterTest(implicit ee: ExecutionEnv)  extends Specificatio
 
         val attemptDateTime = DateTime.now().minusDays(1)
         val formatter = DateTimeFormat.forPattern("d MMMM yyyy").withLocale(Locale.ENGLISH)
-        val expectedActionText = s"Our attempt to take payment for your contribution failed on ${attemptDateTime.toString(formatter)}. Please check that the card details shown are up to date."
+        val expectedActionText = s"Our attempt to take payment for your contribution failed on ${attemptDateTime.toString(formatter)}."
 
         result must be_==(Some(expectedActionText)).await
       }
@@ -63,7 +63,7 @@ class PaymentFailureAlerterTest(implicit ee: ExecutionEnv)  extends Specificatio
 
         val attemptDateTime = DateTime.now().minusDays(1)
         val formatter = DateTimeFormat.forPattern("d MMMM yyyy").withLocale(Locale.ENGLISH)
-        val expectedActionText = s"Our attempt to take payment for your Digital Pack failed on ${attemptDateTime.toString(formatter)}. Please check that the card details shown are up to date."
+        val expectedActionText = s"Our attempt to take payment for your Digital Pack failed on ${attemptDateTime.toString(formatter)}."
 
         result must be_==(Some(expectedActionText)).await
       }


### PR DESCRIPTION
As per age old TODO removed old (and incorrect for DD at least) `"Please check that the card details shown are up to date."` clause from the sentence returned by the API (as it was being replaced on the client anyway). 

_Accompanying client-side PR https://github.com/guardian/manage-frontend/pull/443_