### PR TITLE
Add Zuora accountId to detailed me/mma response

### DIFF
--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -198,7 +198,8 @@ class AccountController(commonActions: CommonActions, override val controllerCom
       accountHasMissedRecentPayments = false,
       safeToUpdatePaymentMethod = true,
       isAutoRenew = isAutoRenew,
-      alertText = alertText
+      alertText = alertText,
+      accountId = accountSummary.id.get
     ).toJson).run.run.map {
       case \/-(Some(result)) =>
         logger.info(s"Successfully retrieved payment details result for identity user: ${maybeUserId.mkString}")
@@ -292,7 +293,8 @@ class AccountController(commonActions: CommonActions, override val controllerCom
         accountHasMissedPayments(contactAndSubscription.subscription.accountId, accountSummary.invoices, accountSummary.payments),
       safeToUpdatePaymentMethod = safeToAllowPaymentUpdate(contactAndSubscription.subscription.accountId, accountSummary.invoices),
       isAutoRenew = isAutoRenew,
-      alertText = alertText
+      alertText = alertText,
+      accountId = accountSummary.id.get
     ).toJson).run.run.map {
       case \/-(subscriptionJSONs) =>
         logger.info(s"Successfully retrieved payment details result for identity user: ${maybeUserId.mkString}")

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -25,7 +25,8 @@ case class AccountDetails(
   accountHasMissedRecentPayments: Boolean,
   safeToUpdatePaymentMethod: Boolean,
   isAutoRenew: Boolean,
-  alertText: Option[String]
+  alertText: Option[String],
+  accountId: String
 )
 
 object AccountDetails {
@@ -170,7 +171,8 @@ object AccountDetails {
             ),
             "currentPlans" -> currentPlans.map(jsonifyPlan),
             "futurePlans" -> futurePlans.map(jsonifyPlan),
-            "readerType" -> accountDetails.subscription.readerType.value
+            "readerType" -> accountDetails.subscription.readerType.value,
+            "accountId" -> accountDetails.accountId
           )),
         ) ++ alertText.map(text => Json.obj("alertText" -> text)).getOrElse(Json.obj())
 


### PR DESCRIPTION
### Why do we need this?

This enables manage-frontend to send to Invoicing API an `accountId` to retrieve all invoices associated with the account. 

### The changes 

The field is added at the level of (Salesforce) `contactId` for example

```
[
  {
    "tier": "Guardian Weekly - Domestic",
    ...
    "subscription": {
      "contactId": "0033111111111QAP",
      "accountId": "2c9211111111111111111e3d"
...
```

### trello card

https://trello.com/c/ggqXe1rg/1492-goal-expose-invoices-for-the-billing-tab
