### PR TITLE
Add profiling for the user-attributes/me/mma endpoint

### DIFF
--- a/membership-attribute-service/app/controllers/AccountControllerMetrics.scala
+++ b/membership-attribute-service/app/controllers/AccountControllerMetrics.scala
@@ -1,0 +1,12 @@
+package controllers
+
+import com.amazonaws.regions.{Region, Regions}
+import com.gu.monitoring.CloudWatch
+
+class AccountControllerMetrics(val stage: String) extends CloudWatch {
+
+  val region = Region.getRegion(Regions.EU_WEST_1)
+  val service = "AccountController"
+  val application = "members-data-api"
+
+}


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
We want to try to improve the time that the `user-attributes/me/mma` endpoint takes to return a result. The first step in doing this is to get a sense of how long it is currently taking so we can then see if changes that we make have improved the situation. That's what this PR does.
