### PR TITLE
write giftee attributes to dynamo, as well as direct

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -160,6 +160,7 @@ class AttributeController(
                 onSuccessSupporter(attrs)
               case None if sendAttributesIfNotFound =>
                 val attr = enrichZuoraAttributes(Attributes(user.id), latestOneOffDate, latestMobileSubscription)
+                log.logger.info(s"${user.id} does not have zuora attributes - $attr - found via $fromWhere")
                 Ok(Json.toJson(attr))
               case _ =>
                 onNotFound


### PR DESCRIPTION
This PR updates the attributes code so that a change in giftee status will update the dynamo attributes.

This means that giftees will get their benefits whether or not they are served from the cache or direct from zuora.  Previously they only came through from zuora.

https://trello.com/c/pWBlEksl/3561-members-data-api-gifting-intermittent-cache-issue