### PR TITLE
Send 50% of user attribute traffic to supporter product data

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -117,7 +117,7 @@ class AttributeController(
 
   protected def getZuoraAttributes(identityId: String)(implicit request: AuthenticatedUserAndBackendRequest[AnyContent]) = {
     Timing.record(metrics, s"Fetch attributes - Average time") {
-      if (random.nextInt(100) >= 20) {
+      if (random.nextInt(100) >= 50) {
         log.info(s"Fetching attributes from Zuora for user $identityId")
         Timing.record(metrics, "Fetch Attributes - Zuora") {
           getAttributesWithConcurrencyLimitHandling(identityId)


### PR DESCRIPTION
Following on from #570 