### PR TITLE
Update identity-auth-play to 3.254

### DIFF
--- a/membership-attribute-service/app/models/SupportReminders.scala
+++ b/membership-attribute-service/app/models/SupportReminders.scala
@@ -1,12 +1,9 @@
 package models
 
-import java.util.Date
-
-import anorm.{RowParser, Macro, Row, Success, ~}
+import anorm.{Macro, RowParser}
 import play.api.libs.json.{Json, Writes}
-import org.scalactic.Bool
 
-sealed trait RecurringReminderStatus 
+sealed trait RecurringReminderStatus
 
 
 object RecurringReminderStatus {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val awsClientV2Version = "2.16.86"
 
   val sentryLogback = "io.sentry" % "sentry-logback" % "1.7.5"
-  val identityAuth = "com.gu.identity" %% "identity-auth-play" % "3.248"
+  val identityAuth = "com.gu.identity" %% "identity-auth-play" % "3.254"
   val identityTestUsers = "com.gu" %% "identity-test-users" % "0.8"
   val postgres = "org.postgresql" % "postgresql" % "42.3.3"
   val jdbc = PlayImport.jdbc


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
Upgrade identity-auth-play to 3.254 to mitigate a critical vulnerability in http4s see https://github.com/guardian/identity/pull/2106 for more info.