### PR TITLE
Publish high frequency zuora count metrics on schedule

### DIFF
--- a/membership-attribute-service/app/monitoring/Metrics.scala
+++ b/membership-attribute-service/app/monitoring/Metrics.scala
@@ -1,9 +1,74 @@
 package monitoring
 
+import java.util.concurrent.ConcurrentHashMap
+
+import akka.actor.ActorSystem
+import com.amazonaws.services.cloudwatch.model.{MetricDatum, PutMetricDataRequest, StatisticSet}
 import com.gu.monitoring.CloudWatch
+import com.gu.monitoring.CloudWatch.cloudwatch
+import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
 
 case class Metrics(service: String) extends CloudWatch {
   val stage = Config.stage
   val application = Config.applicationName // This sets the namespace for Custom Metrics in AWS (see CloudWatch)
+}
+
+// Designed for high-frequency metrics, for example, 1000 per minute is about $450 per month
+final class ExpensiveMetrics(
+  val service: String
+)(implicit system: ActorSystem, ec: ExecutionContext) extends CloudWatch with LazyLogging {
+  logger.info("expensive - created instance")
+
+  val stage = Config.stage
+  val application = Config.applicationName
+
+  system.scheduler.schedule(0.seconds, 55.seconds)(publishAllMetrics())
+
+  import scala.collection.JavaConverters._
+  private val chm = new ConcurrentHashMap[String, Int]().asScala
+
+  def countRequest(key: String): Unit = {
+    chm.get(key) match {
+      case Some(value) => chm.update(key, value + 1)
+      case None => chm.update(key, 1)
+    }
+  }
+
+  private def resetCount(key: String) = chm.replace(key, 0)
+
+  private def publishAllMetrics(): Unit =
+    chm foreach { case (key, value) =>
+      putStatisticsSetCount(key, value)
+      val result = resetCount(key)
+      logger.info(s"expensive reset result $result")
+    }
+
+//  private def putStatisticsSetCount(name: String, count: Int): Unit = {
+//    logger.info(s"expensive metric: $name=$count")
+//    val stats = new StatisticSet()
+//      .withMaximum(1d)
+//      .withMinimum(1d)
+//      .withSampleCount(count.toDouble)
+//      .withSum(count.toDouble)
+//
+//    val metric = new MetricDatum()
+//      .withMetricName(name)
+//      .withUnit("Count")
+//      .withDimensions(mandatoryDimensions:_*)
+//      .withStatisticValues(stats)
+//
+//    val request = new PutMetricDataRequest().
+//      withNamespace(application)
+//      .withMetricData(metric)
+//
+//    cloudwatch.putMetricDataAsync(request, LoggingAsyncHandler)
+//  }
+
+  private def putStatisticsSetCount(name: String, count: Int) = {
+    put(name, count)
+  }
 }

--- a/membership-attribute-service/app/monitoring/Metrics.scala
+++ b/membership-attribute-service/app/monitoring/Metrics.scala
@@ -1,6 +1,7 @@
 package monitoring
 
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
 
 import akka.actor.ActorSystem
 import com.amazonaws.services.cloudwatch.model.{MetricDatum, PutMetricDataRequest, StatisticSet}
@@ -17,13 +18,44 @@ case class Metrics(service: String) extends CloudWatch {
   val application = Config.applicationName // This sets the namespace for Custom Metrics in AWS (see CloudWatch)
 }
 
+//// Designed for high-frequency metrics, for example, 1000 per minute is about $450 per month
+//final class ExpensiveMetrics(
+//  val service: String
+//)(implicit system: ActorSystem, ec: ExecutionContext) extends CloudWatch with LazyLogging {
+//  logger.info("expensive - created instance")
+//
+//  import scala.collection.JavaConverters._
+//  private val chm = new ConcurrentHashMap[String, Int]().asScala
+//
+//  val stage = Config.stage
+//  val application = Config.applicationName
+//
+//  system.scheduler.schedule(5.seconds, 60.seconds)(publishAllMetrics())
+//
+//  def countRequest(key: String): Unit = {
+//    chm.get(key) match {
+//      case Some(value) => chm.update(key, value + 1)
+//      case None => chm.update(key, 1)
+//    }
+//  }
+//
+//  private def resetCount(key: String) = chm.replace(key, 0)
+//
+//  private def publishAllMetrics(): Unit =
+//    chm foreach { case (key, value) =>
+//      put(key, value)
+//      resetCount(key)
+//    }
+//}
+
 // Designed for high-frequency metrics, for example, 1000 per minute is about $450 per month
 final class ExpensiveMetrics(
   val service: String
 )(implicit system: ActorSystem, ec: ExecutionContext) extends CloudWatch with LazyLogging {
   logger.info("expensive - created instance")
+
   import scala.collection.JavaConverters._
-  private val chm = new ConcurrentHashMap[String, Int]().asScala
+  private val chm = new ConcurrentHashMap[String, AtomicInteger]().asScala
 
   val stage = Config.stage
   val application = Config.applicationName
@@ -31,44 +63,14 @@ final class ExpensiveMetrics(
   system.scheduler.schedule(5.seconds, 60.seconds)(publishAllMetrics())
 
   def countRequest(key: String): Unit = {
-    chm.get(key) match {
-      case Some(value) => chm.update(key, value + 1)
-      case None => chm.update(key, 1)
-    }
+    chm.getOrElseUpdate(key, new AtomicInteger(1)).incrementAndGet()
   }
-
-  private def resetCount(key: String) = chm.replace(key, 0)
+  private def resetCount(key: String): Unit =
+    chm.getOrElseUpdate(key, new AtomicInteger(0)).set(0)
 
   private def publishAllMetrics(): Unit =
     chm foreach { case (key, value) =>
-      putStatisticsSetCount(key, value)
-      val result = resetCount(key)
-      logger.info(s"expensive reset result $result")
+      put(key, value.doubleValue())
+      resetCount(key)
     }
-
-//  private def putStatisticsSetCount(name: String, count: Int): Unit = {
-//    logger.info(s"expensive metric: $name=$count")
-//    val stats = new StatisticSet()
-//      .withMaximum(1d)
-//      .withMinimum(1d)
-//      .withSampleCount(count.toDouble)
-//      .withSum(count.toDouble)
-//
-//    val metric = new MetricDatum()
-//      .withMetricName(name)
-//      .withUnit("Count")
-//      .withDimensions(mandatoryDimensions:_*)
-//      .withStatisticValues(stats)
-//
-//    val request = new PutMetricDataRequest().
-//      withNamespace(application)
-//      .withMetricData(metric)
-//
-//    cloudwatch.putMetricDataAsync(request, LoggingAsyncHandler)
-//  }
-
-  private def putStatisticsSetCount(name: String, count: Int) = {
-    put(name, count)
-  }
-
 }

--- a/membership-attribute-service/app/monitoring/Metrics.scala
+++ b/membership-attribute-service/app/monitoring/Metrics.scala
@@ -2,14 +2,10 @@ package monitoring
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
-
 import akka.actor.ActorSystem
-import com.amazonaws.services.cloudwatch.model.{MetricDatum, PutMetricDataRequest, StatisticSet}
 import com.gu.monitoring.CloudWatch
-import com.gu.monitoring.CloudWatch.cloudwatch
 import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
-
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
@@ -18,53 +14,21 @@ case class Metrics(service: String) extends CloudWatch {
   val application = Config.applicationName // This sets the namespace for Custom Metrics in AWS (see CloudWatch)
 }
 
-//// Designed for high-frequency metrics, for example, 1000 per minute is about $450 per month
-//final class ExpensiveMetrics(
-//  val service: String
-//)(implicit system: ActorSystem, ec: ExecutionContext) extends CloudWatch with LazyLogging {
-//  logger.info("expensive - created instance")
-//
-//  import scala.collection.JavaConverters._
-//  private val chm = new ConcurrentHashMap[String, Int]().asScala
-//
-//  val stage = Config.stage
-//  val application = Config.applicationName
-//
-//  system.scheduler.schedule(5.seconds, 60.seconds)(publishAllMetrics())
-//
-//  def countRequest(key: String): Unit = {
-//    chm.get(key) match {
-//      case Some(value) => chm.update(key, value + 1)
-//      case None => chm.update(key, 1)
-//    }
-//  }
-//
-//  private def resetCount(key: String) = chm.replace(key, 0)
-//
-//  private def publishAllMetrics(): Unit =
-//    chm foreach { case (key, value) =>
-//      put(key, value)
-//      resetCount(key)
-//    }
-//}
-
-// Designed for high-frequency metrics, for example, 1000 per minute is about $450 per month
+// Designed for high-frequency metrics, for example, 1000 per minute is about $400 per month
 final class ExpensiveMetrics(
   val service: String
 )(implicit system: ActorSystem, ec: ExecutionContext) extends CloudWatch with LazyLogging {
-  logger.info("expensive - created instance")
-
   import scala.collection.JavaConverters._
-  private val chm = new ConcurrentHashMap[String, AtomicInteger]().asScala
+  private val chm = new ConcurrentHashMap[String, AtomicInteger]().asScala // keep it first in the constructor
 
   val stage = Config.stage
   val application = Config.applicationName
 
   system.scheduler.schedule(5.seconds, 60.seconds)(publishAllMetrics())
 
-  def countRequest(key: String): Unit = {
+  def countRequest(key: String): Unit =
     chm.getOrElseUpdate(key, new AtomicInteger(1)).incrementAndGet()
-  }
+
   private def resetCount(key: String): Unit =
     chm.getOrElseUpdate(key, new AtomicInteger(0)).set(0)
 

--- a/membership-attribute-service/app/monitoring/Metrics.scala
+++ b/membership-attribute-service/app/monitoring/Metrics.scala
@@ -22,14 +22,13 @@ final class ExpensiveMetrics(
   val service: String
 )(implicit system: ActorSystem, ec: ExecutionContext) extends CloudWatch with LazyLogging {
   logger.info("expensive - created instance")
+  import scala.collection.JavaConverters._
+  private val chm = new ConcurrentHashMap[String, Int]().asScala
 
   val stage = Config.stage
   val application = Config.applicationName
 
-  system.scheduler.schedule(0.seconds, 55.seconds)(publishAllMetrics())
-
-  import scala.collection.JavaConverters._
-  private val chm = new ConcurrentHashMap[String, Int]().asScala
+  system.scheduler.schedule(5.seconds, 60.seconds)(publishAllMetrics())
 
   def countRequest(key: String): Unit = {
     chm.get(key) match {
@@ -71,4 +70,5 @@ final class ExpensiveMetrics(
   private def putStatisticsSetCount(name: String, count: Int) = {
     put(name, count)
   }
+
 }


### PR DESCRIPTION
Designed for high-frequency metrics, for example, 1000 per minute is about $400 per month. Uses `ConcurrentHashMap[String, AtomicInteger]` to count concurrent requests in thread-safe manner and periodically publishes the sum.