### PR TITLE
Give more useful error message on missing payment gateway

### DIFF
--- a/membership-attribute-service/app/controllers/PaymentUpdateController.scala
+++ b/membership-attribute-service/app/controllers/PaymentUpdateController.scala
@@ -112,7 +112,10 @@ class PaymentUpdateController(commonActions: CommonActions, override val control
       createPaymentMethod = CreatePaymentMethod(
         accountId = subscription.accountId,
         paymentMethod = bankTransferPaymentMethod,
-        paymentGateway = account.paymentGateway.get, // this will need to change to use this endpoint for 'payment method' SWITCH
+        paymentGateway = account.paymentGateway
+          .getOrElse(
+            throw new RuntimeException(s"Unrecognised payment gateway for account ${subscription.accountId} for user $maybeUserId")
+          ), // this will need to change to use this endpoint for 'payment method' SWITCH
         billtoContact = billToContact,
         invoiceTemplateOverride = None
       )

--- a/membership-attribute-service/app/controllers/PaymentUpdateController.scala
+++ b/membership-attribute-service/app/controllers/PaymentUpdateController.scala
@@ -109,16 +109,17 @@ class PaymentUpdateController(commonActions: CommonActions, override val control
         lastName = billToContact.lastName,
         countryCode = "GB"
       )
-      createPaymentMethod = CreatePaymentMethod(
-        accountId = subscription.accountId,
-        paymentMethod = bankTransferPaymentMethod,
-        paymentGateway = account.paymentGateway
-          .getOrElse(
-            throw new RuntimeException(s"Unrecognised payment gateway for account ${subscription.accountId} for user $maybeUserId")
-          ), // this will need to change to use this endpoint for 'payment method' SWITCH
-        billtoContact = billToContact,
-        invoiceTemplateOverride = None
-      )
+        createPaymentMethod <- EitherT(Future.successful {
+          account.paymentGateway
+                 .map(paymentGateway => CreatePaymentMethod(
+                   accountId = subscription.accountId,
+                   paymentMethod = bankTransferPaymentMethod,
+                   paymentGateway = paymentGateway, // this will need to change to use this endpoint for 'payment method' SWITCH
+                   billtoContact = billToContact,
+                   invoiceTemplateOverride = None
+                 )) \/>
+          s"Unrecognised payment gateway for account ${subscription.accountId}"
+        })
       _ <- EitherT(annotateFailableFuture(tp.zuoraService.createPaymentMethod(createPaymentMethod), "create direct debit payment method"))
       freshDefaultPaymentMethodOption <- EitherT(annotateFailableFuture(tp.paymentService.getPaymentMethod(subscription.accountId), "get fresh default payment method"))
     } yield checkDirectDebitUpdateResult(maybeUserId, freshDefaultPaymentMethodOption, bankAccountName, bankAccountNumber, bankSortCode)).run.map {

--- a/membership-attribute-service/app/controllers/PaymentUpdateController.scala
+++ b/membership-attribute-service/app/controllers/PaymentUpdateController.scala
@@ -114,7 +114,7 @@ class PaymentUpdateController(commonActions: CommonActions, override val control
                  .map(paymentGateway => CreatePaymentMethod(
                    accountId = subscription.accountId,
                    paymentMethod = bankTransferPaymentMethod,
-                   paymentGateway = paymentGateway, // this will need to change to use this endpoint for 'payment method' SWITCH
+                   paymentGateway = paymentGateway,
                    billtoContact = billToContact,
                    invoiceTemplateOverride = None
                  )) \/>


### PR DESCRIPTION
Instead of throwing a `NoSuchElementException` when a payment method has no payment gateway, this change gives us a more meaningful error which is easier to find in a log and easier to trace.