### PR TITLE
Include Guardian Patrons in mdapi user attributes response

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -142,7 +142,7 @@ class AttributeController(
             def customFields(supporterType: String): List[LogField] = List(LogFieldString("lookup-endpoint-description", endpointDescription), LogFieldString("supporter-type", supporterType), LogFieldString("data-source", fromWhere))
 
             val result = enrichedZuoraAttributes match {
-              case Some(attrs @ Attributes(_, Some(tier), _, _, _, _, _, _, _, _)) =>
+              case Some(attrs @ Attributes(_, Some(tier), _, _, _, _, _, _, _, _, _)) =>
                 logInfoWithCustomFields(s"${user.id} is a $tier member - $endpointDescription - $attrs found via $fromWhere", customFields("member"))
                 onSuccessMember(attrs).withHeaders(
                   "X-Gu-Membership-Tier" -> tier,

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -111,9 +111,11 @@ class AttributeController(
     )
   }
 
-  protected def getZuoraAttributes(identityId: String)(implicit request: AuthenticatedUserAndBackendRequest[AnyContent]) = {
+  protected def getSupporterProductDataAttributes(identityId: String)(implicit request: AuthenticatedUserAndBackendRequest[AnyContent]) = {
     log.info(s"Fetching attributes from supporter-product-data table for user $identityId")
-    request.touchpoint.supporterProductDataService.getAttributes(identityId).map(maybeAttributes => ("supporter-product-data", maybeAttributes.getOrElse(None)))
+    request.touchpoint.supporterProductDataService
+      .getAttributes(identityId)
+      .map(maybeAttributes => ("supporter-product-data", maybeAttributes.getOrElse(None)))
   }
 
   private def lookup(endpointDescription: String, onSuccessMember: Attributes => Result, onSuccessSupporter: Attributes => Result, onNotFound: Result, sendAttributesIfNotFound: Boolean = false) = {
@@ -126,7 +128,7 @@ class AttributeController(
       request.user match {
         case Some(user) =>
           // execute futures outside of the for comprehension so they are executed in parallel rather than in sequence
-          val futureAttributes = getZuoraAttributes(user.id)
+          val futureAttributes = getSupporterProductDataAttributes(user.id)
           val futureOneOffContribution = getLatestOneOffContributionDate(user.id, user)
           val futureMobileSubscriptionStatus = getLatestMobileSubscription(user.id)
 
@@ -157,6 +159,9 @@ class AttributeController(
                 }
                 attrs.GuardianWeeklySubscriptionExpiryDate.foreach {date =>
                   logInfoWithCustomFields(s"${user.id} is a Guardian Weekly subscriber expiring $date", customFields("guardian-weekly-subscriber"))
+                }
+                attrs.GuardianPatronExpiryDate.foreach {date =>
+                  logInfoWithCustomFields(s"${user.id} is a Guardian Patron expiring $date", customFields("guardian-patron"))
                 }
                 attrs.RecurringContributionPaymentPlan.foreach { paymentPlan =>
                   logInfoWithCustomFields(s"${user.id} is a regular $paymentPlan contributor", customFields("contributor"))

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -36,6 +36,7 @@ case class Attributes(
   PaperSubscriptionExpiryDate: Option[LocalDate] = None,
   GuardianWeeklySubscriptionExpiryDate: Option[LocalDate] = None,
   LiveAppSubscriptionExpiryDate: Option[LocalDate] = None,
+  GuardianPatronExpiryDate: Option[LocalDate] = None,
   AlertAvailableFor: Option[String] = None) {
   lazy val isFriendTier = Tier.exists(_.equalsIgnoreCase("friend"))
   lazy val isSupporterTier = Tier.exists(_.equalsIgnoreCase("supporter"))
@@ -51,12 +52,13 @@ case class Attributes(
   lazy val isPaperSubscriber = PaperSubscriptionExpiryDate.exists(_.isAfter(now))
   lazy val isGuardianWeeklySubscriber = GuardianWeeklySubscriptionExpiryDate.exists(_.isAfter(now))
   lazy val isPremiumLiveAppSubscriber = LiveAppSubscriptionExpiryDate.exists(_.isAfter(now))
+  lazy val isGuardianPatron = GuardianPatronExpiryDate.exists(_.isAfter(now))
 
   lazy val contentAccess = ContentAccess(
     member = isPaidTier || isFriendTier,
     paidMember = isPaidTier,
     recurringContributor = isRecurringContributor,
-    digitalPack = digitalSubscriberHasActivePlan || isPaperSubscriber,
+    digitalPack = digitalSubscriberHasActivePlan || isPaperSubscriber || isGuardianPatron,
     paperSubscriber = isPaperSubscriber,
     guardianWeeklySubscriber = isGuardianWeeklySubscriber
   )
@@ -71,6 +73,7 @@ case class Attributes(
       || isPaperSubscriber
       || isGuardianWeeklySubscriber
       || isPremiumLiveAppSubscriber
+      || isGuardianPatron
     )
 
 }
@@ -143,6 +146,7 @@ object Attributes {
       (__ \ "paperSubscriptionExpiryDate").writeNullable[LocalDate] and
       (__ \ "guardianWeeklyExpiryDate").writeNullable[LocalDate] and
       (__ \ "liveAppSubscriptionExpiryDate").writeNullable[LocalDate] and
+      (__ \ "guardianPatronExpiryDate").writeNullable[LocalDate] and
       (__ \ "alertAvailableFor").writeNullable[String]
   )(unlift(Attributes.unapply))
     .addNullableField("digitalSubscriptionExpiryDate", _.latestDigitalSubscriptionExpiryDate)

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -18,7 +18,8 @@ case class ContentAccess(
   recurringContributor: Boolean,
   digitalPack: Boolean,
   paperSubscriber: Boolean,
-  guardianWeeklySubscriber: Boolean
+  guardianWeeklySubscriber: Boolean,
+  guardianPatron: Boolean
 )
 
 object ContentAccess {
@@ -60,7 +61,8 @@ case class Attributes(
     recurringContributor = isRecurringContributor,
     digitalPack = digitalSubscriberHasActivePlan || isPaperSubscriber || isGuardianPatron,
     paperSubscriber = isPaperSubscriber,
-    guardianWeeklySubscriber = isGuardianWeeklySubscriber
+    guardianWeeklySubscriber = isGuardianWeeklySubscriber,
+    guardianPatron = isGuardianPatron
   )
 
   // show support messaging (in app & on dotcom) if they do NOT have any active products

--- a/membership-attribute-service/app/services/AttributesFromZuora.scala
+++ b/membership-attribute-service/app/services/AttributesFromZuora.scala
@@ -256,7 +256,8 @@ object AttributesFromZuora extends LazyLogging {
         recurringContributor = false,
         digitalPack = false,
         paperSubscriber = false,
-        guardianWeeklySubscriber = false
+        guardianWeeklySubscriber = false,
+        guardianPatron = false
       )
     )
 
@@ -268,7 +269,8 @@ object AttributesFromZuora extends LazyLogging {
         recurringContributor = true,
         digitalPack = false,
         paperSubscriber = false,
-        guardianWeeklySubscriber = false
+        guardianWeeklySubscriber = false,
+        guardianPatron = false
       )
     )
 

--- a/membership-attribute-service/app/services/SupporterRatePlanToAttributesMapper.scala
+++ b/membership-attribute-service/app/services/SupporterRatePlanToAttributesMapper.scala
@@ -58,6 +58,7 @@ object SupporterRatePlanToAttributesMapper {
   val productRatePlanMappings: Map[Stage, Map[List[ProductRatePlanId], AttributeTransformer]] =
     Map(
       "PROD" -> Map(
+        List("guardian_patron") -> guardianPatronTransformer,
         List(
           "2c92a0fb4edd70c8014edeaa4eae220a",
           "2c92a0fb4edd70c8014edeaa4e972204",
@@ -136,7 +137,6 @@ object SupporterRatePlanToAttributesMapper {
           "2c92a0fe57d0a0c40157d74241005544",
           "2c92a0ff58bdf4eb0158f307ed0e02be"
         ) -> guardianWeeklyTransformer,
-        List("guardian_patron") -> guardianPatronTransformer,
         List(
           "2c92a0fb4ce4b8e7014ce711d3c37e60",
           "2c92a0f9479fb46d0147d0155c6f558b"
@@ -164,6 +164,7 @@ object SupporterRatePlanToAttributesMapper {
         ) -> memberTransformer(Patron)
       ),
       "UAT" -> Map(
+        List("guardian_patron") -> guardianPatronTransformer,
         List(
           "2c92c0f94f2acf73014f2c908f671591",
           "2c92c0f84f2ac59d014f2c94aea9199e",
@@ -244,6 +245,7 @@ object SupporterRatePlanToAttributesMapper {
         ) -> memberTransformer(Patron)
       ),
       "DEV" -> Map(
+        List("guardian_patron") -> guardianPatronTransformer,
         List(
           "2c92c0f84bbfec8b014bc655f4852d9d",
           "2c92c0f94bbffaaa014bc6a4212e205b",

--- a/membership-attribute-service/app/services/SupporterRatePlanToAttributesMapper.scala
+++ b/membership-attribute-service/app/services/SupporterRatePlanToAttributesMapper.scala
@@ -51,6 +51,10 @@ object SupporterRatePlanToAttributesMapper {
     attributes.copy(
       GuardianWeeklySubscriptionExpiryDate = Some(supporterRatePlanItem.termEndDate)
     )
+  val guardianPatronTransformer: AttributeTransformer = (attributes: Attributes, supporterRatePlanItem: DynamoSupporterRatePlanItem) =>
+    attributes.copy(
+      GuardianPatronExpiryDate = Some(supporterRatePlanItem.termEndDate)
+    )
   val productRatePlanMappings: Map[Stage, Map[List[ProductRatePlanId], AttributeTransformer]] =
     Map(
       "PROD" -> Map(
@@ -132,6 +136,7 @@ object SupporterRatePlanToAttributesMapper {
           "2c92a0fe57d0a0c40157d74241005544",
           "2c92a0ff58bdf4eb0158f307ed0e02be"
         ) -> guardianWeeklyTransformer,
+        List("guardian_patron") -> guardianPatronTransformer,
         List(
           "2c92a0fb4ce4b8e7014ce711d3c37e60",
           "2c92a0f9479fb46d0147d0155c6f558b"

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -132,7 +132,7 @@ class AttributeControllerTest extends Specification with AfterAll with Mockito {
 
   private val controller = new AttributeController(new AttributesFromZuora(), commonActions, Helpers.stubControllerComponents(), FakePostgresService(validUserId), FakeMobileSubscriptionService) {
     override val executionContext = scala.concurrent.ExecutionContext.global
-    override def getZuoraAttributes(identityId: String)(implicit request: AuthenticatedUserAndBackendRequest[AnyContent]): Future[(String, Option[Attributes])] = Future {
+    override def getSupporterProductDataAttributes(identityId: String)(implicit request: AuthenticatedUserAndBackendRequest[AnyContent]): Future[(String, Option[Attributes])] = Future {
       if (identityId == validUserId || identityId == validEmployeeUser.id)
         ("Zuora", Some(testAttributes))
       else
@@ -179,7 +179,7 @@ class AttributeControllerTest extends Specification with AfterAll with Mockito {
         | }
       """.stripMargin)
   }
-  
+
   private def verifyIdentityHeadersSet(result:Future[Result], expectedUserId:String, expectedTestUser:Boolean = false) = {
     val resultHeaders = headers(result)
     resultHeaders.get("X-Gu-Identity-Id") should beSome(expectedUserId)
@@ -212,7 +212,7 @@ class AttributeControllerTest extends Specification with AfterAll with Mockito {
                    | }
                  """.stripMargin)
   }
-  
+
   private def verifySuccessfullOneOfContributionsResult(result: Future[Result]) = {
     status(result) shouldEqual OK
     val jsonBody = contentAsJson(result)
@@ -275,13 +275,13 @@ class AttributeControllerTest extends Specification with AfterAll with Mockito {
 
     "retrieve default features and set identity headers for unknown users" in {
       val req = FakeRequest().withCookies(userWithoutAttributesCookie)
-      
+
       val result = controller.features(req)
       verifyDefaultFeaturesResult(result)
       verifyIdentityHeadersSet(result, userWithoutAttributesUserId)
 
-    }    
-    
+    }
+
     "retrieve features and set identity headers for user in cookie" in {
       val req = FakeRequest().withCookies(validUserCookie)
       val result: Future[Result] = controller.features(req)
@@ -299,8 +299,8 @@ class AttributeControllerTest extends Specification with AfterAll with Mockito {
       verifySuccessfulMembershipResult(result)
       verifyIdentityHeadersSet(result, validUser.id)
 
-    }    
-    
+    }
+
     "retrieve all the attributes and set identity headers for user in cookie" in {
       val req = FakeRequest().withCookies(validUserCookie)
       val result: Future[Result] = controller.attributes(req)
@@ -309,7 +309,7 @@ class AttributeControllerTest extends Specification with AfterAll with Mockito {
       verifyIdentityHeadersSet(result, validUser.id)
 
     }
-    
+
     "return unauthorised and set identity headers when attempting to retrieve one off contributions for user with a non validated email" in {
       val req = FakeRequest().withCookies(validUnvalidatedEmailCookie)
       val result: Future[Result] = controller.oneOffContributions(req)
@@ -320,7 +320,7 @@ class AttributeControllerTest extends Specification with AfterAll with Mockito {
     "return one off contributions and set identity headers for user with a validated email" in {
       val req = FakeRequest().withCookies(validUserCookie)
       val result: Future[Result] = controller.oneOffContributions(req)
-      
+
       verifySuccessfullOneOfContributionsResult(result)
       verifyIdentityHeadersSet(result, validUser.id)
     }
@@ -332,7 +332,7 @@ class AttributeControllerTest extends Specification with AfterAll with Mockito {
       verifySuccessfullOneOfContributionsResult(result)
       verifyIdentityHeadersSet(result, validUser.id)
     }
-    
+
     val digipackAllowEmployeeAccessDateHack = Some(new LocalDate(2999, 1, 1))
     "allow DigiPack access via hack to guardian employees with validated guardian.co.uk email" in {
       val req = FakeRequest().withCookies(guardianEmployeeCookie)

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -207,7 +207,8 @@ class AttributeControllerTest extends Specification with AfterAll with Mockito {
                    |     "recurringContributor": true,
                    |     "digitalPack": true,
                    |     "paperSubscriber": true,
-                   |     "guardianWeeklySubscriber": true
+                   |     "guardianWeeklySubscriber": true,
+                   |     "guardianPatron": false
                    |   }
                    | }
                  """.stripMargin)
@@ -266,7 +267,8 @@ class AttributeControllerTest extends Specification with AfterAll with Mockito {
                      |    "recurringContributor": false,
                      |    "digitalPack": false,
                      |    "paperSubscriber": false,
-                     |    "guardianWeeklySubscriber": false
+                     |    "guardianWeeklySubscriber": false,
+                     |    "guardianPatron": false
                      |  }
                      |}""".stripMargin)
       verifyIdentityHeadersSet(result, userWithoutAttributesUserId)

--- a/membership-attribute-service/test/services/SupporterRatePlanToAttributesMapperTest.scala
+++ b/membership-attribute-service/test/services/SupporterRatePlanToAttributesMapperTest.scala
@@ -20,6 +20,13 @@ class SupporterRatePlanToAttributesMapperTest extends Specification {
   )
 
   "SupporterRatePlanToAttributesMapper" should {
+    "identify a Guardian Patron" in {
+      mapper.attributesFromSupporterRatePlans(
+        identityId,
+        List(ratePlanItem("guardian_patron"))
+      ) should beSome.which(_.GuardianPatronExpiryDate should beSome(termEndDate))
+    }
+
     "identify a monthly contribution" in {
       mapper.attributesFromSupporterRatePlans(
         identityId,


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
We want to be able to recognise Guardian Patrons on the website and apps so that we can give them the digital subscription benefits they are entitled to. 

This PR builds on [TODO: add support-frontend PR link]() which adds Patron data into the supporter-product-data DynamoDb table by making that data available through the user attributes endpoint.

### [Trello card](https://trello.com/c/YRVQ9COn/3-patrons)
