### PR TITLE
Use t4g.small instance type

### DIFF
--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -12,6 +12,7 @@ Parameters:
     AllowedValues:
     - t2.small
     - t3.small
+    - t4g.small
     ConstraintDescription: must be a valid EC2 instance type.
   VpcId:
     Description: ID of the VPC onto which to launch the application

--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -10,8 +10,6 @@ Parameters:
     Type: String
     Default: t3.small
     AllowedValues:
-    - t2.small
-    - t3.small
     - t4g.small
     ConstraintDescription: must be a valid EC2 instance type.
   VpcId:

--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -8,7 +8,7 @@ Parameters:
   InstanceType:
     Description: EC2 instance type
     Type: String
-    Default: t3.small
+    Default: t4g.small
     AllowedValues:
     - t4g.small
     ConstraintDescription: must be a valid EC2 instance type.

--- a/membership-attribute-service/conf/riff-raff.yaml
+++ b/membership-attribute-service/conf/riff-raff.yaml
@@ -7,7 +7,7 @@ deployments:
     parameters:
       templatePath: membership-attribute-service.yaml
       amiTags:
-        Recipe: xenial-membership
+        Recipe: bionic-membership-ARM
         AmigoStage: PROD
       amiEncrypted: true
       amiParameter: AmiId


### PR DESCRIPTION
Which is cheaper than the current t3.small:
![Screen Shot 2021-01-21 at 12 22 22](https://user-images.githubusercontent.com/1513454/105350609-56638a80-5be3-11eb-95cd-9631e6e25043.png)


The cpu use of members-data-api instances on t3.small is very flat:
![Screen Shot 2021-01-21 at 11 12 59](https://user-images.githubusercontent.com/1513454/105343864-19df6100-5bda-11eb-9fb5-4fcce4e7cb73.png)
![Screen Shot 2021-01-21 at 11 13 40](https://user-images.githubusercontent.com/1513454/105343948-32e81200-5bda-11eb-98f8-1ec74892f8da.png)
![Screen Shot 2021-01-21 at 11 14 14](https://user-images.githubusercontent.com/1513454/105343954-34b1d580-5bda-11eb-9f90-704ed4d3284b.png)


We just need to ensure that credit use does not increase significantly with t4g.

We had planned on running t3 and t4g at the same time within the same ASG, for a fairer comparison. But this gets messy because they need a separate AMI, and riffraff does not support this.