### PR TITLE
Increase Supporter Product Data use to 10%

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -115,7 +115,7 @@ class AttributeController(
   private lazy val random = new Random
 
   private def getZuoraAttributes(identityId: String)(implicit request: AuthenticatedUserAndBackendRequest[AnyContent]) = {
-    if(random.nextInt(100) >= 5) {
+    if(random.nextInt(100) >= 10) {
       log.info(s"Fetching attributes from Zuora for user $identityId")
       getAttributesWithConcurrencyLimitHandling(identityId)
     } else {


### PR DESCRIPTION
Increase the percentage of requests which are using the SupporterProductData Dynamo table to 10%

### [Trello card](https://trello.com/c/i1pPv4bS/3691-put-supporter-product-data-traffic-to-100)
