### PR TITLE
update sbt so that snyk monitor is available

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.12
+sbt.version=1.4.4


### PR DESCRIPTION
I have noticed that snyk is not checking this project since the branch was renamed to main!  This PR updates to SBT 1.4 so we get the snyk monitor dependency commands.  Once this is merged and teamcity is building using the snyk build step, we will find out the damage.