### PR TITLE
Differentiate anniversary from termEndDate

### DIFF
--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -196,11 +196,10 @@ object AccountDetails {
     start: LocalDate,
     today: LocalDate = LocalDate.now()
   ): LocalDate = {
-    @tailrec def loop(left: LocalDate): LocalDate = {
-      val right = left.plusYears(1)
-      if (today.isEqual(left)) right
-      else if (today.isAfter(left) && today.isBefore(right)) right
-      else loop(right)
+    @tailrec def loop(current: LocalDate): LocalDate = {
+      val next = current.plusYears(1)
+      if (today.isBefore(next)) next
+      else loop(next)
     }
     loop(start)
   }

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -2,7 +2,7 @@ package models
 import java.time.DayOfWeek
 import java.time.format.TextStyle
 import java.util.Locale
-
+import scala.annotation.tailrec
 import com.gu.i18n.Country
 import com.gu.memsub.subsv2.{PaidSubscriptionPlan, PaperCharges, Subscription, SubscriptionPlan}
 import com.gu.memsub.{GoCardless, PayPalMethod, PaymentCard, Product}
@@ -158,6 +158,7 @@ object AccountDetails {
             "lastPaymentDate" -> paymentDetails.lastPaymentDate,
             "chargedThroughDate" -> paymentDetails.chargedThroughDate,
             "renewalDate" -> paymentDetails.termEndDate,
+            "anniversaryDate" -> anniversary(startDate),
             "cancelledAt" -> paymentDetails.pendingCancellation,
             "subscriberId" -> paymentDetails.subscriberId, // TODO remove once nothing is using this key (same time as removing old deprecated endpoints)
             "subscriptionId" -> paymentDetails.subscriberId,
@@ -179,5 +180,28 @@ object AccountDetails {
         ) ++ alertText.map(text => Json.obj("alertText" -> text)).getOrElse(Json.obj())
 
     }
+  }
+
+  /**
+   * Note this is a different concept than termEndDate because termEndDate
+   * could be many years in the future. termEndDate models when Zuora will
+   * renew the subscription whilst anniversary indicates when another year
+   * will have passed since user started their subscription.
+   *
+   * @param start beginning of subscription timeline, perhaps customerAcceptanceDate
+   * @param today where we are on the timeline today
+   * @return next anniversary date of the subscription
+   */
+  def anniversary(
+    start: LocalDate,
+    today: LocalDate = LocalDate.now()
+  ): LocalDate = {
+    @tailrec def loop(left: LocalDate): LocalDate = {
+      val right = left.plusYears(1)
+      if (today.isEqual(left)) right
+      else if (today.isAfter(left) && today.isBefore(right)) right
+      else loop(right)
+    }
+    loop(start)
   }
 }

--- a/membership-attribute-service/test/models/AnniversaryDateTest.scala
+++ b/membership-attribute-service/test/models/AnniversaryDateTest.scala
@@ -5,16 +5,16 @@ import org.specs2.mutable.Specification
 
 class AnniversaryDateTest extends Specification {
   "anniversaryDate" should {
-    "if today is equal left then right" in {
+    "if today is equal to subscription start, then anniversary is exactly in one year" in {
       val actual = AccountDetails.anniversary(LocalDate.parse("2019-05-01"), LocalDate.parse("2019-05-01"))
       actual should_=== LocalDate.parse("2020-05-01")
     }
-    "if today is between left and right then right" in {
+    "if today is before next anniversary, then stop searching and return next anniversary date" in {
       val actual = AccountDetails.anniversary(LocalDate.parse("2019-05-01"), LocalDate.parse("2020-04-28"))
       actual should_=== LocalDate.parse("2020-05-01")
     }
 
-    "if today is outside left and right then eventually right" in {
+    "if next anniversary is many years from the subscription start, then keep moving year by year until today is just before next anniversary date" in {
       val actual = AccountDetails.anniversary(LocalDate.parse("2019-05-01"), LocalDate.parse("2025-05-01"))
       actual should_=== LocalDate.parse("2026-05-01")
     }

--- a/membership-attribute-service/test/models/AnniversaryDateTest.scala
+++ b/membership-attribute-service/test/models/AnniversaryDateTest.scala
@@ -1,0 +1,22 @@
+package models
+
+import org.joda.time.LocalDate
+import org.specs2.mutable.Specification
+
+class AnniversaryDateTest extends Specification {
+  "anniversaryDate" should {
+    "if today is equal left then right" in {
+      val actual = AccountDetails.anniversary(LocalDate.parse("2019-05-01"), LocalDate.parse("2019-05-01"))
+      actual should_=== LocalDate.parse("2020-05-01")
+    }
+    "if today is between left and right then right" in {
+      val actual = AccountDetails.anniversary(LocalDate.parse("2019-05-01"), LocalDate.parse("2020-04-28"))
+      actual should_=== LocalDate.parse("2020-05-01")
+    }
+
+    "if today is outside left and right then eventually right" in {
+      val actual = AccountDetails.anniversary(LocalDate.parse("2019-05-01"), LocalDate.parse("2025-05-01"))
+      actual should_=== LocalDate.parse("2026-05-01")
+    }
+  }
+}


### PR DESCRIPTION
### Why do we need this?

MMA has a concept of annual holiday limits, so we need to be able to model anniversary correctly. `termEndDate` is not sufficient because some subscriptions currently could have it many years in the future.

### The changes 

Adds `anniversaryDate` field to `me/mma` response


      "nextPaymentDate": "2020-09-19",
      "start": "2020-09-19",
      "renewalDate": "2022-09-11",
      "anniversaryDate": "2021-09-19",


### trello card/screenshot/json/related PRs etc

https://trello.com/c/PlKMGmbK/1652-unable-to-apply-holiday-stops-via-mma-if-termstartdate-is-far-enough-in-the-future