### PR TITLE
Update identity-auth-play

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,8 +6,8 @@ object Dependencies {
   val awsClientVersion = "1.11.1022"
 
   val sentryLogback = "io.sentry" % "sentry-logback" % "1.7.5"
-  val identityAuth = "com.gu.identity" %% "identity-auth-play" % "3.235"
-  val identityTestUsers = "com.gu" %% "identity-test-users" % "0.7"
+  val identityAuth = "com.gu.identity" %% "identity-auth-play" % "2.6"
+  val identityTestUsers = "com.gu" %% "identity-test-users" % "0.8"
   val postgres = "org.postgresql" % "postgresql" % "42.2.20"
   val jdbc = PlayImport.jdbc
   val playWS = PlayImport.ws

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val awsClientVersion = "1.11.1022"
 
   val sentryLogback = "io.sentry" % "sentry-logback" % "1.7.5"
-  val identityAuth = "com.gu.identity" %% "identity-auth-play" % "2.6"
+  val identityAuth = "com.gu.identity" %% "identity-auth-play" % "3.247"
   val identityTestUsers = "com.gu" %% "identity-test-users" % "0.8"
   val postgres = "org.postgresql" % "postgresql" % "42.2.20"
   val jdbc = PlayImport.jdbc


### PR DESCRIPTION
to get a more recent version of the http4s dependency. However, this will not solve all current snyk warnings for that dependency