### PR TITLE
add paper and gw attributes to dynamo cache write codepath

### DIFF
--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -100,6 +100,8 @@ object ZuoraAttributes {
 }
 
 case class DynamoAttributes(
+  // this is the dynamo READ model, the WRITE model is in ScanamoAttributeService
+  // if you update this you must make sure you are writing the relevant properties too!
   UserId: String,
   Tier: Option[String] = None,
   RecurringContributionPaymentPlan: Option[String] = None,

--- a/membership-attribute-service/app/services/ScanamoAttributeService.scala
+++ b/membership-attribute-service/app/services/ScanamoAttributeService.scala
@@ -59,6 +59,8 @@ class ScanamoAttributeService(client: AmazonDynamoDBAsync, table: String)(implic
       scanamoSetOpt('RecurringContributionPaymentPlan -> attributes.RecurringContributionPaymentPlan),
       scanamoSetOpt('MembershipJoinDate -> attributes.MembershipJoinDate),
       scanamoSetOpt('DigitalSubscriptionExpiryDate -> attributes.DigitalSubscriptionExpiryDate),
+      scanamoSetOpt('PaperSubscriptionExpiryDate -> attributes.PaperSubscriptionExpiryDate),
+      scanamoSetOpt('GuardianWeeklySubscriptionExpiryDate -> attributes.GuardianWeeklySubscriptionExpiryDate),
       Some(scanamoSet('TTLTimestamp, attributes.TTLTimestamp))
     ).flatten match {
       case first :: remaining =>


### PR DESCRIPTION
In 2018/2019 we removed support asks for GW and Paper subscribers in https://github.com/guardian/members-data-api/pull/363 and https://github.com/guardian/members-data-api/pull/346
However even after that we only store membership/rec-contribution/digisub status in the dynamo cache, so people who are GW/paper will see support messaging randomly depending whether it fetched from the cache or not (around half the time)

This has been the subject of a low level number of complaints about intermittent banners to userhelp.

it would be worse since cache hit ratios decreased aafter the gifting work was done

This PR adds the missing fields so that they end up in dynamo.  Plus a reminder comment in the relevant parts of the code.
There should probably be some refactoring or at least tests, to make this break sooner/louder if there is an issue.

This has been tested locally and writes correctly to dynamo after i took out a GW and paper in DEV.
![image](https://user-images.githubusercontent.com/7304387/100477127-5bbec000-30df-11eb-94b4-616cea93e191.png)
and reads correctly when I force it to hit the cache
```
INFO: 200004231 is a digital subscriber expiring 2999-01-01
INFO: 200004231 is a paper subscriber expiring 2021-11-27
INFO: 200004231 is a Guardian Weekly subscriber expiring 2021-11-27
INFO: 200004231 supports the guardian - Attributes(200004231,None,None,None,None,Some(2999-01-01),Some(2021-11-27),Some(2021-11-27),None,None) - found via Dynamo - too many concurrent calls to Zuora
```
resuling in the json
```json
{
   "userId":"200004231",
   "digitalSubscriptionExpiryDate":"2999-01-01",
   "paperSubscriptionExpiryDate":"2021-11-27",
   "guardianWeeklyExpiryDate":"2021-11-27",
   "showSupportMessaging":false,
   "contentAccess":{
      "member":false,
      "paidMember":false,
      "recurringContributor":false,
      "digitalPack":true,
      "paperSubscriber":true,
      "guardianWeeklySubscriber":true
  
```

There is a rumour that GW should not suppress support asks, but that can be a separate PR on this line of code: https://github.com/guardian/members-data-api/blob/26e95187feeb2431c705f75825d822453d2f4811/membership-attribute-service/app/models/Attributes.scala#L72