### PR TITLE
Fix end date being before start date on cancelled plan display in Manage My Account

### DIFF
--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -238,7 +238,7 @@ object CancelledSubscription {
               "subscriptionId" -> subscription.name.get,
               "cancellationEffectiveDate" -> subscription.termEndDate,
               "start" -> subscription.acceptanceDate,
-              "end" -> subscription.termEndDate,
+              "end" -> Seq(subscription.termEndDate, subscription.acceptanceDate).max,
               "readerType" -> subscription.readerType.value,
               "accountId" -> subscription.accountId.get,
             ),


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
If the sub is cancelled before it is paid for (during it's free trial or before the chosen first paper date) then Manage My Account was showing the wrong end date, causing the end date to be before start date on cancelled plan display in Manage My Account.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
Use the latest of the term end date and customer acceptance date (used for the Start date) as the End date value.

### trello card/screenshot/json/related PRs etc
![179944347-37476330-060d-4e54-9be6-4fd70066f337](https://user-images.githubusercontent.com/1515970/179987021-183790a3-093a-41ac-87bd-debac7f1b599.png)

The duplicate display of cancelled subs is an issue in the /me/mma call which will be fixed at a later date.