### PR TITLE
Remove high frequency Zuora vs cache load meterics

### DIFF
--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -65,7 +65,7 @@ class TouchpointComponents(stage: String)(implicit  system: ActorSystem, executi
   private lazy val zuoraSoapClient = new ClientWithFeatureSupplier(Set.empty, tpConfig.zuoraSoap, RequestRunners.futureRunner, RequestRunners.futureRunner, zuoraMetrics)
   lazy val zuoraService = new ZuoraSoapService(zuoraSoapClient)
 
-  private lazy val zuoraRestClient = new SimpleClient[Future](tpConfig.zuoraRest, ZuoraRequestCounter.withZuoraRequestCounter(RequestRunners.configurableFutureRunner(30.seconds)), zuoraMetrics)
+  private lazy val zuoraRestClient = new SimpleClient[Future](tpConfig.zuoraRest, ZuoraRequestCounter.withZuoraRequestCounter(RequestRunners.configurableFutureRunner(30.seconds)))
   lazy val zuoraRestService = new ZuoraRestService[Future]()(futureInstance(ec), zuoraRestClient)
 
   lazy val catalogRestClient = new SimpleClient[Future](tpConfig.zuoraRest, RequestRunners.configurableFutureRunner(60.seconds))

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -52,7 +52,6 @@ class AttributeController(
     val dynamoService = request.touchpoint.attrService
 
     if (ZuoraRequestCounter.isZuoraConcurrentRequestLimitNotReached) {
-      metrics.put(s"zuora-hit", 1)
       getAttributesFromZuoraWithCacheFallback(
         identityId = identityId,
         identityIdToAccounts = request.touchpoint.zuoraRestService.getAccounts,
@@ -61,7 +60,6 @@ class AttributeController(
         paymentMethodForPaymentMethodId = paymentMethodId => request.touchpoint.zuoraRestService.getPaymentMethod(paymentMethodId.get)
       )
     } else {
-      metrics.put(s"cache-hit", 1)
       dynamoService
         .get(identityId)
         .map(maybeDynamoAttributes => maybeDynamoAttributes.map(DynamoAttributes.asAttributes(_, None)))(executionContext)


### PR DESCRIPTION
They need to be replaced with [Publishing Statistic Sets](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/publishingMetrics.html#publishingDataPoints1) because at 1000 per minutes they are expensive. This would entail probably an `Actor` with mutable state which puts the metrics to AWS periodically.


[withStatisticsValues](https://github.com/search?q=org%3Aguardian+withStatisticValues&type=Code)