### PR TITLE
remove unneeded bintray reference

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,8 +26,6 @@ val commonSettings = Seq(
   resolvers ++= Seq(
     "Guardian Github Releases" at "https://guardian.github.io/maven/repo-releases",
     "Guardian Github Snapshots" at "https://guardian.github.io/maven/repo-snapshots",
-    "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases",
-    Resolver.bintrayRepo("dwhjames", "maven"),
     Resolver.sonatypeRepo("releases")
   ),
   sources in (Compile, doc) := Seq.empty,


### PR DESCRIPTION
Bintray is being switched off in may 1st, and this repo has an unneeded reference to it.  This PR removes it.