### PR TITLE
Bump membership-common from 0.603 to 0.608

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ def buildInfoSettings = Seq(
 val commonSettings = Seq(
   organization := "com.gu",
   version := appVersion,
-  scalaVersion := "2.12.15",
+  scalaVersion := "2.13.7",
   resolvers ++= Seq(
     "Guardian Github Releases" at "https://guardian.github.io/maven/repo-releases",
     "Guardian Github Snapshots" at "https://guardian.github.io/maven/repo-snapshots",
@@ -80,7 +80,6 @@ val api = app("membership-attribute-service")
   )
   .settings(routesGenerator := InjectedRoutesGenerator)
   .settings(
-    scalacOptions += "-Ypartial-unification",
     addCommandAlias("devrun", "run 9400"),
     addCommandAlias("batch-load", "runMain BatchLoader"),
     addCommandAlias("play-artifact", "riffRaffNotifyTeamcity")

--- a/membership-attribute-service/app/controllers/ContactController.scala
+++ b/membership-attribute-service/app/controllers/ContactController.scala
@@ -5,7 +5,6 @@ import com.gu.salesforce.{SFContactId, SimpleContactRepository}
 import com.typesafe.scalalogging.LazyLogging
 import models.DeliveryAddress
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
-import scalaz.\/-
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.Exception
@@ -57,8 +56,8 @@ class ContactController(
     val contactRepo = request.touchpoint.contactRepo
     request.redirectAdvice.userId match {
       case Some(userId) =>
-        contactRepo.get(userId) map {
-          case \/-(Some(contact)) => contact.salesforceContactId == contactId
+        contactRepo.get(userId).map(_.toEither).map {
+          case Right(Some(contact)) => contact.salesforceContactId == contactId
           case _                  => false
         }
       case None => Future.successful(false)

--- a/membership-attribute-service/app/controllers/PaymentUpdateController.scala
+++ b/membership-attribute-service/app/controllers/PaymentUpdateController.scala
@@ -12,15 +12,14 @@ import play.api.data.Form
 import play.api.data.Forms._
 import play.api.libs.json.Json
 import play.api.mvc.{BaseController, ControllerComponents}
+import scalaz.std.scalaFuture._
+import scalaz.EitherT
 
 import scala.concurrent.{ExecutionContext, Future}
-import scalaz.{-\/, EitherT, \/-}
-import scalaz.std.scalaFuture._
-import scalaz.syntax.std.option._
 
 class PaymentUpdateController(commonActions: CommonActions, override val controllerComponents: ControllerComponents) extends BaseController {
-  import commonActions._
   import AccountHelpers._
+  import commonActions._
   implicit val executionContext: ExecutionContext= controllerComponents.executionContext
 
   def updateCard(subscriptionName: String) = AuthAndBackendViaIdapiAction(Return401IfNotSignedInRecently).async { implicit request =>
@@ -32,13 +31,13 @@ class PaymentUpdateController(commonActions: CommonActions, override val control
     val maybeUserId = request.redirectAdvice.userId
     SafeLogger.info(s"Attempting to update card for $maybeUserId")
     (for {
-      user <- EitherT(Future.successful(maybeUserId \/> "no identity cookie for user"))
-      stripeDetails <- EitherT(Future.successful(updateForm.orElse(legacyForm) \/> "no 'stripePaymentMethodID' and 'stripePublicKey' submitted with request"))
+      user <- EitherT.fromEither(Future.successful(maybeUserId.toRight("no identity cookie for user")))
+      stripeDetails <- EitherT.fromEither(Future.successful(updateForm.orElse(legacyForm).toRight("no 'stripePaymentMethodID' and 'stripePublicKey' submitted with request")))
       (stripeCardIdentifier, stripePublicKey) = stripeDetails
-      sfUser <- EitherT(tp.contactRepo.get(user).map(_.flatMap(_ \/> s"no SF user $user")))
-      subscription <- EitherT(tp.subService.current[SubscriptionPlan.AnyPlan](sfUser).map(subscriptionSelector(Some(memsub.Subscription.Name(subscriptionName)), s"the sfUser $sfUser")))
-      stripeService <- EitherT(Future.successful(tp.stripeServicesByPublicKey.get(stripePublicKey)).map(_ \/> s"No Stripe service for public key: $stripePublicKey"))
-      updateResult <- EitherT(setPaymentCardFunction(subscription.accountId, stripeCardIdentifier, stripeService).map(_ \/> "something was missing when attempting to update payment card in Zuora"))
+      sfUser <- EitherT.fromEither(tp.contactRepo.get(user).map(_.toEither).map(_.flatMap(_.toRight(s"no SF user $user"))))
+      subscription <- EitherT.fromEither(tp.subService.current[SubscriptionPlan.AnyPlan](sfUser).map(subs => subscriptionSelector(Some(memsub.Subscription.Name(subscriptionName)), s"the sfUser $sfUser")(subs)))
+      stripeService <- EitherT.fromEither(Future.successful(tp.stripeServicesByPublicKey.get(stripePublicKey)).map(_.toRight(s"No Stripe service for public key: $stripePublicKey")))
+      updateResult <- EitherT.fromEither(setPaymentCardFunction(subscription.accountId, stripeCardIdentifier, stripeService).map(_.toRight("something was missing when attempting to update payment card in Zuora")))
     } yield updateResult match {
       case success: CardUpdateSuccess => {
         SafeLogger.info(s"Successfully updated card for identity user: $user")
@@ -48,11 +47,11 @@ class PaymentUpdateController(commonActions: CommonActions, override val control
         SafeLogger.error(scrub"Failed to update card for identity user: $user due to $failure")
         Forbidden(Json.toJson(failure))
       }
-    }).run.map {
-      case -\/(message) =>
+    }).run.map(_.toEither).map {
+      case Left(message) =>
         SafeLogger.warn(s"Failed to update card for user $maybeUserId, due to $message")
         InternalServerError(s"Failed to update card for user $maybeUserId")
-      case \/-(result) => result
+      case Right(result) => result
     }
   }
 
@@ -94,13 +93,13 @@ class PaymentUpdateController(commonActions: CommonActions, override val control
     val maybeUserId = request.redirectAdvice.userId
     SafeLogger.info(s"Attempting to update direct debit for $maybeUserId")
     (for {
-      user <- EitherT(Future.successful(maybeUserId \/> "no identity cookie for user"))
-      directDebitDetails <- EitherT(Future.successful(updateForm.bindFromRequest().value \/> "no direct debit details submitted with request"))
+      user <- EitherT.fromEither(Future.successful(maybeUserId.toRight("no identity cookie for user")))
+      directDebitDetails <- EitherT.fromEither(Future.successful(updateForm.bindFromRequest().value.toRight("no direct debit details submitted with request")))
       (bankAccountName, bankAccountNumber, bankSortCode) = directDebitDetails
-      sfUser <- EitherT(tp.contactRepo.get(user).map(_.flatMap(_ \/> s"no SF user $user")))
-      subscription <- EitherT(tp.subService.current[SubscriptionPlan.AnyPlan](sfUser).map(subscriptionSelector(Some(memsub.Subscription.Name(subscriptionName)), s"the sfUser $sfUser")))
-      account <- EitherT(annotateFailableFuture(tp.zuoraService.getAccount(subscription.accountId), s"get account with id ${subscription.accountId}"))
-      billToContact <- EitherT(annotateFailableFuture(tp.zuoraService.getContact(account.billToId), s"get billTo contact with id ${account.billToId}"))
+      sfUser <- EitherT.fromEither(tp.contactRepo.get(user).map(_.toEither.flatMap(_.toRight(s"no SF user $user"))))
+      subscription <- EitherT.fromEither(tp.subService.current[SubscriptionPlan.AnyPlan](sfUser).map(subs => subscriptionSelector(Some(memsub.Subscription.Name(subscriptionName)), s"the sfUser $sfUser")(subs)))
+      account <- EitherT.fromEither(annotateFailableFuture(tp.zuoraService.getAccount(subscription.accountId), s"get account with id ${subscription.accountId}"))
+      billToContact <- EitherT.fromEither(annotateFailableFuture(tp.zuoraService.getContact(account.billToId), s"get billTo contact with id ${account.billToId}"))
       bankTransferPaymentMethod = BankTransfer(
         accountHolderName = bankAccountName,
         accountNumber = bankAccountNumber,
@@ -109,24 +108,24 @@ class PaymentUpdateController(commonActions: CommonActions, override val control
         lastName = billToContact.lastName,
         countryCode = "GB"
       )
-        createPaymentMethod <- EitherT(Future.successful {
-          account.paymentGateway
-                 .map(paymentGateway => CreatePaymentMethod(
-                   accountId = subscription.accountId,
-                   paymentMethod = bankTransferPaymentMethod,
-                   paymentGateway = paymentGateway,
-                   billtoContact = billToContact,
-                   invoiceTemplateOverride = None
-                 )) \/>
-          s"Unrecognised payment gateway for account ${subscription.accountId}"
-        })
-      _ <- EitherT(annotateFailableFuture(tp.zuoraService.createPaymentMethod(createPaymentMethod), "create direct debit payment method"))
-      freshDefaultPaymentMethodOption <- EitherT(annotateFailableFuture(tp.paymentService.getPaymentMethod(subscription.accountId), "get fresh default payment method"))
-    } yield checkDirectDebitUpdateResult(maybeUserId, freshDefaultPaymentMethodOption, bankAccountName, bankAccountNumber, bankSortCode)).run.map {
-      case -\/(message) =>
+      createPaymentMethod <- EitherT.fromEither(Future.successful {
+        account.paymentGateway
+               .map(paymentGateway => CreatePaymentMethod(
+                 accountId = subscription.accountId,
+                 paymentMethod = bankTransferPaymentMethod,
+                 paymentGateway = paymentGateway,
+                 billtoContact = billToContact,
+                 invoiceTemplateOverride = None
+               )).toRight(
+        s"Unrecognised payment gateway for account ${subscription.accountId}"
+        )})
+      _ <- EitherT.fromEither(annotateFailableFuture(tp.zuoraService.createPaymentMethod(createPaymentMethod), "create direct debit payment method"))
+      freshDefaultPaymentMethodOption <- EitherT.fromEither(annotateFailableFuture(tp.paymentService.getPaymentMethod(subscription.accountId), "get fresh default payment method"))
+    } yield checkDirectDebitUpdateResult(maybeUserId, freshDefaultPaymentMethodOption, bankAccountName, bankAccountNumber, bankSortCode)).run.map(_.toEither).map {
+      case Left(message) =>
         SafeLogger.warn(s"default-payment-method-lost: failed to update direct debit for user $maybeUserId, due to $message")
         InternalServerError("")
-      case \/-(result) => result
+      case Right(result) => result
     }
 
   }

--- a/membership-attribute-service/app/limit/InstanceCountOnSchedule.scala
+++ b/membership-attribute-service/app/limit/InstanceCountOnSchedule.scala
@@ -6,7 +6,7 @@ import com.gu.aws.CredentialsProvider
 import com.gu.memsub.util.ScheduledTask
 import com.typesafe.scalalogging.LazyLogging
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/membership-attribute-service/app/loghandling/LoggingWithLogstashFields.scala
+++ b/membership-attribute-service/app/loghandling/LoggingWithLogstashFields.scala
@@ -4,12 +4,12 @@ import loghandling.LoggingField._
 import play.api.Logger
 import net.logstash.logback.marker.LogstashMarker
 import net.logstash.logback.marker.Markers._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.language.implicitConversions
 
 trait LoggingWithLogstashFields {
 
-  lazy implicit val log = Logger(getClass)
+  lazy implicit val log: Logger = Logger(getClass)
 
   def logInfoWithCustomFields(message: String, customFields: List[LogField]): Unit = {
     log.logger.info(customFieldMarkers(customFields), message)

--- a/membership-attribute-service/app/monitoring/Metrics.scala
+++ b/membership-attribute-service/app/monitoring/Metrics.scala
@@ -18,13 +18,13 @@ case class Metrics(service: String) extends CloudWatch {
 final class ExpensiveMetrics(
   val service: String
 )(implicit system: ActorSystem, ec: ExecutionContext) extends CloudWatch with LazyLogging {
-  import scala.collection.JavaConverters._
+  import scala.jdk.CollectionConverters._
   private val chm = new ConcurrentHashMap[String, AtomicInteger]().asScala // keep it first in the constructor
 
   val stage = Config.stage
   val application = Config.applicationName
 
-  system.scheduler.schedule(5.seconds, 60.seconds)(publishAllMetrics())
+  system.scheduler.scheduleAtFixedRate(5.seconds, 60.seconds)(() => publishAllMetrics())
 
   def countRequest(key: String): Unit =
     chm.getOrElseUpdate(key, new AtomicInteger(1)).incrementAndGet()

--- a/membership-attribute-service/app/monitoring/SentryLogging.scala
+++ b/membership-attribute-service/app/monitoring/SentryLogging.scala
@@ -8,18 +8,18 @@ import com.gu.monitoring.SafeLogger._
 import configuration.Config
 import io.sentry.Sentry
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 
 object SentryLogging {
-  def init() {
+  def init(): Unit = {
       Config.sentryDsn match {
         case None => SafeLogger.warn("No Sentry logging configured (OK for dev)")
         case Some(sentryDSN) =>
           SafeLogger.info(s"Initialising Sentry logging")
           Try {
             val sentryClient = Sentry.init(sentryDSN)
-            val buildInfo: Map[String, String] = app.BuildInfo.toMap.mapValues(_.toString)
+            val buildInfo: Map[String, String] = app.BuildInfo.toMap.view.mapValues(_.toString).toMap
             val tags = Map("stage" -> Config.stage) ++ buildInfo
             sentryClient.setTags(tags.asJava)
           } match {

--- a/membership-attribute-service/app/services/MobileSubscriptionService.scala
+++ b/membership-attribute-service/app/services/MobileSubscriptionService.scala
@@ -4,16 +4,14 @@ import configuration.Config
 import models.MobileSubscriptionStatus
 import com.github.nscala_time.time.OrderingImplicits._
 import com.gu.monitoring.SafeLogger
-import loghandling.LoggingWithLogstashFields
 import play.api.libs.json.{JsError, JsSuccess}
 import play.api.libs.ws.WSClient
-import scalaz.{-\/, \/, \/-}
 
 import scala.concurrent.{ExecutionContext, Future}
 
 trait MobileSubscriptionService {
 
-  def getSubscriptionStatusForUser(identityId: String): Future[\/[String, Option[MobileSubscriptionStatus]]]
+  def getSubscriptionStatusForUser(identityId: String): Future[Either[String, Option[MobileSubscriptionStatus]]]
 
 }
 
@@ -24,27 +22,27 @@ class MobileSubscriptionServiceImpl(wsClient: WSClient)(implicit ec: ExecutionCo
     case _ => "https://mobile-purchases.mobile-aws.code.dev-guardianapis.com"
   }
 
-  override def getSubscriptionStatusForUser(identityId: String): Future[String \/ Option[MobileSubscriptionStatus]] = {
+  override def getSubscriptionStatusForUser(identityId: String): Future[Either[String, Option[MobileSubscriptionStatus]]] = {
     val response = wsClient.url(s"$subscriptionURL/user/subscriptions/$identityId")
       .withHttpHeaders("Authorization" -> s"Bearer ${Config.Mobile.subscriptionApiKey}")
       .get()
 
     response.map { resp =>
       if (resp.status != 200) {
-        \/.left(s"Unable to fetch the mobile subscription status for $identityId, got HTTP ${resp.status} ${resp.statusText}")
+        Left(s"Unable to fetch the mobile subscription status for $identityId, got HTTP ${resp.status} ${resp.statusText}")
       } else {
         val parsedSubs = (resp.json \ "subscriptions")
           .validate[List[MobileSubscriptionStatus]]
 
         parsedSubs match {
-          case JsError(errors) => -\/(s"Unable to parse mobile subscription response: $errors")
+          case JsError(errors) => Left(s"Unable to parse mobile subscription response: $errors")
           case JsSuccess(subs, _) =>
             SafeLogger.info(s"Successfully retrieved ${subs.size} mobile subscriptions for $identityId")
             val mostRecentValidSub = subs.filter(_.valid).sortBy(_.to).lastOption
             val mostRecentInvalidSub = subs.filterNot(_.valid).sortBy(_.to).lastOption
             val result = mostRecentValidSub.orElse(mostRecentInvalidSub)
             SafeLogger.info(s"Mobile subscription for $identityId is $result")
-            \/-(result)
+            Right(result)
         }
       }
     }

--- a/membership-attribute-service/app/services/ScanamoAttributeService.scala
+++ b/membership-attribute-service/app/services/ScanamoAttributeService.scala
@@ -15,7 +15,6 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.dynamodb.model.{DescribeTableRequest, TableStatus}
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.language.higherKinds
 
 class ScanamoAttributeService(client: DynamoDbAsyncClient, table: String)(implicit executionContext: ExecutionContext)
     extends AttributeService with LazyLogging {
@@ -38,14 +37,14 @@ class ScanamoAttributeService(client: DynamoDbAsyncClient, table: String)(implic
     run(scanamo.get("UserId" === userId).map(_.flatMap {
       _
         .left.map(e => logger.warn("Scanamo error in get: ", e))
-        .right.toOption
+        .toOption
     }))
 
   def getMany(userIds: List[String]): Future[Seq[DynamoAttributes]] =
     run(scanamo.getAll("UserId" in userIds.toSet)).map(_.flatMap{
       _
         .left.map(e => logger.warn("Scanamo error in getAll: ", e))
-        .right.toOption
+        .toOption
     }).map(_.toList)
 
   override def set(attributes: DynamoAttributes): Future[Unit] = run(scanamo.put(attributes))

--- a/membership-attribute-service/app/utils/ListEither.scala
+++ b/membership-attribute-service/app/utils/ListEither.scala
@@ -1,26 +1,29 @@
 package utils
 
-import scalaz.{EitherT, ListT, OptionT, \/}
+import scalaz.{EitherT, IList, ListT, OptionT, \/}
 import scalaz.std.scalaFuture._
+
 import scala.concurrent.{ExecutionContext, Future}
 
 object ListEither {
 
-  type FutureEither[X] = EitherT[Future, String, X]
+  type FutureEither[X] = EitherT[String, Future, X]
 
-  def apply[A](m: Future[\/[String, List[A]]]): ListT[FutureEither, A] =
-    ListT[FutureEither, A](EitherT[Future, String, List[A]](m))
+  private def apply[A](m: Future[\/[String, IList[A]]]): ListT[FutureEither, A] =
+    ListT[FutureEither, A](EitherT[String, Future, IList[A]](m))
 
   def fromOptionEither[A](value: OptionT[FutureEither, List[A]])(implicit ex: ExecutionContext): ListT[FutureEither, A] =
-    ListT[FutureEither, A](value.run.map(_.toList.flatten))
+  ListT[FutureEither, A](value.map(IList.fromList).run.map(x => IList.fromOption(x).flatten))
 
-  def liftList[A](x: Future[\/[String, A]])(implicit ex: ExecutionContext): ListT[FutureEither, A] =
-    apply(x.map(_.map[List[A]](a => List(a))))
+  private def liftListDisjunction[A](x: Future[\/[String, A]])(implicit ex: ExecutionContext): ListT[FutureEither, A] =
+    apply(x.map(_.map[IList[A]](a => IList(a))))
+
+  def liftList[A](x: Future[Either[String, A]])(implicit ex: ExecutionContext): ListT[FutureEither, A] =
+    liftListDisjunction(x.map(\/.fromEither))
 
   def liftEitherList[A](future: Future[A])(implicit ex: ExecutionContext): ListT[FutureEither, A] = {
     apply(future map { value: A =>
-      \/.right[String, List[A]](List(value))
+      \/.right[String, IList[A]](IList(value))
     })
   }
-
 }

--- a/membership-attribute-service/app/utils/OptionEither.scala
+++ b/membership-attribute-service/app/utils/OptionEither.scala
@@ -1,19 +1,22 @@
 package utils
 
-import scalaz.{EitherT, OptionT, \/}
+import scalaz.{-\/, EitherT, OptionT, \/, \/-}
 
 import scala.concurrent.{ExecutionContext, Future}
 
 // this is helping us stack future/either/option
 object OptionEither {
 
-  type FutureEither[X] = EitherT[Future, String, X]
+  type FutureEither[X] = EitherT[String, Future, X]
 
   def apply[A](m: Future[\/[String, Option[A]]]): OptionT[FutureEither, A] =
-    OptionT[FutureEither, A](EitherT[Future, String, Option[A]](m))
+    OptionT[FutureEither, A](EitherT[String, Future, Option[A]](m))
 
-  def liftOption[A](x: Future[\/[String, A]])(implicit ex: ExecutionContext): OptionT[FutureEither, A] =
+  private def liftOptionDisjunction[A](x: Future[\/[String, A]])(implicit ex: ExecutionContext): OptionT[FutureEither, A] =
     apply(x.map(_.map[Option[A]](Some.apply)))
+
+  def liftOption[A](x: Future[Either[String, A]])(implicit ex: ExecutionContext): OptionT[FutureEither, A] =
+    liftOptionDisjunction(x.map(\/.fromEither))
 
   def liftFutureEither[A](x: Option[A]): OptionT[FutureEither, A] =
     apply(Future.successful(\/.right[String,Option[A]](x)))

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -1,4 +1,4 @@
-GET         /healthcheck                                                        controllers.HealthCheckController.healthCheck
+GET         /healthcheck                                                        controllers.HealthCheckController.healthCheck()
 
 GET         /user-attributes/me                                                 controllers.AttributeController.attributes
 

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -3,26 +3,23 @@ package controllers
 import actions.{AuthAndBackendRequest, AuthenticatedUserAndBackendRequest, CommonActions, HowToHandleRecencyOfSignedIn}
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
-import com.gu.identity.model.{PrivateFields, StatusFields, User}
+import com.gu.identity.model.{StatusFields, User}
 import com.gu.identity.{RedirectAdviceResponse, SignedInRecently}
 import components.{TouchpointBackends, TouchpointComponents}
 import configuration.Config
-import models.{Attributes, ContributionData, MobileSubscriptionStatus}
+import models.{Attributes, MobileSubscriptionStatus}
 import org.joda.time.LocalDate
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import org.specs2.specification.AfterAll
 import play.api.libs.json.Json
 import play.api.mvc._
-import play.api.test._
 import play.api.test.Helpers._
-import scalaz.\/
+import play.api.test._
 import services.{AttributesFromZuora, AuthenticationService, FakePostgresService, MobileSubscriptionService}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import models.SupportReminders
-import models.RecurringReminderStatus
 
 class AttributeControllerTest extends Specification with AfterAll with Mockito {
 
@@ -129,8 +126,8 @@ class AttributeControllerTest extends Specification with AfterAll with Mockito {
   }
 
   object FakeMobileSubscriptionService extends MobileSubscriptionService {
-    override def getSubscriptionStatusForUser(identityId: String): Future[String \/ Option[MobileSubscriptionStatus]] =
-      Future.successful(\/.right(None))
+    override def getSubscriptionStatusForUser(identityId: String): Future[Either[String, Option[MobileSubscriptionStatus]]] =
+      Future.successful(Right(None))
   }
 
   private val controller = new AttributeController(new AttributesFromZuora(), commonActions, Helpers.stubControllerComponents(), FakePostgresService(validUserId), FakeMobileSubscriptionService) {
@@ -185,8 +182,8 @@ class AttributeControllerTest extends Specification with AfterAll with Mockito {
   
   private def verifyIdentityHeadersSet(result:Future[Result], expectedUserId:String, expectedTestUser:Boolean = false) = {
     val resultHeaders = headers(result)
-    resultHeaders.get("X-Gu-Identity-Id") should beEqualTo(Some(expectedUserId))
-    resultHeaders.get("X-Gu-Membership-Test-User") should beEqualTo(Some(expectedTestUser.toString))
+    resultHeaders.get("X-Gu-Identity-Id") should beSome(expectedUserId)
+    resultHeaders.get("X-Gu-Membership-Test-User") should beSome(expectedTestUser.toString)
 
   }
 
@@ -361,5 +358,5 @@ class AttributeControllerTest extends Specification with AfterAll with Mockito {
 
   }
 
-  override def afterAll() = as.terminate()
+  override def afterAll(): Unit = as.terminate()
 }

--- a/membership-attribute-service/test/controllers/PaymentDetailMapperTest.scala
+++ b/membership-attribute-service/test/controllers/PaymentDetailMapperTest.scala
@@ -8,7 +8,7 @@ import org.mockito.Mockito.when
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
-import scalaz.{-\/, \/, \/-}
+import scalaz.\/
 import testdata.SubscriptionTestData
 
 import scala.concurrent.Future
@@ -22,7 +22,7 @@ class PaymentDetailMapperTest(implicit ee: ExecutionEnv) extends Specification w
       val mockPaymentService = mock[PaymentService]
       PaymentDetailMapper.paymentDetailsForSub(
         isGiftRedemption = true,
-        \/-(digipackGift),
+        Right(digipackGift),
         mockPaymentService
       ).map(
         details => details mustEqual PaymentDetailMapper.getGiftPaymentDetails(digipackGift)
@@ -42,7 +42,7 @@ class PaymentDetailMapperTest(implicit ee: ExecutionEnv) extends Specification w
 
       PaymentDetailMapper.paymentDetailsForSub(
         isGiftRedemption = false,
-        \/-(digipack),
+        Right(digipack),
         mockPaymentService
       ).map(
         details => details mustEqual expectedPaymentDetails
@@ -62,7 +62,7 @@ class PaymentDetailMapperTest(implicit ee: ExecutionEnv) extends Specification w
 
       PaymentDetailMapper.paymentDetailsForSub(
         isGiftRedemption = false,
-        \/-(digipack),
+        Right(digipack),
         mockPaymentService
       ).map(
         details => details mustEqual expectedPaymentDetails
@@ -75,7 +75,7 @@ class PaymentDetailMapperTest(implicit ee: ExecutionEnv) extends Specification w
 
       PaymentDetailMapper.paymentDetailsForSub(
         isGiftRedemption = false,
-        -\/(friend),
+        Left(friend),
         mockPaymentService
       ).map(
         details => details mustEqual expectedPaymentDetails

--- a/membership-attribute-service/test/services/AttributesMakerTest.scala
+++ b/membership-attribute-service/test/services/AttributesMakerTest.scala
@@ -3,15 +3,14 @@ package services
 import com.github.nscala_time.time.Implicits._
 import com.gu.memsub.Subscription.AccountId
 import com.gu.zuora.rest.ZuoraRestService.{PaymentMethodId, PaymentMethodResponse}
-import models.{Attributes, AccountWithSubscriptions, DynamoAttributes, ZuoraAttributes}
+import models.{AccountWithSubscriptions, ZuoraAttributes}
 import org.joda.time.{DateTime, LocalDate}
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mutable.Specification
-import testdata.SubscriptionTestData
 import testdata.AccountObjectTestData._
+import testdata.SubscriptionTestData
 
 import scala.concurrent.Future
-import scalaz.\/
 
 class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with SubscriptionTestData {
   override def referenceDate = new LocalDate()
@@ -19,9 +18,9 @@ class AttributesMakerTest(implicit ee: ExecutionEnv)  extends Specification with
   val referenceDateAsDynamoTimestamp = referenceDate.toDateTimeAtStartOfDay.getMillis / 1000
   val identityId = "123"
 
-  def paymentMethodResponseNoFailures(id: PaymentMethodId) = Future.successful(\/.right(PaymentMethodResponse(0, "CreditCardReferenceTransaction", referenceDate.toDateTimeAtCurrentTime)))
-  def paymentMethodResponseRecentFailure(id: PaymentMethodId) = Future.successful(\/.right(PaymentMethodResponse(1, "CreditCardReferenceTransaction", DateTime.now().minusDays(1))))
-  def paymentMethodResponseStaleFailure(id: PaymentMethodId) = Future.successful(\/.right(PaymentMethodResponse(1, "CreditCardReferenceTransaction", DateTime.now().minusMonths(2))))
+  def paymentMethodResponseNoFailures(id: PaymentMethodId) = Future.successful(Right(PaymentMethodResponse(0, "CreditCardReferenceTransaction", referenceDate.toDateTimeAtCurrentTime)))
+  def paymentMethodResponseRecentFailure(id: PaymentMethodId) = Future.successful(Right(PaymentMethodResponse(1, "CreditCardReferenceTransaction", DateTime.now().minusDays(1))))
+  def paymentMethodResponseStaleFailure(id: PaymentMethodId) = Future.successful(Right(PaymentMethodResponse(1, "CreditCardReferenceTransaction", DateTime.now().minusMonths(2))))
 
   "zuoraAttributes" should {
     val anotherAccountSummary = accountObjectWithZeroBalance.copy(Id = AccountId("another accountId"))

--- a/membership-attribute-service/test/services/FakeContributionsStoreDatabaseService.scala
+++ b/membership-attribute-service/test/services/FakeContributionsStoreDatabaseService.scala
@@ -1,8 +1,6 @@
 package services
 
-import java.util.{Date, GregorianCalendar}
-
-import scalaz.\/
+import java.util.GregorianCalendar
 
 import scala.concurrent.Future
 import services.ContributionsStoreDatabaseService.DatabaseGetResult
@@ -18,13 +16,13 @@ case class FakePostgresService(validId: String) extends ContributionsStoreDataba
     )
     def getAllContributions(identityId: String): DatabaseGetResult[List[ContributionData]] =
         if (identityId == validId)
-            Future.successful(\/.right(List(testContributionData)))
+            Future.successful(Right(List(testContributionData)))
         else
-            Future.successful(\/.right(Nil))
+            Future.successful(Right(Nil))
 
     def getLatestContribution(identityId: String): DatabaseGetResult[Option[ContributionData]] =
-        Future.successful(\/.right(None))
+        Future.successful(Right(None))
 
     def getSupportReminders(identityId: String): DatabaseGetResult[SupportReminders] =
-        Future.successful(\/.right(SupportReminders(RecurringReminderStatus.NotSet, None)))
+        Future.successful(Right(SupportReminders(RecurringReminderStatus.NotSet, None)))
 }

--- a/membership-attribute-service/test/services/SupporterProductDataIntegrationTest.scala
+++ b/membership-attribute-service/test/services/SupporterProductDataIntegrationTest.scala
@@ -73,11 +73,11 @@ class SupporterProductDataIntegrationTest(implicit ee: ExecutionEnv) extends Spe
   def getFromZuora(identityId: String) = {
     attributesFromZuora.getAttributesFromZuoraWithCacheFallback(
       identityId,
-      identityIdToAccounts = touchpoint.zuoraRestService.getAccounts,
-      subscriptionsForAccountId = accountId => reads => touchpoint.subService.subscriptionsForAccountId[AnyPlan](accountId)(reads),
-      giftSubscriptionsForIdentityId = touchpoint.zuoraRestService.getGiftSubscriptionRecordsFromIdentityId,
+      identityIdToAccounts = id => touchpoint.zuoraRestService.getAccounts(id).map(_.toEither),
+      subscriptionsForAccountId = accountId => reads => touchpoint.subService.subscriptionsForAccountId[AnyPlan](accountId)(reads).map(_.toEither),
+      giftSubscriptionsForIdentityId = id => touchpoint.zuoraRestService.getGiftSubscriptionRecordsFromIdentityId(id).map(_.toEither),
       dynamoAttributeService = attrService,
-      paymentMethodForPaymentMethodId = paymentMethodId => touchpoint.zuoraRestService.getPaymentMethod(paymentMethodId.get),
+      paymentMethodForPaymentMethodId = paymentMethodId => touchpoint.zuoraRestService.getPaymentMethod(paymentMethodId.get).map(_.toEither),
       supporterProductDataService = touchpoint.supporterProductDataService
     )
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
   val awsDynamo = "software.amazon.awssdk" % "dynamodb" % awsClientV2Version
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.603"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.608"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.33"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "2.0.3"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"


### PR DESCRIPTION
This is an [upgrade of membership-common](https://github.com/guardian/members-data-api/pull/647/files#diff-ad2642dc77b3679e4ad2c7d3b2f59a2dcf48c1bf5b93a558a4fa44828315a34cR21), which has necessitated the upgrade of:
* [Scala to 2.13](https://github.com/guardian/members-data-api/pull/647/files#diff-5634c415cd8c8504fdb973a3ed092300b43c4b8fc1e184f7249eb29a55511f91R25)
* Scalaz to 7.3 through a transitive dependency of membership-common.
 
In Scalaz 7.3, [disjunctions have become invariant](https://github.com/scalaz/scalaz/pull/1603).  So I've taken the opportunity to convert them to `Either`s throughout,  as otherwise I would have to add explicit types all over the place and an `Either` is probably more familiar to most people anyway.  The code calls methods of membership-common that take and return disjunctions so in those cases I've mapped back and forth between `Either`s and `Disjunction`s.  This is the bulk of this PR.

There are also a few deprecation warnings that have been resolved.

Tested on Code.
