### PR TITLE
Recognise Digital Subscription gift accounts

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -58,6 +58,7 @@ class AttributeController(
         identityId = identityId,
         identityIdToAccounts = request.touchpoint.zuoraRestService.getAccounts,
         subscriptionsForAccountId = accountId => reads => request.touchpoint.subService.subscriptionsForAccountId[AnyPlan](accountId)(reads),
+        giftSubscriptionsForIdentityId = request.touchpoint.zuoraRestService.getGiftSubscriptionsFromIdentityId,
         dynamoAttributeService = dynamoService,
         paymentMethodForPaymentMethodId = paymentMethodId => request.touchpoint.zuoraRestService.getPaymentMethod(paymentMethodId.get)
       )

--- a/membership-attribute-service/app/services/AttributesFromZuora.scala
+++ b/membership-attribute-service/app/services/AttributesFromZuora.scala
@@ -7,10 +7,11 @@ import com.gu.memsub.subsv2.reads.SubPlanReads.anyPlanReads
 import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.SafeLogger._
 import com.gu.scanamo.error.DynamoReadError
-import com.gu.zuora.rest.ZuoraRestService.{AccountObject, GetAccountsQueryResponse, PaymentMethodId, PaymentMethodResponse}
+import com.gu.zuora.rest.ZuoraRestService.{AccountObject, GetAccountsQueryResponse, GiftSubscriptionsFromIdentityIdResponse, PaymentMethodId, PaymentMethodResponse}
 import loghandling.LoggingWithLogstashFields
 import models._
 import org.joda.time.{DateTime, LocalDate}
+
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 import scalaz.std.list._
@@ -25,6 +26,7 @@ class AttributesFromZuora(implicit val executionContext: ExecutionContext, syste
      identityId: String,
      identityIdToAccounts: String => Future[String \/ GetAccountsQueryResponse],
      subscriptionsForAccountId: AccountId => SubPlanReads[AnyPlan] => Future[Disjunction[String, List[Subscription[AnyPlan]]]],
+     giftSubscriptionsForIdentityId: String => Future[Disjunction[String, GiftSubscriptionsFromIdentityIdResponse]],
      paymentMethodForPaymentMethodId: PaymentMethodId => Future[\/[String, PaymentMethodResponse]],
      dynamoAttributeService: AttributeService,
      forDate: LocalDate = LocalDate.now(),

--- a/membership-attribute-service/app/services/AttributesFromZuora.scala
+++ b/membership-attribute-service/app/services/AttributesFromZuora.scala
@@ -56,7 +56,7 @@ class AttributesFromZuora(implicit val executionContext: ExecutionContext, syste
         }
 
     def userHasDigiSub(accountsWithSubscriptions: List[AccountWithSubscriptions]) =
-      accountsWithSubscriptions.flatMap(_.subscriptions).exists(_.asDigipack.isDefined) //TODO: is this reliable?
+      accountsWithSubscriptions.flatMap(_.subscriptions).exists(_.asDigipack.isDefined)
 
     lazy val getAttrFromZuora =
       for {
@@ -69,7 +69,7 @@ class AttributesFromZuora(implicit val executionContext: ExecutionContext, syste
           if(userHasDigiSub(subscriptions)) Future.successful(\/.right[String, List[GiftSubscriptionsFromIdentityIdRecord]](Nil))
           else giftSubscriptionsForIdentityId(identityId)
         )
-        giftAttributes = giftSubscriptions.headOption.map(record => ZuoraAttributes(identityId, DigitalSubscriptionExpiryDate = Some(record.TermEndDate))) //TODO: is identityId right?
+        giftAttributes = giftSubscriptions.headOption.map(record => ZuoraAttributes(identityId, DigitalSubscriptionExpiryDate = Some(record.TermEndDate)))
         maybeZAttributes <- EitherT(AttributesMaker.zuoraAttributes(identityId, subscriptions, paymentMethodForPaymentMethodId, forDate).map(\/.right[String, Option[ZuoraAttributes]]))
       } yield {
         val maybeAttributes = maybeZAttributes.orElse(giftAttributes).map(ZuoraAttributes.asAttributes(_))

--- a/membership-attribute-service/app/services/AttributesFromZuora.scala
+++ b/membership-attribute-service/app/services/AttributesFromZuora.scala
@@ -74,9 +74,9 @@ class AttributesFromZuora(implicit val executionContext: ExecutionContext, syste
           if(userHasDigiSub(subscriptions)) Future.successful(\/.right[String, List[GiftSubscriptionsFromIdentityIdRecord]](Nil))
           else giftSubscriptionsForIdentityId(identityId)
         )
-        maybeGiftAttributes = Option(giftSubscriptions)
+        maybeGiftAttributes = Some(giftSubscriptions.map(_.TermEndDate))
           .filter(_.nonEmpty)
-          .map(_.maxBy(_.TermEndDate.toDateTimeAtStartOfDay.getMillis).TermEndDate)
+          .map(_.maxBy(_.toDateTimeAtStartOfDay.getMillis))
           .map(date => ZuoraAttributes(identityId, DigitalSubscriptionExpiryDate = Some(date)))
         maybeRegularAttributes <- EitherT(AttributesMaker.zuoraAttributes(identityId, subscriptions, paymentMethodForPaymentMethodId, forDate).map(\/.right[String, Option[ZuoraAttributes]]))
       } yield {
@@ -198,7 +198,7 @@ class AttributesFromZuora(implicit val executionContext: ExecutionContext, syste
 
 object AttributesFromZuora {
   def mergeDigitalSubscriptionExpiryDate(regular: Option[ZuoraAttributes], gift: Option[ZuoraAttributes]) = {
-    val maybeExpiryDates = Option(
+    val maybeExpiryDates = Some(
       List(regular, gift).flatten.flatMap(_.DigitalSubscriptionExpiryDate)
     ).filter(_.nonEmpty)
 

--- a/membership-attribute-service/app/services/AttributesFromZuora.scala
+++ b/membership-attribute-service/app/services/AttributesFromZuora.scala
@@ -57,10 +57,11 @@ class AttributesFromZuora(implicit val executionContext: ExecutionContext, syste
           case Failure(e) => SafeLogger.error(scrub"Failed to retrieve attributes from cache for $identityId because $e")
         }
 
-    def userHasDigiSub(accountsWithSubscriptions: List[AccountWithSubscriptions]) = {
-      val subs = accountsWithSubscriptions.flatMap(_.subscriptions)
-      subs.exists(_.asDigipack.isDefined) || getSubsWhichIncludeDigitalPack(subs, LocalDate.now()).nonEmpty
-    }
+    def userHasDigiSub(accountsWithSubscriptions: List[AccountWithSubscriptions]) =
+      getSubsWhichIncludeDigitalPack(
+        accountsWithSubscriptions.flatMap(_.subscriptions),
+        LocalDate.now()
+      ).nonEmpty
 
     lazy val getAttrFromZuora =
       for {

--- a/membership-attribute-service/test/services/AttributesFromZuoraTest.scala
+++ b/membership-attribute-service/test/services/AttributesFromZuoraTest.scala
@@ -89,7 +89,7 @@ class AttributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
     size = accounts.size
   )
 
-  def nilGiftSubscriptionsFromIdentityId(identityId: String) = Future.successful(\/.right(GiftSubscriptionsFromIdentityIdResponse(Nil, 0)))
+  def nilGiftSubscriptionsFromIdentityId(identityId: String): Future[String \/ List[GiftSubscriptionsFromIdentityIdRecord]] = Future.successful(\/.right(Nil))
 
   override def before = {
     org.mockito.Mockito.reset(mockDynamoAttributesService)
@@ -117,7 +117,7 @@ class AttributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
         val termEndDate = new LocalDate(2021, 12, 1)
         val giftSubscriptionAttributes = Attributes(testId, DigitalSubscriptionExpiryDate = Some(termEndDate))
         def giftSubscriptionsFromIdentityId(identityId: String) =
-          Future.successful(\/.right(GiftSubscriptionsFromIdentityIdResponse(List(GiftSubscriptionsFromIdentityIdRecord("abc123", termEndDate)), 1)))
+          Future.successful(\/.right(List(GiftSubscriptionsFromIdentityIdRecord("abc123", termEndDate))))
 
         val attributes: Future[(String, Option[Attributes])] = attributesFromZuora.getAttributesFromZuoraWithCacheFallback(testId, identityIdToAccountIds, subscriptionFromAccountId, giftSubscriptionsFromIdentityId, paymentMethodResponseNoFailures, mockDynamoAttributesService, referenceDate)
         attributes must be_==("Zuora", Some(giftSubscriptionAttributes)).await

--- a/membership-attribute-service/test/testdata/SubscriptionTestData.scala
+++ b/membership-attribute-service/test/testdata/SubscriptionTestData.scala
@@ -4,6 +4,7 @@ import com.github.nscala_time.time.Implicits._
 import com.gu.i18n.Currency.GBP
 import com.gu.memsub.Benefit._
 import com.gu.memsub.Subscription.{ProductRatePlanChargeId, ProductRatePlanId, RatePlanId, _}
+import com.gu.memsub.subsv2.ReaderType.Gift
 import com.gu.memsub.subsv2._
 import com.gu.memsub.{Subscription => _, _}
 import org.joda.time.LocalDate
@@ -56,6 +57,7 @@ trait SubscriptionTestData {
   }
 
   val digipack = toSubscription(false)(NonEmptyList(digipackPlan(referenceDate, referenceDate + 1.year)))
+  val digipackGift = toSubscription(false)(NonEmptyList(digipackPlan(referenceDate, referenceDate + 1.year))).copy(readerType = Gift)
   val guardianWeekly = toSubscription(false)(NonEmptyList(guardianWeeklyPlan(referenceDate, referenceDate + 1.year)))
   val sunday = toSubscription(false)(NonEmptyList(paperPlan(referenceDate, referenceDate + 1.year)))
   val sundayPlus = toSubscription(false)(NonEmptyList(paperPlusPlan(referenceDate, referenceDate + 1.year)))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.1-SNAPSHOT"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.587"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.9"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.2"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.586"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.1-SNAPSHOT"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.9"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.2"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"


### PR DESCRIPTION
In order to recognise Digital Subscription gift subs in members-data-api we need to query Zuora for subs which are active and have the custom field GifteeIdentityId set to the id of the current user.

We also need to ensure that the purchaser of the gift is not interpreted as having a digital subscription. 

As background the way that Digital subscription gifts are represented in Zuora is as a regular gift sub with 
- `readerType = Gift` 
- `IdentityId` custom field set to the identity id of the purchaser
- `GifteeIdentityId` custom field set to the identity id of the person who has redeemed the gift code.

More details [here](https://docs.google.com/document/d/1tey3Px090ZaBwwOOvlCK6lbPl7MW_3MCJjqYer3NSeY/edit#)

This PR depends on https://github.com/guardian/membership-common/pull/631

### [Trello card](https://trello.com/c/25rECTtP/3355-update-members-data-api-to-recognise-gift-subs-80)

I have now tested this end to end by creating a new Digital Subscription gift, redeeming it and then viewing the members-data-api output which was
```json
// 20201013134252
// https://members-data-api.thegulocal.com/user-attributes/me

{
  "userId": "200003991",
  "digitalSubscriptionExpiryDate": "2021-10-14",
  "showSupportMessaging": false,
  "contentAccess": {
    "member": false,
    "paidMember": false,
    "recurringContributor": false,
    "digitalPack": true,
    "paperSubscriber": false,
    "guardianWeeklySubscriber": false
  }
}
```