### PR TITLE
Expose Digital Subscription giftees to MMA

### DIFF
--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -30,7 +30,7 @@ import models.{AccountDetails, ApiError, CancelledSubscription, ContactAndSubscr
 import org.joda.time.{LocalDate, LocalTime}
 import play.api.data.Form
 import play.api.data.Forms._
-import play.api.libs.json.{Format, JsObject, Json, __}
+import play.api.libs.json.{Json}
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 import scalaz.std.option._
 import scalaz.std.scalaFuture._
@@ -317,7 +317,7 @@ class AccountController(commonActions: CommonActions, override val controllerCom
     plan = PersonalPlan(
       name = giftSub.plan.productName,
       price = Price(0f, giftSub.plan.charges.currencies.head),
-      interval = BillingPeriod.Year.noun // is this correct? What should this mean? Should it be optional?
+      interval = BillingPeriod.Year.noun
     ),
     subscriberId = giftSub.name.get,
     remainingTrialLength = 0

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -58,7 +58,7 @@ class AttributeController(
         identityId = identityId,
         identityIdToAccounts = request.touchpoint.zuoraRestService.getAccounts,
         subscriptionsForAccountId = accountId => reads => request.touchpoint.subService.subscriptionsForAccountId[AnyPlan](accountId)(reads),
-        giftSubscriptionsForIdentityId = request.touchpoint.zuoraRestService.getGiftSubscriptionsFromIdentityId,
+        giftSubscriptionsForIdentityId = request.touchpoint.zuoraRestService.getGiftSubscriptionRecordsFromIdentityId,
         dynamoAttributeService = dynamoService,
         paymentMethodForPaymentMethodId = paymentMethodId => request.touchpoint.zuoraRestService.getPaymentMethod(paymentMethodId.get)
       )

--- a/membership-attribute-service/app/controllers/PaymentDetailMapper.scala
+++ b/membership-attribute-service/app/controllers/PaymentDetailMapper.scala
@@ -1,0 +1,47 @@
+package controllers
+
+import com.gu.memsub.{BillingPeriod, Price}
+import com.gu.memsub.services.PaymentService
+import com.gu.memsub.subsv2.ReaderType.Gift
+import com.gu.memsub.subsv2.{Subscription, SubscriptionPlan}
+import com.gu.services.model.PaymentDetails
+import com.gu.services.model.PaymentDetails.PersonalPlan
+import scalaz.{-\/, \/, \/-}
+
+import scala.concurrent.Future
+
+object PaymentDetailMapper {
+
+  def getGiftPaymentDetails(giftSub: Subscription[SubscriptionPlan.Paid]) = PaymentDetails(
+    pendingCancellation = giftSub.isCancelled,
+    chargedThroughDate = None,
+    startDate = giftSub.startDate,
+    customerAcceptanceDate = giftSub.startDate,
+    nextPaymentPrice = None,
+    lastPaymentDate = None,
+    nextPaymentDate = None,
+    termEndDate = giftSub.termEndDate,
+    pendingAmendment = false,
+    paymentMethod = None,
+    plan = PersonalPlan(
+      name = giftSub.plan.productName,
+      price = Price(0f, giftSub.plan.charges.currencies.head),
+      interval = BillingPeriod.Year.noun
+    ),
+    subscriberId = giftSub.name.get,
+    remainingTrialLength = 0
+  )
+
+  def paymentDetailsForSub(
+    maybeUserId: Option[String],
+    freeOrPaidSub: Subscription[SubscriptionPlan.Free] \/ Subscription[SubscriptionPlan.Paid],
+    paymentService: PaymentService
+  ): Future[PaymentDetails] = freeOrPaidSub match {
+    case \/-(giftSub) if giftSub.gifteeIdentityId == maybeUserId && giftSub.readerType == Gift =>
+      Future.successful(getGiftPaymentDetails(giftSub))
+    case \/-(paidSub)  =>
+      paymentService.paymentDetails(freeOrPaidSub, defaultMandateIdIfApplicable = Some(""))
+    case -\/(freeSub) => Future.successful(PaymentDetails(freeSub))
+  }
+
+}

--- a/membership-attribute-service/app/utils/OptionEither.scala
+++ b/membership-attribute-service/app/utils/OptionEither.scala
@@ -18,6 +18,11 @@ object OptionEither {
   def liftFutureEither[A](x: Option[A]): OptionT[FutureEither, A] =
     apply(Future.successful(\/.right[String,Option[A]](x)))
 
+  def liftFutureOption[A](future: Future[Option[A]])(implicit ex: ExecutionContext): OptionT[FutureEither, A] =
+    apply(future map { value: Option[A] =>
+      \/.right[String, Option[A]](value)
+    })
+
   def liftEitherOption[A](future: Future[A])(implicit ex: ExecutionContext): OptionT[FutureEither, A] = {
     apply(future map { value: A =>
       \/.right[String, Option[A]](Some(value))

--- a/membership-attribute-service/test/controllers/PaymentDetailMapperTest.scala
+++ b/membership-attribute-service/test/controllers/PaymentDetailMapperTest.scala
@@ -1,0 +1,88 @@
+package controllers
+
+import com.gu.memsub.services.PaymentService
+import com.gu.memsub.subsv2.{Subscription, SubscriptionPlan}
+import com.gu.services.model.PaymentDetails
+import org.joda.time.LocalDate
+import org.mockito.Mockito.when
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import scalaz.{-\/, \/, \/-}
+import testdata.SubscriptionTestData
+
+import scala.concurrent.Future
+
+class PaymentDetailMapperTest(implicit ee: ExecutionEnv) extends Specification with SubscriptionTestData with Mockito {
+
+  override def referenceDate = LocalDate.now()
+
+  "PaymentDetailMapper" should {
+    "recognise a giftee's gift subscription" in {
+      val mockPaymentService = mock[PaymentService]
+      PaymentDetailMapper.paymentDetailsForSub(
+        Some("12345"),
+        \/-(digipackGift),
+        mockPaymentService
+      ).map(
+        details => details mustEqual PaymentDetailMapper.getGiftPaymentDetails(digipackGift)
+      )
+    }
+
+    "recognise a gifter's gift subscription" in {
+      val mockPaymentService = mock[PaymentService]
+      val expectedPaymentDetails = PaymentDetails(digipackGift, None, None, None)
+
+      when(mockPaymentService.paymentDetails(
+        any[Subscription[SubscriptionPlan.Free] \/ Subscription[SubscriptionPlan.Paid]](),
+        any[Option[String]]()
+      )).thenReturn(
+        Future.successful(expectedPaymentDetails)
+      )
+
+      PaymentDetailMapper.paymentDetailsForSub(
+        Some("6789"),
+        \/-(digipack),
+        mockPaymentService
+      ).map(
+        details => details mustEqual expectedPaymentDetails
+      )
+    }
+
+    "recognise a regular digital subscription" in {
+      val mockPaymentService = mock[PaymentService]
+      val expectedPaymentDetails = PaymentDetails(digipack, None, None, None)
+
+      when(mockPaymentService.paymentDetails(
+        any[Subscription[SubscriptionPlan.Free] \/ Subscription[SubscriptionPlan.Paid]](),
+        any[Option[String]]()
+      )).thenReturn(
+        Future.successful(expectedPaymentDetails)
+      )
+
+      PaymentDetailMapper.paymentDetailsForSub(
+        Some("12345"),
+        \/-(digipack),
+        mockPaymentService
+      ).map(
+        details => details mustEqual expectedPaymentDetails
+      )
+    }
+
+    "recognise a free subscription" in {
+      val mockPaymentService = mock[PaymentService]
+      val expectedPaymentDetails = PaymentDetails(friend)
+
+      PaymentDetailMapper.paymentDetailsForSub(
+        Some("12345"),
+        -\/(friend),
+        mockPaymentService
+      ).map(
+        details => details mustEqual expectedPaymentDetails
+      )
+    }
+
+  }
+
+
+}

--- a/membership-attribute-service/test/services/AttributesFromZuoraTest.scala
+++ b/membership-attribute-service/test/services/AttributesFromZuoraTest.scala
@@ -116,7 +116,7 @@ class AttributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
         val termEndDate = new LocalDate(2021, 12, 1)
         val giftSubscriptionAttributes = Attributes(testId, DigitalSubscriptionExpiryDate = Some(termEndDate))
         def giftSubscriptionsFromIdentityId(identityId: String) =
-          Future.successful(\/.right(List(GiftSubscriptionsFromIdentityIdRecord("abc123", termEndDate))))
+          Future.successful(\/.right(List(GiftSubscriptionsFromIdentityIdRecord("name", "abc123", termEndDate))))
 
         val attributes: Future[(String, Option[Attributes])] = attributesFromZuora.getAttributesFromZuoraWithCacheFallback(testId, identityIdToAccountIds, subscriptionFromAccountId, giftSubscriptionsFromIdentityId, paymentMethodResponseNoFailures, mockDynamoAttributesService, referenceDate)
         attributes must be_==("Zuora", Some(giftSubscriptionAttributes)).await
@@ -128,9 +128,9 @@ class AttributesFromZuoraTest(implicit ee: ExecutionEnv) extends Specification w
         val giftSubscriptionAttributes = Attributes(testId, DigitalSubscriptionExpiryDate = Some(latestDate))
         def giftSubscriptionsFromIdentityId(identityId: String) =
           Future.successful(\/.right(List(
-            GiftSubscriptionsFromIdentityIdRecord("abc123", earliestDate),
-            GiftSubscriptionsFromIdentityIdRecord("abc123", latestDate),
-            GiftSubscriptionsFromIdentityIdRecord("abc123", earliestDate)
+            GiftSubscriptionsFromIdentityIdRecord("name", "abc123", earliestDate),
+            GiftSubscriptionsFromIdentityIdRecord("name", "abc123", latestDate),
+            GiftSubscriptionsFromIdentityIdRecord("name", "abc123", earliestDate)
           )))
 
         val attributes: Future[(String, Option[Attributes])] = attributesFromZuora.getAttributesFromZuoraWithCacheFallback(testId, identityIdToAccountIds, subscriptionFromAccountId, giftSubscriptionsFromIdentityId, paymentMethodResponseNoFailures, mockDynamoAttributesService, referenceDate)

--- a/membership-attribute-service/test/testdata/SubscriptionTestData.scala
+++ b/membership-attribute-service/test/testdata/SubscriptionTestData.scala
@@ -52,6 +52,7 @@ trait SubscriptionTestData {
       hasPendingFreePlan = false,
       plans = CovariantNonEmptyList(plans.head, plans.tail.toList),
       readerType = ReaderType.Direct,
+      gifteeIdentityId = None,
       autoRenew = true
     )
   }

--- a/membership-attribute-service/test/testdata/SubscriptionTestData.scala
+++ b/membership-attribute-service/test/testdata/SubscriptionTestData.scala
@@ -58,7 +58,8 @@ trait SubscriptionTestData {
   }
 
   val digipack = toSubscription(false)(NonEmptyList(digipackPlan(referenceDate, referenceDate + 1.year)))
-  val digipackGift = toSubscription(false)(NonEmptyList(digipackPlan(referenceDate, referenceDate + 1.year))).copy(readerType = Gift)
+  val digipackGift = toSubscription(false)(NonEmptyList(digipackPlan(referenceDate, referenceDate + 1.year)))
+    .copy(readerType = Gift, gifteeIdentityId = Some("12345"))
   val guardianWeekly = toSubscription(false)(NonEmptyList(guardianWeeklyPlan(referenceDate, referenceDate + 1.year)))
   val sunday = toSubscription(false)(NonEmptyList(paperPlan(referenceDate, referenceDate + 1.year)))
   val sundayPlus = toSubscription(false)(NonEmptyList(paperPlusPlan(referenceDate, referenceDate + 1.year)))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.1-SNAPSHOT"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.591"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.9"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.2"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val awsDynamo = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.589"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.1-SNAPSHOT"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.9"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "1.4.2"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"

--- a/start-api.sh
+++ b/start-api.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 cd $(dirname $0)
-sbt -Djava.awt.headless=true "project membership-attribute-service" "devrun"
+sbt -mem 2048 -Djava.awt.headless=true "project membership-attribute-service" "devrun"


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? 
Once we start selling Digital Subscription gifts we will want users to be able to view the details of these subs in the Manage My Account pages. 
Gift subs will already show up for the _purchaser_ of the subscription but not for the _giftee_, this PR adds that functionality.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
Digital Subscription gifts are represented in Zuora as a single subscription for both purchaser and redeemer (giftee) with a custom field `gifteeIdentityId` recording the identity id of the giftee. 
Therefore to work out whether a user is a DS giftee we need to query Zuora for subscriptions where the `gifteeIdentityId` matches the identity id of the currently logged in user.
This PR relies on [changes in membership-common](https://github.com/guardian/membership-common/pull/634)

### trello card/screenshot/json/related PRs etc
https://trello.com/c/vtkGm5Wm/3392-gifting-add-giftee-and-gifter-digital-subs-to-mma-members-data-api-changes
