### PR TITLE
Get recently cancelled subscriptions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -76,6 +76,7 @@ val api = app("membership-attribute-service")
   .settings(libraryDependencies ++= apiDependencies)
   .settings(routesGenerator := InjectedRoutesGenerator)
   .settings(
+    scalacOptions += "-Ypartial-unification",
     addCommandAlias("devrun", "run 9400"),
     addCommandAlias("batch-load", "runMain BatchLoader"),
     addCommandAlias("play-artifact", "riffRaffNotifyTeamcity")

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -33,50 +33,6 @@ case class AccountDetails(
 
 object AccountDetails {
 
-  def externalisePlanName(plan: SubscriptionPlan.AnyPlan): Option[String] = plan.product match {
-    case _: Product.Weekly => if(plan.name.contains("Six for Six")) Some("currently on '6 for 6'") else None
-    case _: Product.Paper => Some(plan.name.replace("+",  " plus Digital Subscription"))
-    case _ => None
-  }
-
-  def jsonifyPlan(plan: SubscriptionPlan.AnyPlan, subscription: Subscription[SubscriptionPlan.AnyPlan]): JsObject = {
-    Json.obj(
-      "name" -> externalisePlanName(plan),
-      "start" -> plan.start,
-      "end" -> plan.end,
-      // if the customer acceptance date is future dated (e.g. 6for6) then always display, otherwise only show if starting less than 30 days from today
-      "shouldBeVisible" -> (subscription.acceptanceDate.isAfter(now) || plan.start.isBefore(now.plusDays(30)))
-    ) ++ (plan match {
-      case paidPlan: PaidSubscriptionPlan[_, _] => Json.obj(
-        "chargedThrough" -> paidPlan.chargedThrough,
-        "amount" -> paidPlan.charges.price.prices.head.amount * 100,
-        "currency" -> paidPlan.charges.price.prices.head.currency.glyph,
-        "currencyISO" -> paidPlan.charges.price.prices.head.currency.iso,
-        "interval" -> paidPlan.charges.billingPeriod.noun,
-      )
-      case _ => Json.obj()
-    }) ++ (plan.charges match {
-      case paperCharges: PaperCharges => Json.obj("daysOfWeek" ->
-        paperCharges.dayPrices
-          .filterNot(_._2.isFree) // note 'Echo Legacy' rate plan has all days of week but some are zero price, this filters those out
-          .keys.toList
-          .map(_.dayOfTheWeekIndex)
-          .sorted
-          .map(DayOfWeek.of)
-          .map(_.getDisplayName(TextStyle.FULL, Locale.ENGLISH))
-      )
-      case _ => Json.obj()
-    })
-  }
-
-  def mmaCategoryFrom(product: Product): String = product match {
-    case _: Product.Paper => "subscriptions" // Paper includes GW 🤦‍
-    case _: Product.ZDigipack => "subscriptions"
-    case _: Product.Contribution => "contributions"
-    case _: Product.Membership => "membership"
-    case _ => product.name // fallback
-  }
-
   implicit class ResultLike(accountDetails: AccountDetails) extends LazyLogging {
 
     import accountDetails._
@@ -127,6 +83,41 @@ object AccountDetails {
         case _ => Json.obj()
       }
 
+
+      def externalisePlanName(plan: SubscriptionPlan.AnyPlan): Option[String] = plan.product match {
+        case _: Product.Weekly => if(plan.name.contains("Six for Six")) Some("currently on '6 for 6'") else None
+        case _: Product.Paper => Some(plan.name.replace("+",  " plus Digital Subscription"))
+        case _ => None
+      }
+
+      def jsonifyPlan(plan: SubscriptionPlan.AnyPlan) = Json.obj(
+        "name" -> externalisePlanName(plan),
+        "start" -> plan.start,
+        "end" -> plan.end,
+        // if the customer acceptance date is future dated (e.g. 6for6) then always display, otherwise only show if starting less than 30 days from today
+        "shouldBeVisible" -> (subscription.acceptanceDate.isAfter(now) || plan.start.isBefore(now.plusDays(30)))
+      ) ++ (plan match {
+        case paidPlan: PaidSubscriptionPlan[_, _] => Json.obj(
+          "chargedThrough" -> paidPlan.chargedThrough,
+          "amount" -> paidPlan.charges.price.prices.head.amount * 100,
+          "currency" -> paidPlan.charges.price.prices.head.currency.glyph,
+          "currencyISO" -> paidPlan.charges.price.prices.head.currency.iso,
+          "interval" -> paidPlan.charges.billingPeriod.noun,
+        )
+        case _ => Json.obj()
+      }) ++ (plan.charges match {
+        case paperCharges: PaperCharges => Json.obj("daysOfWeek" ->
+            paperCharges.dayPrices
+            .filterNot(_._2.isFree) // note 'Echo Legacy' rate plan has all days of week but some are zero price, this filters those out
+            .keys.toList
+            .map(_.dayOfTheWeekIndex)
+            .sorted
+            .map(DayOfWeek.of)
+            .map(_.getDisplayName(TextStyle.FULL, Locale.ENGLISH))
+        )
+        case _ => Json.obj()
+      })
+
       val sortedPlans = subscription.plans.list.sortBy(_.start.toDate)
       val currentPlans = sortedPlans.filter(plan => !plan.start.isAfter(now) && plan.end.isAfter(now))
       val futurePlans = sortedPlans.filter(plan => plan.start.isAfter(now))
@@ -175,8 +166,8 @@ object AccountDetails {
               "currencyISO" -> paymentDetails.plan.price.currency.iso,
               "interval" -> paymentDetails.plan.interval.mkString
             ),
-            "currentPlans" -> currentPlans.map(plan => jsonifyPlan(plan, subscription)),
-            "futurePlans" -> futurePlans.map(plan => jsonifyPlan(plan, subscription)),
+            "currentPlans" -> currentPlans.map(jsonifyPlan),
+            "futurePlans" -> futurePlans.map(jsonifyPlan),
             "readerType" -> accountDetails.subscription.readerType.value,
             "accountId" -> accountDetails.accountId,
             "cancellationEffectiveDate" -> cancellationEffectiveDate
@@ -206,6 +197,13 @@ object AccountDetails {
       else loop(next)
     }
     loop(start)
+  }
+  def mmaCategoryFrom(product: Product): String = product match {
+    case _: Product.Paper => "subscriptions" // Paper includes GW 🤦‍
+    case _: Product.ZDigipack => "subscriptions"
+    case _: Product.Contribution => "contributions"
+    case _: Product.Membership => "membership"
+    case _ => product.name // fallback
   }
 }
 

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -9,6 +9,7 @@ GET         /user-attributes/me/mma/:subscriptionName                           
 
 POST        /user-attributes/me/cancel/:subscriptionName                        controllers.AccountController.cancelSpecificSub(subscriptionName: String)
 GET         /user-attributes/me/cancellation-date/:subscriptionName             controllers.AccountController.decideCancellationEffectiveDate(subscriptionName: String)
+GET         /user-attributes/me/cancelled-subscriptions                         controllers.AccountController.cancelledSubscriptions()
 
 POST        /user-attributes/me/contribution-update-amount/:subscriptionName    controllers.AccountController.updateAmountForSpecificContribution(subscriptionName: String)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.1-SNAPSHOT"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.588"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.9"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.2"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.586"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.1-SNAPSHOT"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.9"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.2"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"


### PR DESCRIPTION
### Why do we need this?

Return subscriptions that have been cancelled and have completely ended in the last N months, so that MMA can nudge users to resubscribe.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->

* Related PR: https://github.com/guardian/membership-common/pull/632
* https://members-data-api.thegulocal.com/user-attributes/me/cancelled-subscriptions responds with minimal information necessary to render cancelled and finished products

```
[
  {
    "mmaCategory": "subscriptions",
    "tier": "Guardian Weekly - Domestic",
    "subscription": {
      "subscriptionId": "A-S00060454",
      "cancellationEffectiveDate": "2020-09-01",
      "start": "2020-03-20",
      "end": "2020-09-01",
      "readerType": "Direct",
      "accountId": "2c92c0f870c2be7e0170c4a8413a7474"
    }
  },
  ...
]
```
* One design principle here was to be careful that this exceptional feature is not introducing bugs or interfering with main business logic of current subscriptions. 
* Note I am using out-of-the-box `OptionT(EitherT(v))` instead of custom `ListEither.fromOptionEither(v)` used elsewhere

### trello card

* https://trello.com/c/5TTEKK6n/1587-expose-data-for-cancelled-products-for-3-months-after-cancellation-date-s
