### PR TITLE
Ensuring the GoCardless gateway is set as default when updating Direct Debit details

### DIFF
--- a/membership-attribute-service/app/controllers/PaymentUpdateController.scala
+++ b/membership-attribute-service/app/controllers/PaymentUpdateController.scala
@@ -6,6 +6,7 @@ import com.gu.memsub.subsv2.SubscriptionPlan
 import com.gu.memsub.{CardUpdateFailure, CardUpdateSuccess, GoCardless, PaymentMethod}
 import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.SafeLogger._
+import com.gu.zuora.api.GoCardless
 import com.gu.zuora.soap.models.Commands.{BankTransfer, CreatePaymentMethod}
 import json.PaymentCardUpdateResultWriters._
 import play.api.data.Form
@@ -137,21 +138,13 @@ class PaymentUpdateController(commonActions: CommonActions, override val control
         lastName = billToContact.lastName,
         countryCode = "GB",
       )
-      createPaymentMethod <- EitherT.fromEither(Future.successful {
-        account.paymentGateway
-          .map(paymentGateway =>
-            CreatePaymentMethod(
-              accountId = subscription.accountId,
-              paymentMethod = bankTransferPaymentMethod,
-              paymentGateway = paymentGateway,
-              billtoContact = billToContact,
-              invoiceTemplateOverride = None,
-            ),
-          )
-          .toRight(
-            s"Unrecognised payment gateway for account ${subscription.accountId}",
-          )
-      })
+      createPaymentMethod = CreatePaymentMethod(
+        accountId = subscription.accountId,
+        paymentMethod = bankTransferPaymentMethod,
+        paymentGateway = GoCardless,
+        billtoContact = billToContact,
+        invoiceTemplateOverride = None,
+      )
       _ <- EitherT.fromEither(annotateFailableFuture(tp.zuoraService.createPaymentMethod(createPaymentMethod), "create direct debit payment method"))
       freshDefaultPaymentMethodOption <- EitherT.fromEither(
         annotateFailableFuture(tp.paymentService.getPaymentMethod(subscription.accountId), "get fresh default payment method"),


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
Before, the payment method update API was not changing the account's payment gateway, causing a misalignment between the default payment method and the gateway.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
Ensure the GoCardless gateway is set as default when updating Direct Debit details.

### trello card/screenshot/json/related PRs etc
