### PR TITLE
Add missing product rate plan ids to SupporterRatePlanToAttributesMapper

### DIFF
--- a/membership-attribute-service/app/services/AttributesFromZuora.scala
+++ b/membership-attribute-service/app/services/AttributesFromZuora.scala
@@ -71,7 +71,8 @@ class AttributesFromZuora(implicit val executionContext: ExecutionContext, syste
         LocalDate.now()
       ).nonEmpty
 
-    val futureSupporterProductDataAttributes = EitherT(supporterProductDataService.getAttributes(identityId))
+    // Disable this checking for now while I make some changes to the data store
+    // val futureSupporterProductDataAttributes = EitherT(supporterProductDataService.getAttributes(identityId))
 
     lazy val getAttrFromZuora =
       for {
@@ -89,12 +90,12 @@ class AttributesFromZuora(implicit val executionContext: ExecutionContext, syste
           .map(_.maxBy(_.toDateTimeAtStartOfDay.getMillis))
           .map(date => ZuoraAttributes(identityId, DigitalSubscriptionExpiryDate = Some(date)))
         maybeNonGifteeAttributes <- EitherT(AttributesMaker.zuoraAttributes(identityId, subscriptions, paymentMethodForPaymentMethodId, forDate).map(\/.right[String, Option[ZuoraAttributes]]))
-        supporterProductDataAttributes <- futureSupporterProductDataAttributes
+        // supporterProductDataAttributes <- futureSupporterProductDataAttributes
       } yield {
         val maybeGifteeAndNonGifteeAttributes = mergeDigitalSubscriptionExpiryDate(maybeNonGifteeAttributes, maybeGifteeAttributes)
         val maybeAttributesFromZuora = maybeGifteeAndNonGifteeAttributes.map(ZuoraAttributes.asAttributes(_))
 
-        alertIfAttributesDoNotMatch(identityId, maybeAttributesFromZuora, supporterProductDataAttributes)
+        // alertIfAttributesDoNotMatch(identityId, maybeAttributesFromZuora, supporterProductDataAttributes)
 
         attributesFromDynamo.foreach(maybeUpdateCache(maybeGifteeAndNonGifteeAttributes, _, maybeAttributesFromZuora))
         Future.successful("Zuora", maybeAttributesFromZuora)

--- a/membership-attribute-service/app/services/SupporterRatePlanToAttributesMapper.scala
+++ b/membership-attribute-service/app/services/SupporterRatePlanToAttributesMapper.scala
@@ -90,6 +90,7 @@ object SupporterRatePlanToAttributesMapper {
         "2c92a00c77992ba70177a6596f710265",
         "2c92a0ff73add07f0173b99f14390afc",
         "2c92a00773adc09d0173b99e4ded7f45",
+        "2c92a0fb4edd70c8014edeaa4e8521fe"
       ) -> digitalSubTransformer,
       List("2c92a0fc5aacfadd015ad24db4ff5e97") -> monthlyContributionTransformer,
       List("2c92a0fc5e1dc084015e37f58c200eea") -> annualContributionTransformer,
@@ -108,7 +109,9 @@ object SupporterRatePlanToAttributesMapper {
         "2c92a0ff5af9b657015b0fea5b653f81",
         "2c92a0fd5614305c01561dc88f3275be",
         "2c92a0ff560d311b0156136f2afe5315",
-        "2c92a0fd560d13880156136b72e50f0c"
+        "2c92a0fd560d13880156136b72e50f0c",
+        "2c92a0ff56fe33f001572334561765c1",
+        "2c92a0fd596d321a0159735a7b150e43"
       ) -> paperTransformer,
       List(
         "2c92a00870ec598001710740ce702ff0",
@@ -135,7 +138,27 @@ object SupporterRatePlanToAttributesMapper {
         "2c92a0fe6619b4b901661aa8e66c1692",
         "2c92a0ff67cebd0d0167f0a1a834234e",
         "2c92a0fe6619b4b301661aa494392ee2",
-        "2c92a00e6dd988e2016df85387417498"
+        "2c92a00e6dd988e2016df85387417498",
+        "2c92a0fd58cf57000158f30ae6d06f2a",
+        "2c92a0ff58bdf4eb0158f2ecc89c1034",
+        "2c92a0ff58bdf4ee0158f30905e82181",
+        "2c92a0fd5a5adc8b015a5c690d0d1ec6",
+        "2c92a0ff5a4b85e7015a4cf95d352a07",
+        "2c92a0ff5a5adca9015a611f77db4431",
+        "2c92a0fc5a2a49f0015a41f473da233a",
+        "2c92a0fe5a5ad344015a5c67b1144250",
+        "2c92a0ff59d9d540015a41a40b3e07d3",
+        "2c92a0fd5a5adc8b015a5c65074b7c41",
+        "2c92a0ff5a5adca7015a5c4af5963efa",
+        "2c92a0fe5a5ad349015a5c61d6e05d8d",
+        "2c92a0fe57d0a0c40157d74240de5543",
+        "2c92a0ff57d0a0b60157d741e722439a",
+        "2c92a0ff58bdf4eb0158f307eccf02af",
+        "2c92a0fc6ae918b6016b080950e96d75",
+        "2c92a0fc5b42d2c9015b6259f7f40040",
+        "2c92a0fd57d0a9870157d7412f19424f",
+        "2c92a0fe57d0a0c40157d74241005544",
+        "2c92a0ff58bdf4eb0158f307ed0e02be",
       ) -> guardianWeeklyTransformer,
       List(
         "2c92a0fb4ce4b8e7014ce711d3c37e60",

--- a/membership-attribute-service/test/services/SupporterRatePlanToAttributesMapperTest.scala
+++ b/membership-attribute-service/test/services/SupporterRatePlanToAttributesMapperTest.scala
@@ -23,14 +23,14 @@ class SupporterRatePlanToAttributesMapperTest extends Specification {
       mapper.attributesFromSupporterRatePlans(
         identityId,
         List(ratePlanItem("2c92a0fc5aacfadd015ad24db4ff5e97"))
-      )  should beSome.which(_.RecurringContributionPaymentPlan should beSome("Monthly Contribution"))
+      ) should beSome.which(_.RecurringContributionPaymentPlan should beSome("Monthly Contribution"))
     }
 
     "identify an annual contribution" in {
       mapper.attributesFromSupporterRatePlans(
         identityId,
         List(ratePlanItem("2c92a0fc5e1dc084015e37f58c200eea"))
-      )  should beSome.which(_.RecurringContributionPaymentPlan should beSome("Annual Contribution"))
+      ) should beSome.which(_.RecurringContributionPaymentPlan should beSome("Annual Contribution"))
     }
 
     "identify a Digital Subscription" in {
@@ -41,7 +41,8 @@ class SupporterRatePlanToAttributesMapperTest extends Specification {
         "2c92a00d779932ef0177a65430d30ac1", // Three Month Gift
         "2c92a00c77992ba70177a6596f710265", // One Year Gift
         "2c92a0ff73add07f0173b99f14390afc", // Deprecated Three Month Gift
-        "2c92a00773adc09d0173b99e4ded7f45" // Deprecated One Year Gift
+        "2c92a00773adc09d0173b99e4ded7f45", // Deprecated One Year Gift
+        "2c92a0fb4edd70c8014edeaa4e8521fe" // Quarterly
       )
       possibleProductRatePlanIds.map(productRatePlanId =>
         mapper
@@ -61,7 +62,28 @@ class SupporterRatePlanToAttributesMapperTest extends Specification {
         "2c92a0fe6619b4b901661aa8e66c1692", // annual, domestic delivery")
         "2c92a0ff67cebd0d0167f0a1a834234e", // one year, domestic delivery"
         "2c92a0fe6619b4b301661aa494392ee2", // quarterly, domestic delivery")
-        "2c92a00e6dd988e2016df85387417498" // three months, domestic delivery
+        "2c92a00e6dd988e2016df85387417498", // three months, domestic delivery
+        // Old pre 2018 Zoned plans
+        "2c92a0fd58cf57000158f30ae6d06f2a", // 1 Year
+        "2c92a0ff58bdf4eb0158f2ecc89c1034", // 1 Year
+        "2c92a0ff58bdf4ee0158f30905e82181", // 1 Year
+        "2c92a0fd5a5adc8b015a5c690d0d1ec6", // 12 Issues
+        "2c92a0ff5a4b85e7015a4cf95d352a07", // 12 Issues
+        "2c92a0ff5a5adca9015a611f77db4431", // 3 Years
+        "2c92a0fc5a2a49f0015a41f473da233a", // 6 Issues
+        "2c92a0fe5a5ad344015a5c67b1144250", // 6 Issues
+        "2c92a0ff59d9d540015a41a40b3e07d3", // 6 Issues
+        "2c92a0fd5a5adc8b015a5c65074b7c41", // 6 Months
+        "2c92a0ff5a5adca7015a5c4af5963efa", // 6 Months
+        "2c92a0fe5a5ad349015a5c61d6e05d8d", // 6 Months Only
+        "2c92a0fe57d0a0c40157d74240de5543", // Annual
+        "2c92a0ff57d0a0b60157d741e722439a", // Annual
+        "2c92a0ff58bdf4eb0158f307eccf02af", // Annual
+        "2c92a0fc6ae918b6016b080950e96d75", // Holiday Credit
+        "2c92a0fc5b42d2c9015b6259f7f40040", // Holiday Credit - old
+        "2c92a0fd57d0a9870157d7412f19424f", // Quarterly
+        "2c92a0fe57d0a0c40157d74241005544", // Quarterly
+        "2c92a0ff58bdf4eb0158f307ed0e02be" // Quarterly
       )
       possibleProductRatePlanIds.map(productRatePlanId =>
         mapper
@@ -91,7 +113,9 @@ class SupporterRatePlanToAttributesMapperTest extends Specification {
         "2c92a0ff5af9b657015b0fea5b653f81", //Sunday"
         "2c92a0fd5614305c01561dc88f3275be", //Weekend"
         "2c92a0ff560d311b0156136f2afe5315", //Sixday"
-        "2c92a0fd560d13880156136b72e50f0c" //Everyday"
+        "2c92a0fd560d13880156136b72e50f0c", //Everyday"
+        "2c92a0ff56fe33f001572334561765c1", //Echo-Legacy
+        "2c92a0fd596d321a0159735a7b150e43" //Fiveday
       )
       possibleProductRatePlanIds.map(productRatePlanId =>
         mapper
@@ -166,11 +190,11 @@ class SupporterRatePlanToAttributesMapperTest extends Specification {
     }
 
     "handle an empty list of supporterProductRatePlanIds correctly" in {
-        mapper
-          .attributesFromSupporterRatePlans(
-            identityId,
-            Nil
-          ) should beNone
+      mapper
+        .attributesFromSupporterRatePlans(
+          identityId,
+          Nil
+        ) should beNone
     }
 
     "handle supporter with multiple products correctly" in {
@@ -185,7 +209,18 @@ class SupporterRatePlanToAttributesMapperTest extends Specification {
             ratePlanItem("2c92a0fe6619b4b601661ab300222651")
           )
         ) should beSome(
-          Attributes(identityId, Some("Supporter"),Some("Monthly Contribution"), None, None, Some(termEndDate), Some(termEndDate), Some(termEndDate), None, None)
+        Attributes(
+          identityId,
+          Some("Supporter"),
+          Some("Monthly Contribution"),
+          None,
+          None,
+          Some(termEndDate),
+          Some(termEndDate),
+          Some(termEndDate),
+          None,
+          None
+        )
       )
     }
 
@@ -197,7 +232,7 @@ class SupporterRatePlanToAttributesMapperTest extends Specification {
           List(
             ratePlanItem("2c92a0ff56fe33f50157040bbdcf3ae4", furthestEndDate), // Everyday+
             ratePlanItem("2c92a0fb4edd70c8014edeaa4eae220a"), //Digital pack
-            ratePlanItem("2c92a00870ec598001710740d0d83017"), //Sunday
+            ratePlanItem("2c92a00870ec598001710740d0d83017") //Sunday
           )
         ) should beSome(
         Attributes(
@@ -216,15 +251,10 @@ class SupporterRatePlanToAttributesMapperTest extends Specification {
     }
 
     "have a product rate plan for all active subscriptions" in {
-
       val allMappedProductRatePlans: List[String] = productRatePlanMappings("PROD").keys.flatten.toList
+      val allUnmapped = allActiveProductRatePlans.filter { case (name, id) => !allMappedProductRatePlans.contains(id) }
 
-      val allActiveProductRatePlanIds = allActiveProductRatePlans.map(_._1)
-
-      allActiveProductRatePlans.map { case (productRatePlanId, _) =>
-        allMappedProductRatePlans should contain(productRatePlanId)
-      }
-
+      allUnmapped should beEmpty
     }
 
     "find unused rate plans" in {
@@ -232,7 +262,9 @@ class SupporterRatePlanToAttributesMapperTest extends Specification {
 
       val allActiveProductRatePlanIds = allActiveProductRatePlans.map(_._1)
       val allUnused = allMappedProductRatePlans.filter(productRatePlanId => !allActiveProductRatePlanIds.contains(productRatePlanId))
-      System.out.println(s"There are ${allUnused.length} mapped rate plans which appear to be unused") //TODO: Should we remove legacy product rate plan ids from the mapper
+      System.out.println(
+        s"There are ${allUnused.length} mapped rate plans which appear to be unused"
+      ) //TODO: Should we remove legacy product rate plan ids from the mapper
       success
     }
   }
@@ -242,47 +274,85 @@ object SupporterRatePlanToAttributesMapperTest {
   // This is a list of all active product rate plans from an extract taken
   // using the support-frontend/supporter-product-data project on 26th Feb 2021
   val allActiveProductRatePlans = List(
-    ("2c92a0fc5e1dc084015e37f58c200eea", "Annual Contribution"),
-    ("2c92a0fd56fe270b0157040dd79b35da", "Everyday"),
-    ("2c92a0fc5aacfadd015ad24db4ff5e97", "Monthly Contribution"),
-    ("2c92a0fb4edd70c8014edeaa4eae220a", "Digital Pack Monthly"),
-    ("2c92a0fb4edd70c8014edeaa4e972204", "Digital Pack Annual"),
-    ("2c92a0fe6619b4b301661aa494392ee2", "GW Oct 18 - Quarterly - Domestic"),
-    ("2c92a0fe6619b4b901661aa8e66c1692", "GW Oct 18 - Annual - Domestic"),
-    ("2c92a0fb4c5481db014c69f4a1e03bbd", "Non Founder Supporter - annual"),
-    ("2c92a0ff56fe33f00157040f9a537f4b", "Weekend"),
-    ("2c92a0ff56fe33f50157040bbdcf3ae4", "Everyday+"),
-    ("2c92a0fe5af9a6b9015b0fe1ecc0116c", "Sunday"),
-    ("2c92a0ff67cebd0d0167f0a1a834234e", "GW Oct 18 - 1 Year - Domestic"),
-    ("2c92a0fd56fe270b0157040e42e536ef", "Sixday"),
-    ("2c92a0fb4ce4b8e7014ce711d3c37e60", "Friends"),
-    ("2c92a0fd6205707201621fa1350710e3", "Saturday+"),
-    ("2c92a0fe56fe33ff0157040d4b824168", "Sunday+"),
-    ("2c92a0fd56fe26b60157040cdd323f76", "Weekend+"),
-    ("2c92a0f94c547592014c69f5b0ff4f7e", "Non Founder Supporter - monthly"),
-    ("2c92a0086619bf8901661ab02752722f", "GW Oct 18 - Quarterly - ROW"),
-    ("2c92a0fe6619b4b601661ab300222651", "GW Oct 18 - Annual - ROW"),
-    ("2c92a0fc56fe26ba0157040c5ea17f6a", "Sixday+"),
-    ("2c92a0fd5614305c01561dc88f3275be", "Weekend"),
-    ("2c92a0fd560d13880156136b72e50f0c", "Everyday"),
-    ("2c92a0ff5af9b657015b0fea5b653f81", "Sunday"),
-    ("2c92a00870ec598001710740ca532f69", "Sixday"),
-    ("2c92a00870ec598001710740d0d83017", "Sunday"),
-    ("2c92a00870ec598001710740d24b3022", "Weekend"),
-    ("2c92a00870ec598001710740c78d2f13", "Everyday"),
-    ("2c92a0ff560d311b0156136f2afe5315", "Sixday"),
-    ("2c92a00e6dd988e2016df85387417498", "GW Oct 18 - 3 Month - Domestic"),
-    ("2c92a0ff73add07f0173b99f14390afc", "Digital Subscription Three Month Fixed - Deprecated"),
-    ("2c92a00773adc09d0173b99e4ded7f45", "Digital Subscription One Year Fixed - Deprecated"),
-    ("2c92a0ff67cebd140167f0a2f66a12eb", "GW Oct 18 - 1 Year - ROW"),
-    ("2c92a00c77992ba70177a6596f710265", "Digital Subscription One Year Fixed - One Time Charge"),
-    ("2c92a0076dd9892e016df8503e7c6c48", "GW Oct 18 - 3 Month - ROW"),
-    ("2c92a0fd6205707201621f9f6d7e0116", "Saturday"),
-    ("2c92a0fd5e1dcf0d015e3cb39d0a7ddb", "Saturday"),
-    ("2c92a0ff560d311b0156136b9f5c3968", "Weekend+"),
-    ("2c92a00d779932ef0177a65430d30ac1", "Digital Subscription Three Month Fixed - One Time Charge"),
-    ("2c92a0f94c54758b014c69f813bd39ec", "Non Founder Partner - annual"),
-    ("2c92a0fd560d13880156136b8e490f8b", "Sunday+"),
-    ("2c92a0fb4c5481dc014c69f95fce7240", "Non Founder Partner - monthly")
+    ("Annual Contribution", "2c92a0fc5e1dc084015e37f58c200eea"),
+    ("Digital Pack Annual", "2c92a0fb4edd70c8014edeaa4e972204"),
+    ("Digital Pack Monthly", "2c92a0fb4edd70c8014edeaa4eae220a"),
+    ("Digital Pack Quarterly", "2c92a0fb4edd70c8014edeaa4e8521fe"),
+    ("Digital Subscription One Year Fixed - One Time Charge", "2c92a00c77992ba70177a6596f710265"),
+    ("Digital Subscription Three Month Fixed - One Time Charge", "2c92a00d779932ef0177a65430d30ac1"),
+    ("Echo-Legacy", "2c92a0ff56fe33f001572334561765c1"),
+    ("Everyday", "2c92a00870ec598001710740c78d2f13"),
+    ("Everyday", "2c92a0fd560d13880156136b72e50f0c"),
+    ("Everyday", "2c92a0fd56fe270b0157040dd79b35da"),
+    ("Everyday+", "2c92a00870ec598001710740d3d03035"),
+    ("Everyday+", "2c92a0fd560d132301560e43cf041a3c"),
+    ("Everyday+", "2c92a0ff56fe33f50157040bbdcf3ae4"),
+    ("Fiveday", "2c92a0fd596d321a0159735a7b150e43"),
+    ("Friend", "2c92a0f9479fb46d0147d0155c6f558b"),
+    ("Friends", "2c92a0fb4ce4b8e7014ce711d3c37e60"),
+    ("GW Oct 18 - 1 Year - Domestic", "2c92a0ff67cebd0d0167f0a1a834234e"),
+    ("GW Oct 18 - 1 Year - ROW", "2c92a0ff67cebd140167f0a2f66a12eb"),
+    ("GW Oct 18 - 3 Month - Domestic", "2c92a00e6dd988e2016df85387417498"),
+    ("GW Oct 18 - 3 Month - ROW", "2c92a0076dd9892e016df8503e7c6c48"),
+    ("GW Oct 18 - Annual - Domestic", "2c92a0fe6619b4b901661aa8e66c1692"),
+    ("GW Oct 18 - Annual - ROW", "2c92a0fe6619b4b601661ab300222651"),
+    ("GW Oct 18 - Quarterly - Domestic", "2c92a0fe6619b4b301661aa494392ee2"),
+    ("GW Oct 18 - Quarterly - ROW", "2c92a0086619bf8901661ab02752722f"),
+    ("Guardian Weekly 1 Year", "2c92a0fd58cf57000158f30ae6d06f2a"),
+    ("Guardian Weekly 1 Year", "2c92a0ff58bdf4eb0158f2ecc89c1034"),
+    ("Guardian Weekly 1 Year", "2c92a0ff58bdf4ee0158f30905e82181"),
+    ("Guardian Weekly 12 Issues", "2c92a0fd5a5adc8b015a5c690d0d1ec6"),
+    ("Guardian Weekly 12 Issues", "2c92a0ff5a4b85e7015a4cf95d352a07"),
+    ("Guardian Weekly 3 Years", "2c92a0ff5a5adca9015a611f77db4431"),
+    ("Guardian Weekly 6 Issues", "2c92a0fc5a2a49f0015a41f473da233a"),
+    ("Guardian Weekly 6 Issues", "2c92a0fe5a5ad344015a5c67b1144250"),
+    ("Guardian Weekly 6 Issues", "2c92a0ff59d9d540015a41a40b3e07d3"),
+    ("Guardian Weekly 6 Months", "2c92a0fd5a5adc8b015a5c65074b7c41"),
+    ("Guardian Weekly 6 Months", "2c92a0ff5a5adca7015a5c4af5963efa"),
+    ("Guardian Weekly 6 Months Only", "2c92a0fe5a5ad349015a5c61d6e05d8d"),
+    ("Guardian Weekly Annual", "2c92a0fe57d0a0c40157d74240de5543"),
+    ("Guardian Weekly Annual", "2c92a0ff57d0a0b60157d741e722439a"),
+    ("Guardian Weekly Annual", "2c92a0ff58bdf4eb0158f307eccf02af"),
+    ("Guardian Weekly Holiday Credit", "2c92a0fc6ae918b6016b080950e96d75"),
+    ("Guardian Weekly Holiday Credit - old", "2c92a0fc5b42d2c9015b6259f7f40040"),
+    ("Guardian Weekly Quarterly", "2c92a0fd57d0a9870157d7412f19424f"),
+    ("Guardian Weekly Quarterly", "2c92a0fe57d0a0c40157d74241005544"),
+    ("Guardian Weekly Quarterly", "2c92a0ff58bdf4eb0158f307ed0e02be"),
+    ("Monthly Contribution", "2c92a0fc5aacfadd015ad24db4ff5e97"),
+    ("Non Founder Partner - annual", "2c92a0f94c54758b014c69f813bd39ec"),
+    ("Non Founder Partner - monthly", "2c92a0fb4c5481dc014c69f95fce7240"),
+    ("Non Founder Patron - annual", "2c92a0f94c547592014c69fb0c4274fc"),
+    ("Non Founder Patron - monthly", "2c92a0fb4c5481db014c69fb9118704b"),
+    ("Non Founder Supporter - annual", "2c92a0fb4c5481db014c69f4a1e03bbd"),
+    ("Non Founder Supporter - monthly", "2c92a0f94c547592014c69f5b0ff4f7e"),
+    ("Partner - annual", "2c92a0f9479fb46d0147d0155cb15596"),
+    ("Partner - monthly", "2c92a0f9479fb46d0147d0155ca15595"),
+    ("Patron - annual", "2c92a0f9479fb46d0147d0155c245581"),
+    ("Patron - monthly", "2c92a0f9479fb46d0147d0155bf9557a"),
+    ("Saturday", "2c92a0fd6205707201621f9f6d7e0116"),
+    ("Saturday ", "2c92a0fd5e1dcf0d015e3cb39d0a7ddb"),
+    ("Saturday+", "2c92a0fd6205707201621fa1350710e3"),
+    ("Saturday+", "2c92a0ff6205708e01622484bb2c4613"),
+    ("Sixday", "2c92a00870ec598001710740ca532f69"),
+    ("Sixday", "2c92a0fd56fe270b0157040e42e536ef"),
+    ("Sixday", "2c92a0ff560d311b0156136f2afe5315"),
+    ("Sixday+", "2c92a00870ec598001710740c4582ead"),
+    ("Sixday+", "2c92a0fc56fe26ba0157040c5ea17f6a"),
+    ("Sixday+", "2c92a0ff560d311b0156136b697438a9"),
+    ("Staff - monthly", "2c92a0f949efde7c0149f1f18162178e"),
+    ("Sunday", "2c92a00870ec598001710740d0d83017"),
+    ("Sunday", "2c92a0fe5af9a6b9015b0fe1ecc0116c"),
+    ("Sunday", "2c92a0ff5af9b657015b0fea5b653f81"),
+    ("Sunday+", "2c92a00870ec598001710740cf9e3004"),
+    ("Sunday+", "2c92a0fd560d13880156136b8e490f8b"),
+    ("Sunday+", "2c92a0fe56fe33ff0157040d4b824168"),
+    ("Supporter - annual", "2c92a0fb4bb97034014bbbc562604ff7"),
+    ("Supporter - monthly", "2c92a0fb4bb97034014bbbc562114fef"),
+    ("Weekend", "2c92a00870ec598001710740d24b3022"),
+    ("Weekend", "2c92a0fd5614305c01561dc88f3275be"),
+    ("Weekend", "2c92a0ff56fe33f00157040f9a537f4b"),
+    ("Weekend+", "2c92a00870ec598001710740c6672ee7"),
+    ("Weekend+", "2c92a0fd56fe26b60157040cdd323f76"),
+    ("Weekend+", "2c92a0ff560d311b0156136b9f5c3968")
   )
 }


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
The SupporterRatePlanToAttributesMapper class is missing some product rate plan ids which are still in use by active subscriptions. This PR adds them in.
