### PR TITLE
Serve all Zuora attribute requests from the Supporter Product Data store

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -113,21 +113,10 @@ class AttributeController(
     )
   }
 
-  private lazy val random = new Random
-
   protected def getZuoraAttributes(identityId: String)(implicit request: AuthenticatedUserAndBackendRequest[AnyContent]) = {
-    Timing.record(metrics, s"Fetch attributes - Average time") {
-      if (random.nextInt(100) >= 80) {
-        log.info(s"Fetching attributes from Zuora for user $identityId")
-        Timing.record(metrics, "Fetch Attributes - Zuora") {
-          getAttributesWithConcurrencyLimitHandling(identityId)
-        }
-      } else {
-        log.info(s"Fetching attributes from supporter-product-data table for user $identityId")
-        Timing.record(metrics, "Fetch Attributes - SupporterProductData") {
-          request.touchpoint.supporterProductDataService.getAttributes(identityId).map(maybeAttributes => ("supporter-product-data", maybeAttributes.getOrElse(None)))
-        }
-      }
+    log.info(s"Fetching attributes from supporter-product-data table for user $identityId")
+    Timing.record(metrics, "Fetch Attributes - SupporterProductData") {
+      request.touchpoint.supporterProductDataService.getAttributes(identityId).map(maybeAttributes => ("supporter-product-data", maybeAttributes.getOrElse(None)))
     }
   }
 


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
Following on from #586 this PR moves the remaining traffic over from direct calls to Zuora to the supporter product data dynamo table.

### [**Trello card**](https://trello.com/c/i1pPv4bS/3691-put-supporter-product-data-traffic-to-100-80)
