### PR TITLE
Return reminderCode from endpoint

### DIFF
--- a/membership-attribute-service/app/models/SupportReminders.scala
+++ b/membership-attribute-service/app/models/SupportReminders.scala
@@ -24,7 +24,8 @@ object RecurringReminderStatus {
 }
 
 case class SupportReminderDb (
-  isCancelled: Boolean,
+  is_cancelled: Boolean,
+  reminder_code: java.util.UUID,
 )
 
 object SupportReminderDb {
@@ -33,6 +34,7 @@ object SupportReminderDb {
 
 case class SupportReminders (
   recurringStatus: RecurringReminderStatus,
+  recurringReminderCode: Option[String],
 )
 
 object SupportReminders {

--- a/membership-attribute-service/app/services/ContributionsStoreDatabaseService.scala
+++ b/membership-attribute-service/app/services/ContributionsStoreDatabaseService.scala
@@ -65,7 +65,9 @@ class PostgresDatabaseService private (database: Database)(implicit ec: Executio
 
   override def getSupportReminders(identityId: String): ContributionsStoreDatabaseService.DatabaseGetResult[SupportReminders] = {
     val statement = SQL"""
-      SELECT reminder_cancelled_at IS NOT NULL as isCancelled
+      SELECT
+        reminder_cancelled_at IS NOT NULL as is_cancelled,
+        reminder_code
       FROM recurring_reminder_signups
       WHERE identity_id = $identityId
     """
@@ -73,9 +75,9 @@ class PostgresDatabaseService private (database: Database)(implicit ec: Executio
 
     executeQuery(statement, rowParser).map { result =>
       result.map {
-        case Some(SupportReminderDb(true)) => SupportReminders(recurringStatus=Cancelled)
-        case Some(SupportReminderDb(false)) => SupportReminders(recurringStatus=Active)
-        case None => SupportReminders(recurringStatus=NotSet)
+        case Some(SupportReminderDb(true, reminderCode)) => SupportReminders(recurringStatus=Cancelled, recurringReminderCode=Some(reminderCode.toString()))
+        case Some(SupportReminderDb(false, reminderCode)) => SupportReminders(recurringStatus=Active, recurringReminderCode=Some(reminderCode.toString()))
+        case None => SupportReminders(recurringStatus=NotSet, recurringReminderCode=None)
       }
     }
   }

--- a/membership-attribute-service/test/services/FakeContributionsStoreDatabaseService.scala
+++ b/membership-attribute-service/test/services/FakeContributionsStoreDatabaseService.scala
@@ -14,5 +14,5 @@ object FakePostgresService extends ContributionsStoreDatabaseService {
         Future.successful(\/.right(None))
 
     def getSupportReminders(identityId: String): DatabaseGetResult[SupportReminders] =
-        Future.successful(\/.right(SupportReminders(RecurringReminderStatus.NotSet)))
+        Future.successful(\/.right(SupportReminders(RecurringReminderStatus.NotSet, None)))
 }


### PR DESCRIPTION
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->

Return `recurringReminderCode` from the reminders endpoint for use by the MMA client to cancel/reactivate a reminder with the `support-reminders` service.

**DO NOT MERGE** until we update both the PROD databases with this new field.
