### PR TITLE
SSH via Session Manager SSM tunnel instead of port 22

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,3 +263,23 @@ Responses:
       "userId": "123",
       "membershipJoinDate": "2017-04-04"
     }
+    
+## SSH into instances
+
+`membership-attribute-service` is installed as systemd service via `.deb` package.
+
+Application instances allow SSH via SSM tunnel, not via port 22,
+ 
+1. Get fresh Janus credentials
+1. Find instance `prism -f instanceName attribute code`
+1. 1ssm ssh -x -i i-123456 --profile membership`
+
+| Description           | Command |
+| --------------------- | ------------------------------------------------------------------------ |
+| application directory | `/usr/share/membership-attribute-service`                                |
+| service config        | `/lib/systemd/system/membership-attribute-service.service`               |
+| application logs      | `/var/log/membership-attribute-service/membership-attribute-service.log` |
+| stdout/stderr logs    | `journalctl -u membership-attribute-service`                             |
+| service status        | `systemctl status membership-attribute-service`                          |
+| healthcheck           | `curl http://127.0.0.1:9000/healthcheck`                                 |
+

--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -296,12 +296,8 @@ Resources:
     Properties:
       VpcId:
         Ref: VpcId
-      GroupDescription: Open up HTTP access to load balancer, SSH to office
+      GroupDescription: Open up HTTP access to load balancer
       SecurityGroupIngress:
-      - IpProtocol: tcp
-        FromPort: '22'
-        ToPort: '22'
-        CidrIp: 77.91.248.0/21
       - IpProtocol: tcp
         FromPort: '9000'
         ToPort: '9000'

--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -153,6 +153,34 @@ Resources:
             Effect: Allow
       ManagedPolicyArns:
       - !Sub arn:aws:iam::${AWS::AccountId}:policy/guardian-ec2-role-for-ssm
+
+  SSMRunCommandPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: ssm-run-command-policy
+      PolicyDocument:
+        Statement:
+          # minimal policy to allow running commands via ssm
+          - Effect: Allow
+            Resource: "*"
+            Action:
+              - ec2messages:AcknowledgeMessage
+              - ec2messages:DeleteMessage
+              - ec2messages:FailMessage
+              - ec2messages:GetEndpoint
+              - ec2messages:GetMessages
+              - ec2messages:SendReply
+              - ssm:UpdateInstanceInformation
+              - ssm:ListInstanceAssociations
+              - ssm:DescribeInstanceProperties
+              - ssm:DescribeDocumentParameters
+              - ssmmessages:CreateControlChannel
+              - ssmmessages:CreateDataChannel
+              - ssmmessages:OpenControlChannel
+              - ssmmessages:OpenDataChannel
+      Roles:
+        - !Ref MembershipRole
+
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:


### PR DESCRIPTION
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->

- https://trello.com/c/11vqtW59/1645-replace-ssh-with-ssm-tunnelling
- [Session Manager launches tunneling support for SSH and SCP](https://aws.amazon.com/about-aws/whats-new/2019/07/session-manager-launches-tunneling-support-for-ssh-and-scp/)
- https://github.com/guardian/ssm-scala/pull/111
- See email `SSH like you've never seen it before`

> For a long time at the guardian it has been possible to SSH without opening up port 22 - so it should be removed from security groups on all infrastructure. Instead, we can use SSM tunnelling where your janus credentials are all you need to get onto an instance - no more messing round with the VPN!

### How to test?

1. Get fresh Janus credentials
1. Find instance `prism -f instanceName attribute code`
1. `ssm ssh -x -i i-123456 --profile membership`  

There were issues removing port 22 rule from Security group via CloudFormatoin on first [riffraff attempt](https://riffraff.gutools.co.uk/deployment/view/47f53300-a20b-43bd-b829-326e9217fd0b?verbose=1):

```
resource sg-e12345 has a dependent object (Service: AmazonEC2; Status Code: 400; Error Code: DependencyViolation; Request ID: ************; Proxy: null)
```

However the new security group without port 22 was created so on the next riffraff attempt it indeed succeeded and instances used the new security group. Since the old security group was not deleted it is necessary to manually clean up after confirming nothing depends on it anymore

- [How to determine AWS security group dependencies?](https://serverfault.com/questions/546012/how-to-determine-aws-security-group-dependencies)
- https://awssolutions.wordpress.com/2012/10/17/deleting-aws-security-group-error-has-a-dependant-job/
