### PR TITLE
Upgrade Jackson dependencies to fix Snyk vulnerability CVE-2020-36518

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,11 +25,19 @@ object Dependencies {
   val anorm = "org.playframework.anorm" %% "anorm" % "2.6.10"
   val netty = "io.netty" % "netty-codec" % "4.1.74.Final"
   val nettyHttp = "io.netty" % "netty-codec-http" % "4.1.74.Final"
-  val jacksonVersion = "2.11.4"
+
+  val jacksonVersion         = "2.13.2"
+  val jacksonDatabindVersion = "2.13.2.2"
 
   val jackson = Seq(
-    "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
-    "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion
+    "com.fasterxml.jackson.core"     % "jackson-core" %  jacksonVersion,
+    "com.fasterxml.jackson.core"     % "jackson-annotations" %  jacksonVersion,
+    "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" %  jacksonVersion,
+    "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" %  jacksonVersion,
+    "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion,
+    "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
+    "com.fasterxml.jackson.module"     % "jackson-module-parameter-names" % jacksonVersion,
+    "com.fasterxml.jackson.module"     %% "jackson-module-scala" % jacksonVersion,
   )
 
   //projects


### PR DESCRIPTION
### Why do we need this?
Security.

### The changes 
Jackson related dependency versions have been bumped because of vulnerability [CWE-400](https://cwe.mitre.org/data/definitions/400.html) // [CVE-2020-36518](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518) // [SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244](https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244)

I used this https://github.com/playframework/playframework/discussions/11222 as a reference for which transient dependencies are needed.