### PR TITLE
UAT stage is named CODE in instance count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dynamodb-local
 
 api/conf/keys.conf
 api/public/
+.bsp

--- a/membership-attribute-service/app/limit/InstanceCountOnSchedule.scala
+++ b/membership-attribute-service/app/limit/InstanceCountOnSchedule.scala
@@ -26,7 +26,7 @@ class InstanceCountOnSchedule(stage: String)(implicit ec: ExecutionContext, syst
       .getAutoScalingGroups
       .asScala
       .toList
-      .filter(_.getAutoScalingGroupName.startsWith(s"Memb-Attributes-$stage"))
+      .filter(_.getAutoScalingGroupName.startsWith(s"Memb-Attributes-${if (stage == "UAT") "CODE" else stage}"))
       .flatMap(_.getInstances.asScala)
       .filter(_.getHealthStatus == "Healthy")
       .filter(_.getLifecycleState == "InService")
@@ -37,12 +37,12 @@ class InstanceCountOnSchedule(stage: String)(implicit ec: ExecutionContext, syst
       Future(getCurrentNumberOfInstances(stage))
         .map { count =>
           if (count < 1) {
-            logger.error(s"There should be at least one healthy in-service instance. Failing to default value $defaultInstanceCount")
+            logger.error(s"There should be at least one healthy in-service instance in $stage. Failing to default value $defaultInstanceCount")
             defaultInstanceCount
           } else count
         }
         .recover { case e =>
-          logger.error(s"Failed to determine AWS instance count. Failing to default value $defaultInstanceCount", e)
+          logger.error(s"Failed to determine AWS instance count in $stage. Failing to default value $defaultInstanceCount", e)
           defaultInstanceCount
         }
     }


### PR DESCRIPTION
### Why do we need this? 

PROD logs were filled with false positive error message

```
ERROR: There should be at least one healthy in-service instance. Failing to default value 6
```

This error message actually pertained to CODE (as we switch "touchpoint" backends in PROD), and was caused by config `stage` set to `UAT`, however in AWS it is known as `CODE`. PROD was unaffected.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->

### trello card/screenshot/json/related PRs etc
