### PR TITLE
Revert cancellation flags

### DIFF
--- a/membership-attribute-service/app/models/SelfServiceCancellation.scala
+++ b/membership-attribute-service/app/models/SelfServiceCancellation.scala
@@ -31,8 +31,8 @@ object SelfServiceCancellation {
 
     case (_, Some(Country.UK)) =>
       SelfServiceCancellation(
-        isAllowed = true,
-        shouldDisplayEmail = true,
+        isAllowed = false,
+        shouldDisplayEmail = false,
         phoneRegionsToDisplay = List(ukRowPhone)
       )
 


### PR DESCRIPTION
Forgot to revert them in https://github.com/guardian/members-data-api/pull/472 after testing.