### PR TITLE
Calculate effective cancellation date

### DIFF
--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -15,7 +15,7 @@ import com.gu.salesforce.SimpleContactRepository
 import com.gu.services.model.PaymentDetails
 import com.gu.stripe.{Stripe, StripeService}
 import com.gu.zuora.api.RegionalStripeGateways
-import com.gu.zuora.rest.ZuoraRestService.{PaymentMethodId, cancelSubscriptionCommandWrites}
+import com.gu.zuora.rest.ZuoraRestService.PaymentMethodId
 import com.typesafe.scalalogging.LazyLogging
 import components.TouchpointComponents
 import loghandling.DeprecatedRequestLogger

--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -70,20 +70,23 @@ class AccountController(commonActions: CommonActions, override val controllerCom
   )
 
   /**
-   * Note this method only makes sense if subscription was fetched with charge-detail=current-segment
+   * fetched with /v1/subscription/{key}?charge-detail=current-segment which zeroes out all the non-active charges
    *
    * There are multiple scenarios
    *   - period between acquisition date and fulfilment date => None which indicates cancel now
    *     - usually contractEffectiveDate to customerAcceptanceDate, except in the case of Guardian Weekly+6for6
    *       where customerAcceptanceDate indicates start of GW proper invoiced period instead of start of 6for6
    *       invoiced period despite GW+6for6 being just a regular Subscription with multiple products.
-   *     - free trial or user choose start date of first issue in the future
+   *     - free trial, or user choose start date of first issue in the future (lead time)
    *   - Subscription within invoiced period proper => Some(endOfLastInvoicePeriod)
-   *   - non-paid product => None which indicates cancel now
+   *   - free product => None which indicates cancel now
    *   - edge case of being on the first day of invoice period however bill run has not yet happened => ERROR
    *   - Today is after end of last invoice date and bill run has already completed => ERROR
-   *  fetched with /v1/subscription/{key}?charge-detail=current-segment
-   * @return None indicates cancel now, Some indicates cancel at end of last invoiced period
+   *
+   * @return
+   *   Right(None) indicates cancel now,
+   *   Right(Some("yyyy-mm-dd")) indicates cancel at end of last invoiced period
+   *   Left indicates error and MMA should not proceed with automatic cancelation
    */
   private def calculateEffectiveCancellationDate[P <: SubscriptionPlan.AnyPlan : SubPlanReads](
     identityId: String,
@@ -98,8 +101,7 @@ class AccountController(commonActions: CommonActions, override val controllerCom
         val billRunHasAlreadyHappened = now.isAfter(LocalTime.parse("12:00"))
 
         paidPlans match {
-          case paidPlan1 :: paidPlan2 :: _ =>
-            \/.left("Failed to determine specific single active paid rate plan charge")
+          case paidPlan1 :: paidPlan2 :: _ => \/.left("Failed to determine specific single active paid rate plan charge")
 
           case paidPlan :: Nil => // single rate plan charge identified
             paidPlan.chargedThrough match {
@@ -110,7 +112,7 @@ class AccountController(commonActions: CommonActions, override val controllerCom
                 else
                   \/.right(CancellationEffectiveDate(subscriptionName,Some(endOfLastInvoicePeriod)))
               case None =>
-                if (paidPlan.start.equals(LocalDate.now()) && billRunHasAlreadyHappened) // if effectiveStartDate exists but not chargedThroughDate
+                if (paidPlan.start.equals(LocalDate.now()) && !billRunHasAlreadyHappened) // effectiveStartDate exists but not chargedThroughDate
                   \/.left(s"Invoiced period has started today, however Bill Run has not yet completed (it usually runs around 6am)")
                 else
                   \/.left(s"Unknown reason for missing chargedThroughDate. Investigate ASAP!")
@@ -122,6 +124,8 @@ class AccountController(commonActions: CommonActions, override val controllerCom
       none = \/.right(CancellationEffectiveDate(subscriptionName, Option.empty[LocalDate]))) // we are within period between acquisition date and fulfilment date so cancel now (lead time / free trial)
     )
   }
+
+  private def CancelError(details: String, code: Int): ApiError = ApiError("Failed to cancel subscription", details, code)
 
   def cancelSubscription[P <: SubscriptionPlan.AnyPlan : SubPlanReads](subscriptionName: memsub.Subscription.Name) = AuthAndBackendViaAuthLibAction.async { implicit request =>
     val tp = request.touchpoint
@@ -155,14 +159,12 @@ class AccountController(commonActions: CommonActions, override val controllerCom
 
     logger.info(s"Attempting to cancel contribution for $maybeUserId")
 
-    def CancelError(details: String, code: Int): ApiError = ApiError("Failed to cancel subscription", details, code)
-
     (for {
       identityId <- EitherT(Future.successful(maybeUserId \/> unauthorized))
       cancellationReason <- EitherT(handleInputBody(cancelForm))
       sfContact <- EitherT(tp.contactRepo.get(identityId).map(_.flatMap(_ \/> s"No Salesforce user: $identityId"))).leftMap(CancelError(_, 404))
       sfSub <- EitherT(tp.subService.current[P](sfContact).map(subscriptionSelector(Some(subscriptionName), s"Salesforce user $sfContact"))).leftMap(CancelError(_, 404))
-      accountId <- EitherT(Future.successful(if (sfSub.name == subscriptionName) \/-(sfSub.accountId) else -\/(s"$subscriptionName does not belong to $identityId"))).leftMap(CancelError(_, 503))
+      accountId <- EitherT(Future.successful(if (sfSub.name == subscriptionName) \/-(sfSub.accountId) else -\/(CancelError(s"$subscriptionName does not belong to $identityId", 503))))
       cancellationEffectiveDate <- calculateEffectiveCancellationDate[P](identityId, subscriptionName, tp).leftMap(CancelError(_, 500))
       cancellation <- EitherT(executeCancellation(cancellationEffectiveDate, cancellationReason, accountId, sfSub.termEndDate))
     } yield cancellation).run.map {

--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -246,7 +246,7 @@ class AccountController(commonActions: CommonActions, override val controllerCom
       accountSummary <- OptionEither.liftOption(tp.zuoraRestService.getAccount(sub.accountId).recover { case x => \/.left(s"error receiving account summary for subscription: ${sub.name} with account id ${sub.accountId}. Reason: $x") })
       stripeService = accountSummary.billToContact.country.map(RegionalStripeGateways.getGatewayForCountry).flatMap(tp.stripeServicesByPaymentGateway.get).getOrElse(tp.ukStripeService)
       alertText <- OptionEither.liftEitherOption(alertText(accountSummary, sub, getPaymentMethod))
-//      cancellationEffectiveDate <- OptionEither.liftOption(tp.zuoraRestService.getCancellationEffectiveDate(sub.name))
+      cancellationEffectiveDate <- OptionEither.liftOption(tp.zuoraRestService.getCancellationEffectiveDate(sub.name))
       isAutoRenew = sub.autoRenew
     } yield AccountDetails(
       contactId = contact.salesforceContactId,
@@ -261,8 +261,8 @@ class AccountController(commonActions: CommonActions, override val controllerCom
       safeToUpdatePaymentMethod = true,
       isAutoRenew = isAutoRenew,
       alertText = alertText,
-      accountId = accountSummary.id.get
-//      cancellationEffectiveDate
+      accountId = accountSummary.id.get,
+      cancellationEffectiveDate
     ).toJson).run.run.map {
       case \/-(Some(result)) =>
         logger.info(s"Successfully retrieved payment details result for identity user: ${maybeUserId.mkString}")

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -27,7 +27,7 @@ case class AccountDetails(
   isAutoRenew: Boolean,
   alertText: Option[String],
   accountId: String,
-  cancellationEffectiveDate: Option[String] = None
+  cancellationEffectiveDate: Option[String]
 )
 
 object AccountDetails {

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -26,7 +26,8 @@ case class AccountDetails(
   safeToUpdatePaymentMethod: Boolean,
   isAutoRenew: Boolean,
   alertText: Option[String],
-  accountId: String
+  accountId: String,
+  cancellationEffectiveDate: Option[String] = None
 )
 
 object AccountDetails {
@@ -172,7 +173,8 @@ object AccountDetails {
             "currentPlans" -> currentPlans.map(jsonifyPlan),
             "futurePlans" -> futurePlans.map(jsonifyPlan),
             "readerType" -> accountDetails.subscription.readerType.value,
-            "accountId" -> accountDetails.accountId
+            "accountId" -> accountDetails.accountId,
+            "cancellationEffectiveDate" -> cancellationEffectiveDate
           )),
         ) ++ alertText.map(text => Json.obj("alertText" -> text)).getOrElse(Json.obj())
 

--- a/membership-attribute-service/app/models/SelfServiceCancellation.scala
+++ b/membership-attribute-service/app/models/SelfServiceCancellation.scala
@@ -31,8 +31,8 @@ object SelfServiceCancellation {
 
     case (_, Some(Country.UK)) =>
       SelfServiceCancellation(
-        isAllowed = false,
-        shouldDisplayEmail = false,
+        isAllowed = true,
+        shouldDisplayEmail = true,
         phoneRegionsToDisplay = List(ukRowPhone)
       )
 

--- a/membership-attribute-service/app/models/SelfServiceCancellation.scala
+++ b/membership-attribute-service/app/models/SelfServiceCancellation.scala
@@ -31,8 +31,8 @@ object SelfServiceCancellation {
 
     case (_, Some(Country.UK)) =>
       SelfServiceCancellation(
-        isAllowed = true,
-        shouldDisplayEmail = true,
+        isAllowed = false,
+        shouldDisplayEmail = false,
         phoneRegionsToDisplay = List(ukRowPhone)
       )
 

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -8,7 +8,7 @@ GET         /user-attributes/me/mma                                             
 GET         /user-attributes/me/mma/:subscriptionName                           controllers.AccountController.paymentDetailsSpecificSub(subscriptionName: String)
 
 POST        /user-attributes/me/cancel/:subscriptionName                        controllers.AccountController.cancelSpecificSub(subscriptionName: String)
-GET         /user-attributes/me/cancel/:subscriptionName                        controllers.AccountController.decideCancellationEffectiveDate(subscriptionName: String)
+GET         /user-attributes/me/cancellation-date/:subscriptionName             controllers.AccountController.decideCancellationEffectiveDate(subscriptionName: String)
 
 POST        /user-attributes/me/contribution-update-amount/:subscriptionName    controllers.AccountController.updateAmountForSpecificContribution(subscriptionName: String)
 

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -8,6 +8,7 @@ GET         /user-attributes/me/mma                                             
 GET         /user-attributes/me/mma/:subscriptionName                           controllers.AccountController.paymentDetailsSpecificSub(subscriptionName: String)
 
 POST        /user-attributes/me/cancel/:subscriptionName                        controllers.AccountController.cancelSpecificSub(subscriptionName: String)
+GET         /user-attributes/me/cancel/:subscriptionName                        controllers.AccountController.decideCancellationEffectiveDate(subscriptionName: String)
 
 POST        /user-attributes/me/contribution-update-amount/:subscriptionName    controllers.AccountController.updateAmountForSpecificContribution(subscriptionName: String)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.584"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.1-SNAPSHOT"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.9"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.2"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.1-SNAPSHOT"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.585"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.9"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.2"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"


### PR DESCRIPTION
- https://trello.com/c/b8Rx4P6u/1642-manage-frontend-cancellation-flow-give-user-choice-of-date-of-cancellation-but-the-date-is-never-used-s
- https://trello.com/c/IIlIyWzB/1636-self-service-cancellation-effective-date-bug
- Related PR: https://github.com/guardian/membership-common/pull/629
- This should fix the bug with GW+6for6 where it would always return 6-for-6 end even if use was in GW proper period.
- Add `calculateEffectiveCancellationDate` method which tries to improve the logic of determining the state of the subscription is in today (free trial, lead time, invoiced period) by making use of `charge-detail=current-segment` approach. It decides EffectiveCancellationDate as Today or End of Last Invoice Period.
- MMA can `GET /user-attributes/me/cancel/:subscriptionName` to obtain the precise date decided by MDAPI to show the user, so there is no room for providing misleading information on MMA
- Add `cancellationEffectiveDate` to `/user-attributes/me/mma` response
