### PR TITLE
reduce instances to 3

### DIFF
--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -42,7 +42,7 @@ Mappings:
   StageVariables:
     PROD:
       MaxInstances: 12 # This should be (at least) double the desired capacity.
-      MinInstances: 6
+      MinInstances: 3
       NotificationAlarmPeriod: 1200
       InstanceName: PROD:membership-attribute-service
       DynamoDBTable: "Memb-Attributes-Tables-PROD-SupporterAttributesFallback"


### PR DESCRIPTION
We increased to 6 a while ago due to some big event possible trump election, but now we want to see if 3 is ok for the reservations.
The orignial PR doesn't have much information https://github.com/guardian/members-data-api/pull/344