### PR TITLE
Add reminder status endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,9 @@ dynamodb-local
 api/conf/keys.conf
 api/public/
 .bsp
+
+.bloop/
+.metals/
+.vscode/
+project/.bloop/
+project/metals.sbt

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -29,7 +29,7 @@ class AttributeController(
   attributesFromZuora: AttributesFromZuora,
   commonActions: CommonActions,
   override val controllerComponents: ControllerComponents,
-  oneOffContributionDatabaseService: OneOffContributionDatabaseService,
+  contributionsStoreDatabaseService: ContributionsStoreDatabaseService,
   mobileSubscriptionService: MobileSubscriptionService
 )(implicit system: ActorSystem) extends BaseController with LoggingWithLogstashFields {
   import attributesFromZuora._
@@ -76,7 +76,7 @@ class AttributeController(
     val userHasValidatedEmail = user.statusFields.userEmailValidated.getOrElse(false)
 
     if (userHasValidatedEmail) {
-      oneOffContributionDatabaseService.getLatestContribution(identityId) map {
+      contributionsStoreDatabaseService.getLatestContribution(identityId) map {
         case -\/(databaseError) =>
           //Failed to get one-off data, but this should not block the zuora request
           log.error(databaseError)
@@ -216,7 +216,7 @@ class AttributeController(
       if (userHasValidatedEmail) {
         request.user.map(_.id) match {
           case Some(identityId) =>
-            oneOffContributionDatabaseService.getAllContributions(identityId).map {
+            contributionsStoreDatabaseService.getAllContributions(identityId).map {
               case -\/(err) => Ok(err)
               case \/-(result) => Ok(Json.toJson(result).toString)
             }

--- a/membership-attribute-service/app/models/SupportReminders.scala
+++ b/membership-attribute-service/app/models/SupportReminders.scala
@@ -1,0 +1,40 @@
+package models
+
+import java.util.Date
+
+import anorm.{RowParser, Macro, Row, Success, ~}
+import play.api.libs.json.{Json, Writes}
+import org.scalactic.Bool
+
+sealed trait RecurringReminderStatus 
+
+
+object RecurringReminderStatus {
+  case object NotSet extends RecurringReminderStatus
+  case object Active extends RecurringReminderStatus
+  case object Cancelled extends RecurringReminderStatus
+
+  implicit val writes = new Writes[RecurringReminderStatus] {
+    def writes(status: RecurringReminderStatus) = status match {
+      case NotSet => Json.toJson("NotSet")
+      case Active => Json.toJson("Active")
+      case Cancelled => Json.toJson("Cancelled")
+    }
+  }
+}
+
+case class SupportReminderDb (
+  isCancelled: Boolean,
+)
+
+object SupportReminderDb {
+  val supportReminderDbRowParser: RowParser[SupportReminderDb] = Macro.indexedParser[SupportReminderDb]
+}
+
+case class SupportReminders (
+  recurringStatus: RecurringReminderStatus,
+)
+
+object SupportReminders {
+  implicit val jsWrite = Json.writes[SupportReminders]
+}

--- a/membership-attribute-service/app/services/ContributionsStoreDatabaseService.scala
+++ b/membership-attribute-service/app/services/ContributionsStoreDatabaseService.scala
@@ -4,25 +4,30 @@ import anorm._
 import com.typesafe.scalalogging.StrictLogging
 import models.ContributionData
 import play.api.db.Database
-import services.OneOffContributionDatabaseService.DatabaseGetResult
+import services.ContributionsStoreDatabaseService.DatabaseGetResult
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 import scalaz.\/
+import models.SupportReminders
+import models.SupportReminderDb
+import models.RecurringReminderStatus._
 
 
-trait OneOffContributionDatabaseService {
+trait ContributionsStoreDatabaseService {
   def getAllContributions(identityId: String): DatabaseGetResult[List[ContributionData]]
 
   def getLatestContribution(identityId: String): DatabaseGetResult[Option[ContributionData]]
+
+  def getSupportReminders(identityId: String): DatabaseGetResult[SupportReminders]
 }
 
-object OneOffContributionDatabaseService {
+object ContributionsStoreDatabaseService {
   type DatabaseGetResult[R] = Future[\/[String, R]]
 }
 
 class PostgresDatabaseService private (database: Database)(implicit ec: ExecutionContext)
-  extends OneOffContributionDatabaseService with StrictLogging {
+  extends ContributionsStoreDatabaseService with StrictLogging {
 
   private def executeQuery[R](statement: SimpleSql[Row], parser: ResultSetParser[R]): DatabaseGetResult[R] =
     Future(database.withConnection { implicit conn =>
@@ -56,6 +61,23 @@ class PostgresDatabaseService private (database: Database)(implicit ec: Executio
     val latestRowParser: ResultSetParser[Option[ContributionData]] = ContributionData.contributionRowParser.singleOpt
 
     executeQuery(statement, latestRowParser)
+  }
+
+  override def getSupportReminders(identityId: String): ContributionsStoreDatabaseService.DatabaseGetResult[SupportReminders] = {
+    val statement = SQL"""
+      SELECT reminder_cancelled_at IS NOT NULL as isCancelled
+      FROM recurring_reminder_signups
+      WHERE identity_id = $identityId
+    """
+    val rowParser: ResultSetParser[Option[SupportReminderDb]] = SupportReminderDb.supportReminderDbRowParser.singleOpt
+
+    executeQuery(statement, rowParser).map { result =>
+      result.map {
+        case Some(SupportReminderDb(true)) => SupportReminders(recurringStatus=Cancelled)
+        case Some(SupportReminderDb(false)) => SupportReminders(recurringStatus=Active)
+        case None => SupportReminders(recurringStatus=NotSet)
+      }
+    }
   }
 }
 

--- a/membership-attribute-service/app/wiring/AppLoader.scala
+++ b/membership-attribute-service/app/wiring/AppLoader.scala
@@ -70,7 +70,7 @@ class MyComponents(context: Context)
     new HealthCheckController(touchPointBackends, controllerComponents),
     new AttributeController(attributesFromZuora, commonActions, controllerComponents, dbService, mobileSubscriptionService),
     new ExistingPaymentOptionsController(commonActions, controllerComponents),
-    new AccountController(commonActions, controllerComponents),
+    new AccountController(commonActions, controllerComponents, dbService),
     new PaymentUpdateController(commonActions, controllerComponents),
     new ContactController(commonActions, controllerComponents)
   )

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -11,6 +11,8 @@ POST        /user-attributes/me/cancel/:subscriptionName                        
 GET         /user-attributes/me/cancellation-date/:subscriptionName             controllers.AccountController.decideCancellationEffectiveDate(subscriptionName: String)
 GET         /user-attributes/me/cancelled-subscriptions                         controllers.AccountController.cancelledSubscriptions()
 
+GET         /user-attributes/me/reminders                                       controllers.AccountController.reminders
+
 POST        /user-attributes/me/contribution-update-amount/:subscriptionName    controllers.AccountController.updateAmountForSpecificContribution(subscriptionName: String)
 
 POST        /user-attributes/me/update-card/:subscriptionName                   controllers.PaymentUpdateController.updateCard(subscriptionName: String)

--- a/membership-attribute-service/test/controllers/AccountControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AccountControllerTest.scala
@@ -6,13 +6,15 @@ import org.specs2.mutable.Specification
 import play.api.test.Helpers._
 import play.api.test._
 
+import services.FakePostgresService
+
 class AccountControllerTest extends Specification with Mockito {
 
   "validateContributionAmountUpdateForm" should {
 
     val subName = "s1"
     val commonActions = mock[CommonActions]
-    val controller = new AccountController(commonActions, stubControllerComponents())
+    val controller = new AccountController(commonActions, stubControllerComponents(), FakePostgresService)
     val request = FakeRequest("POST", s"/api/update/amount/contributions/$subName")
 
     "succeed when given value is valid" in {

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -17,12 +17,12 @@ import play.api.mvc._
 import play.api.test._
 import play.api.test.Helpers._
 import scalaz.\/
-import services.ContributionsStoreDatabaseService.DatabaseGetResult
-import services.{AttributesFromZuora, AuthenticationService, MobileSubscriptionService, ContributionsStoreDatabaseService}
+import services.{AttributesFromZuora, AuthenticationService, MobileSubscriptionService, FakePostgresService}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import models.SupportReminders
+import models.RecurringReminderStatus
 
 class AttributeControllerTest extends Specification with AfterAll with Mockito {
 
@@ -117,17 +117,6 @@ class AttributeControllerTest extends Specification with AfterAll with Mockito {
   private val commonActions = new CommonActions(touchpointBackends, stubParser)(scala.concurrent.ExecutionContext.global, ActorMaterializer()) {
     override val AuthAndBackendViaAuthLibAction = NoCacheAction andThen FakeAuthAndBackendViaAuthLibAction
     override def AuthAndBackendViaIdapiAction(howToHandleRecencyOfSignedIn: HowToHandleRecencyOfSignedIn)= NoCacheAction andThen FakeAuthAndBackendViaIdapiAction
-  }
-
-  object FakePostgresService extends ContributionsStoreDatabaseService {
-    def getAllContributions(identityId: String): DatabaseGetResult[List[ContributionData]] =
-      Future.successful(\/.right(Nil))
-
-    def getLatestContribution(identityId: String): DatabaseGetResult[Option[ContributionData]] =
-      Future.successful(\/.right(None))
-
-    def getSupportReminders(identityId: String): DatabaseGetResult[Option[SupportReminders]] =
-      Future.successful(\/.right(None))
   }
 
   object FakeMobileSubscriptionService extends MobileSubscriptionService {

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -17,11 +17,12 @@ import play.api.mvc._
 import play.api.test._
 import play.api.test.Helpers._
 import scalaz.\/
-import services.OneOffContributionDatabaseService.DatabaseGetResult
-import services.{AttributesFromZuora, AuthenticationService, MobileSubscriptionService, OneOffContributionDatabaseService}
+import services.ContributionsStoreDatabaseService.DatabaseGetResult
+import services.{AttributesFromZuora, AuthenticationService, MobileSubscriptionService, ContributionsStoreDatabaseService}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import models.SupportReminders
 
 class AttributeControllerTest extends Specification with AfterAll with Mockito {
 
@@ -118,11 +119,14 @@ class AttributeControllerTest extends Specification with AfterAll with Mockito {
     override def AuthAndBackendViaIdapiAction(howToHandleRecencyOfSignedIn: HowToHandleRecencyOfSignedIn)= NoCacheAction andThen FakeAuthAndBackendViaIdapiAction
   }
 
-  object FakePostgresService extends OneOffContributionDatabaseService {
+  object FakePostgresService extends ContributionsStoreDatabaseService {
     def getAllContributions(identityId: String): DatabaseGetResult[List[ContributionData]] =
       Future.successful(\/.right(Nil))
 
     def getLatestContribution(identityId: String): DatabaseGetResult[Option[ContributionData]] =
+      Future.successful(\/.right(None))
+
+    def getSupportReminders(identityId: String): DatabaseGetResult[Option[SupportReminders]] =
       Future.successful(\/.right(None))
   }
 

--- a/membership-attribute-service/test/services/FakeContributionsStoreDatabaseService.scala
+++ b/membership-attribute-service/test/services/FakeContributionsStoreDatabaseService.scala
@@ -1,0 +1,18 @@
+package services
+
+import scalaz.\/
+import scala.concurrent.Future
+import services.ContributionsStoreDatabaseService.DatabaseGetResult
+import models.{ContributionData, SupportReminders, RecurringReminderStatus}
+
+
+object FakePostgresService extends ContributionsStoreDatabaseService {
+    def getAllContributions(identityId: String): DatabaseGetResult[List[ContributionData]] =
+    Future.successful(\/.right(Nil))
+
+    def getLatestContribution(identityId: String): DatabaseGetResult[Option[ContributionData]] =
+        Future.successful(\/.right(None))
+
+    def getSupportReminders(identityId: String): DatabaseGetResult[SupportReminders] =
+        Future.successful(\/.right(SupportReminders(RecurringReminderStatus.NotSet)))
+}


### PR DESCRIPTION
## What? 
Add an endpoint at `/user-attributes/me/reminders` for getting information about a users reminders. Currently we just return info about their recurring reminder which can be one of: `NotSet`, `Active`, and `Cancelled`. This is used by MMA to display/hide a consent on the email preferences page that allows a user to cancel/reactivate a recurring reminder.

## Images
mma email-prefs page:
<img width="824" alt="Screenshot 2021-02-26 at 13 40 25" src="https://user-images.githubusercontent.com/17720442/109307807-16727180-7839-11eb-9c28-8708cb179eed.png">
