### PR TITLE
The calculation for the end date in the /me/mma response was nonsence…

### DIFF
--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -43,8 +43,6 @@ object AccountDetails {
 
       val mmaCategory = mmaCategoryFrom(product)
 
-      val endDate = paymentDetails.chargedThroughDate.getOrElse(paymentDetails.termEndDate)
-
       val paymentMethod = paymentDetails.paymentMethod match {
         case Some(payPal: PayPalMethod) =>
           Json.obj(
@@ -140,6 +138,7 @@ object AccountDetails {
       val futurePlans = sortedPlans.filter(plan => plan.start.isAfter(now))
 
       val startDate: LocalDate = sortedPlans.headOption.map(_.start).getOrElse(paymentDetails.customerAcceptanceDate)
+      val endDate: LocalDate = sortedPlans.headOption.map(_.end).getOrElse(paymentDetails.termEndDate)
 
       if (currentPlans.length > 1) logger.warn(s"More than one 'current plan' on sub with id: ${subscription.id}")
 


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
Some situations (e.g. cancelling a Guardian Weekly sub before fulfilment is due to start) lead to a cancelled sub's start date being after the end date. See screenshot.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
The calculation for the end date in the /me/mma response was nonsensical - it used the chargedThroughDate which has no relevance to the sub contract mechanic - and led to the end date being before the start date. I've changed it to use the same logic as the start date, maintaining the original fallback to the term end date.

### trello card/screenshot/json/related PRs etc
I'll fix the duplicate entry on this page in a separate PR, whereupon I'll add a test too. This fix is a dependency.
![179944347-37476330-060d-4e54-9be6-4fd70066f337](https://user-images.githubusercontent.com/1515970/179971747-526ef000-4661-4826-8b13-6964969f6e83.png)


