### PR TITLE
MMA fix for Digital Subscription gift subscriptions

### DIFF
--- a/membership-attribute-service/app/controllers/PaymentDetailMapper.scala
+++ b/membership-attribute-service/app/controllers/PaymentDetailMapper.scala
@@ -37,7 +37,7 @@ object PaymentDetailMapper {
     freeOrPaidSub: Subscription[SubscriptionPlan.Free] \/ Subscription[SubscriptionPlan.Paid],
     paymentService: PaymentService
   ): Future[PaymentDetails] = freeOrPaidSub match {
-    case \/-(giftSub) if giftSub.readerType == Gift && isGiftRedemption =>
+    case \/-(giftSub) if isGiftRedemption =>
       Future.successful(getGiftPaymentDetails(giftSub))
     case \/-(paidSub)  =>
       paymentService.paymentDetails(freeOrPaidSub, defaultMandateIdIfApplicable = Some(""))

--- a/membership-attribute-service/app/controllers/PaymentDetailMapper.scala
+++ b/membership-attribute-service/app/controllers/PaymentDetailMapper.scala
@@ -33,11 +33,11 @@ object PaymentDetailMapper {
   )
 
   def paymentDetailsForSub(
-    maybeUserId: Option[String],
+    isGiftRedemption: Boolean,
     freeOrPaidSub: Subscription[SubscriptionPlan.Free] \/ Subscription[SubscriptionPlan.Paid],
     paymentService: PaymentService
   ): Future[PaymentDetails] = freeOrPaidSub match {
-    case \/-(giftSub) if giftSub.gifteeIdentityId == maybeUserId && giftSub.readerType == Gift =>
+    case \/-(giftSub) if giftSub.readerType == Gift && isGiftRedemption =>
       Future.successful(getGiftPaymentDetails(giftSub))
     case \/-(paidSub)  =>
       paymentService.paymentDetails(freeOrPaidSub, defaultMandateIdIfApplicable = Some(""))

--- a/membership-attribute-service/app/models/ContactAndSubscription.scala
+++ b/membership-attribute-service/app/models/ContactAndSubscription.scala
@@ -6,5 +6,6 @@ import com.gu.salesforce.Contact
 
 case class ContactAndSubscription(
     contact: Contact,
-    subscription: Subscription[AnyPlan]
+    subscription: Subscription[AnyPlan],
+    isGiftRedemption: Boolean
 )

--- a/membership-attribute-service/test/controllers/PaymentDetailMapperTest.scala
+++ b/membership-attribute-service/test/controllers/PaymentDetailMapperTest.scala
@@ -21,7 +21,7 @@ class PaymentDetailMapperTest(implicit ee: ExecutionEnv) extends Specification w
     "recognise a giftee's gift subscription" in {
       val mockPaymentService = mock[PaymentService]
       PaymentDetailMapper.paymentDetailsForSub(
-        Some("12345"),
+        isGiftRedemption = true,
         \/-(digipackGift),
         mockPaymentService
       ).map(
@@ -41,7 +41,7 @@ class PaymentDetailMapperTest(implicit ee: ExecutionEnv) extends Specification w
       )
 
       PaymentDetailMapper.paymentDetailsForSub(
-        Some("6789"),
+        isGiftRedemption = false,
         \/-(digipack),
         mockPaymentService
       ).map(
@@ -61,7 +61,7 @@ class PaymentDetailMapperTest(implicit ee: ExecutionEnv) extends Specification w
       )
 
       PaymentDetailMapper.paymentDetailsForSub(
-        Some("12345"),
+        isGiftRedemption = false,
         \/-(digipack),
         mockPaymentService
       ).map(
@@ -74,7 +74,7 @@ class PaymentDetailMapperTest(implicit ee: ExecutionEnv) extends Specification w
       val expectedPaymentDetails = PaymentDetails(friend)
 
       PaymentDetailMapper.paymentDetailsForSub(
-        Some("12345"),
+        isGiftRedemption = false,
         -\/(friend),
         mockPaymentService
       ).map(


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
#481 had a bug which was that if a user both purchases and then redeems a DS gift subscription their `/mma` data will redact payment details from both the sub that represents them as a purchaser as well as one which represents them as a gifter. This is incorrect as we should retain the payment details for the purchaser sub.

This PR fixes this bug.



### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->

### trello card/screenshot/json/related PRs etc
### MMA page after the fix:
![Screen Shot 2020-12-01 at 10 54 22](https://user-images.githubusercontent.com/181371/100740086-08df5400-33d0-11eb-9d7a-b0e04e9a444c.png)
