### PR TITLE
Make digital subscription gifts appear in mdapi

### DIFF
--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -333,7 +333,7 @@ class AccountController(commonActions: CommonActions, override val controllerCom
       // subscription so we can reuse it and avoid a call to Zuora
       nonGiftSubs.find(_.subscription.name == subscriptionName) match {
         case Some(contactAndSubscription) => Future.successful(Some(contactAndSubscription.subscription))
-        case _ => subscriptionService.get[AnyPlan](subscriptionName, isActiveToday = false)
+        case _ => subscriptionService.get[AnyPlan](subscriptionName, isActiveToday = false) //set isActiveToday to false so that we find digisub plans with a one time charge
       }
     }
     Future.sequence(all).map(_.flatten) // failures turn to None, and are logged, so just ignore them

--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -333,7 +333,7 @@ class AccountController(commonActions: CommonActions, override val controllerCom
       // subscription so we can reuse it and avoid a call to Zuora
       nonGiftSubs.find(_.subscription.name == subscriptionName) match {
         case Some(contactAndSubscription) => Future.successful(Some(contactAndSubscription.subscription))
-        case _ => subscriptionService.get[AnyPlan](subscriptionName, isActiveToday = true)
+        case _ => subscriptionService.get[AnyPlan](subscriptionName, isActiveToday = false)
       }
     }
     Future.sequence(all).map(_.flatten) // failures turn to None, and are logged, so just ignore them

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
   val awsDynamo = "software.amazon.awssdk" % "dynamodb" % awsClientV2Version
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.1-SNAPSHOT"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.610"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.33"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "2.0.3"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
   val awsDynamo = "software.amazon.awssdk" % "dynamodb" % awsClientV2Version
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion
   val awsCloudWatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion
-  val membershipCommon = "com.gu" %% "membership-common" % "0.609"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.1-SNAPSHOT"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.33"
   val kinesis = "com.gu" % "kinesis-logback-appender" % "2.0.3"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"

--- a/start-api-debug.sh
+++ b/start-api-debug.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 cd $(dirname $0)
-sbt -Djava.awt.headless=true -jvm-debug 9997 "project membership-attribute-service" "devrun"
+sbt -mem 4096 -Djava.awt.headless=true -jvm-debug 9997 "project membership-attribute-service" "devrun"


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
https://github.com/guardian/membership-common/pull/646 enables membership-common to load digital subscription gifts from Zuora. This PR updates members-data-api to use this version and also makes a small change to how we request  subscriptions from Zuora to ensure that they are returned in the first place.

### trello card/screenshot/json/related PRs etc
https://trello.com/c/lsQSGoD0/163-investigate-gift-redemptions-not-showing-up-in-members-data-api
