### PR TITLE
Just in case Revert "Fix end date being before start date on cancelled plan display in Manage My Account"

### DIFF
--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -238,7 +238,7 @@ object CancelledSubscription {
               "subscriptionId" -> subscription.name.get,
               "cancellationEffectiveDate" -> subscription.termEndDate,
               "start" -> subscription.acceptanceDate,
-              "end" -> Seq(subscription.termEndDate, subscription.acceptanceDate).max,
+              "end" -> subscription.termEndDate,
               "readerType" -> subscription.readerType.value,
               "accountId" -> subscription.accountId.get,
             ),


### PR DESCRIPTION
Reverts guardian/members-data-api#776