### PR TITLE
update dependencies that cause snyk alerts

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,12 +3,12 @@ import play.sbt.PlayImport
 
 object Dependencies {
 
-  val awsClientVersion = "1.11.286"
+  val awsClientVersion = "1.11.909"
 
   val sentryLogback = "io.sentry" % "sentry-logback" % "1.7.5"
-  val identityAuth = "com.gu.identity" %% "identity-auth-play" % "3.195"
+  val identityAuth = "com.gu.identity" %% "identity-auth-play" % "3.235"
   val identityTestUsers = "com.gu" %% "identity-test-users" % "0.7"
-  val postgres = "org.postgresql" % "postgresql" % "42.2.1"
+  val postgres = "org.postgresql" % "postgresql" % "42.2.18"
   val jdbc = PlayImport.jdbc
   val playWS = PlayImport.ws
   val playFilters = PlayImport.filters
@@ -43,7 +43,8 @@ object Dependencies {
     kinesis,
     logstash,
     anorm,
-    "com.amazonaws" % "aws-java-sdk-autoscaling" % awsClientVersion
+    "com.amazonaws" % "aws-java-sdk-autoscaling" % awsClientVersion,
+    "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.10.6",
   )
 
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ logLevel := Level.Warn
 
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.4")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.7")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
 


### PR DESCRIPTION
This PR fixes the various snyk issues that were causing alerts.

https://app.snyk.io/org/the-guardian-cuu/project/eb14145e-93f0-4b8c-be32-9b40ad2a1300/

After, there is only a guava issue that has caused problems in the past as Medium Severity.  So better to address that in another PR.

Tested locally and works on /attributes/me

```
Issues with no direct upgrade or patch:
  ✗ Information Disclosure [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415] in com.google.guava:guava@27.1-jre
    introduced by com.gu:membership-attribute-service_2.12@1.0-SNAPSHOT > com.gu.identity:identity-auth-play_2.12@3.235 > com.typesafe.play:play_2.12@2.7.7 > com.google.guava:guava@27.1-jre and 7 other path(s)
  This issue was fixed in versions: 30.0-android, 30.0-jre
```