### PR TITLE
Snyk fixes for vulnerabilities in netty-codec and netty-codec-http

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,8 +22,8 @@ object Dependencies {
   val kinesis = "com.gu" % "kinesis-logback-appender" % "2.0.2"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"
   val anorm = "org.playframework.anorm" %% "anorm" % "2.6.10"
-  val netty = "io.netty" % "netty-codec" % "4.1.46.Final"
-  val nettyHttp = "io.netty" % "netty-codec-http" % "4.1.46.Final"
+  val netty = "io.netty" % "netty-codec" % "4.1.59.Final"
+  val nettyHttp = "io.netty" % "netty-codec-http" % "4.1.59.Final"
 
   //projects
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,6 +22,7 @@ object Dependencies {
   val kinesis = "com.gu" % "kinesis-logback-appender" % "2.0.2"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"
   val anorm = "org.playframework.anorm" %% "anorm" % "2.6.10"
+  val netty = "io.netty" % "netty-codec" % "4.1.46.Final"
 
   //projects
 
@@ -45,6 +46,7 @@ object Dependencies {
     anorm,
     "com.amazonaws" % "aws-java-sdk-autoscaling" % awsClientVersion,
     "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.10.6",
+    netty,
   )
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,6 +23,7 @@ object Dependencies {
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"
   val anorm = "org.playframework.anorm" %% "anorm" % "2.6.10"
   val netty = "io.netty" % "netty-codec" % "4.1.46.Final"
+  val nettyHttp = "io.netty" % "netty-codec-http" % "4.1.46.Final"
 
   //projects
 
@@ -47,6 +48,7 @@ object Dependencies {
     "com.amazonaws" % "aws-java-sdk-autoscaling" % awsClientVersion,
     "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.10.6",
     netty,
+    nettyHttp,
   )
 
 }


### PR DESCRIPTION
This adds explicit dependencies on up-to-date versions of netty-codec and netty-codec-http to mitigate vulnerabilities introduced via kinesis-logback-appender.