### PR TITLE
Migrate to Salesforce auth without akka-agent

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.572"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.575"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.9"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.2"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"


### PR DESCRIPTION
Related PR: Related PR: https://github.com/guardian/membership-common/pull/619

members-data-api already has salesforce client connected to the healthcheck as a safety net:
https://github.com/guardian/members-data-api/blob/6daac40fc28865f6aefbdd4e1c3fa538d9cdb724/membership-attribute-service/app/services/SalesforceService.scala#L6
