### PR TITLE
update members data api to play 2.8 plus other bumps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,37 +22,37 @@ def buildInfoSettings = Seq(
 val commonSettings = Seq(
   organization := "com.gu",
   version := appVersion,
-  scalaVersion := "2.12.13",
+  scalaVersion := "2.12.14",
   resolvers ++= Seq(
     "Guardian Github Releases" at "https://guardian.github.io/maven/repo-releases",
     "Guardian Github Snapshots" at "https://guardian.github.io/maven/repo-snapshots",
     Resolver.sonatypeRepo("releases")
   ),
-  sources in (Compile, doc) := Seq.empty,
-  publishArtifact in (Compile, packageDoc) := false,
-  parallelExecution in Global := false,
+  Compile / doc / sources := Seq.empty,
+  Compile / packageDoc / publishArtifact := false,
+  Global / parallelExecution := false,
   updateOptions := updateOptions.value.withCachedResolution(true),
-  javaOptions in Test += "-Dconfig.resource=TEST.public.conf"
+  Test / javaOptions += "-Dconfig.resource=TEST.public.conf"
 ) ++ buildInfoSettings
 
 lazy val dynamoDBLocalSettings = Seq(
   dynamoDBLocalDownloadDir := file("dynamodb-local"),
-  startDynamoDBLocal := (startDynamoDBLocal.dependsOn(compile in Test)).value,
-  test in Test := (test in Test).dependsOn(startDynamoDBLocal).value,
-  testOnly in Test := ((testOnly in Test).dependsOn(startDynamoDBLocal)).evaluated,
-  testOptions in Test += (dynamoDBLocalTestCleanup).value
+  startDynamoDBLocal := (startDynamoDBLocal.dependsOn(Test / compile)).value,
+  Test / test := (Test / test).dependsOn(startDynamoDBLocal).value,
+  Test / testOnly := ((Test / testOnly).dependsOn(startDynamoDBLocal)).evaluated,
+  Test / testOptions += (dynamoDBLocalTestCleanup).value
 )
 
 import com.typesafe.sbt.packager.archetypes.systemloader.ServerLoader.Systemd
 val buildDebSettings = Seq(
-  serverLoading in Debian := Some(Systemd),
+  Debian / serverLoading := Some(Systemd),
   debianPackageDependencies := Seq("openjdk-8-jre-headless"),
   maintainer := "Membership Dev <membership.dev@theguardian.com>",
   packageSummary := "Members Data API",
   packageDescription := """Members Data API""",
-  riffRaffPackageType := (packageBin in Debian).value,
+  riffRaffPackageType := (Debian / packageBin).value,
   riffRaffArtifactResources += (file("cloudformation/membership-attribute-service.yaml") -> "cloudformation/membership-attribute-service.yaml"),
-  javaOptions in Universal ++= Seq(
+  Universal / javaOptions ++= Seq(
     "-Dpidfile.path=/dev/null",
     "-J-XX:MaxRAMFraction=2",
     "-J-XX:InitialRAMFraction=2",
@@ -74,7 +74,10 @@ def app(name: String) =
     .settings(buildDebSettings)
 
 val api = app("membership-attribute-service")
-  .settings(libraryDependencies ++= apiDependencies)
+  .settings(
+    libraryDependencies ++= apiDependencies,
+    dependencyOverrides ++= depOverrides,
+  )
   .settings(routesGenerator := InjectedRoutesGenerator)
   .settings(
     scalacOptions += "-Ypartial-unification",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,7 +24,12 @@ object Dependencies {
   val anorm = "org.playframework.anorm" %% "anorm" % "2.6.10"
   val netty = "io.netty" % "netty-codec" % "4.1.59.Final"
   val nettyHttp = "io.netty" % "netty-codec-http" % "4.1.59.Final"
-  val jacksonVersion = "2.12.3"
+  val jacksonVersion = "2.11.4"
+
+  val jackson = Seq(
+    "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
+    "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
+  )
 
   //projects
 
@@ -47,10 +52,10 @@ object Dependencies {
     logstash,
     anorm,
     "com.amazonaws" % "aws-java-sdk-autoscaling" % awsClientVersion,
-    "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
-    "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
     netty,
     nettyHttp,
-  )
+  ) ++ jackson
+
+  val depOverrides = jackson
 
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.5.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ logLevel := Level.Warn
 
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.7")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
 


### PR DESCRIPTION
Identity release the libraries mainly for play 2.8 now, the 2.7 process is a bit of a bolt on on a special branch.
So I have decided the easiest solution is to bump members data api to play 2.8 as it needs doing anyway.

This will make it easier to get the snyk updates out in https://github.com/guardian/members-data-api/pull/571