### PR TITLE
Give recurring contributors SupporterPlus on apps

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -91,22 +91,8 @@ class AttributeController(
   }
 
   private def isLiveApp(ua: String): Boolean = ua.matches("""^Guardian(News)?\/.*""")
-  private def isHighContributor(contribution: ContributionAmount, isMonthly: Boolean): Boolean = {
-    val threshold = contribution.currency match {
-      case Currency.GBP | Currency.USD | Currency.EUR =>
-        if (isMonthly) 10 else 95
-      case Currency.CAD =>
-        if (isMonthly) 13 else 120
-      case Currency.AUD | Currency.NZD =>
-        if (isMonthly) 15 else 140
-    }
-    contribution.amount >= threshold
-  }
   private def upgradeRecurringContributorsOnApps(userAgent: Option[String], attributes: Attributes): Attributes =
-    if (
-      userAgent.exists(isLiveApp) &&
-      attributes.RecurringContributionAmount.exists(amount => isHighContributor(amount, attributes.isMonthlyRecurringContributor))
-    ) {
+    if (attributes.HighContributor.contains(true) && userAgent.exists(isLiveApp)) {
       attributes.copy(SupporterPlusExpiryDate = Some(LocalDate.now().plusDays(1)))
     } else attributes
 

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -104,7 +104,6 @@ class AttributeController(
   }
   private def upgradeRecurringContributorsOnApps(userAgent: Option[String], attributes: Attributes): Attributes =
     if (
-      attributes.isRecurringContributor &&
       userAgent.exists(isLiveApp) &&
       attributes.RecurringContributionAmount.exists(amount => isHighContributor(amount, attributes.isMonthlyRecurringContributor))
     ) {

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -32,7 +32,7 @@ case class Attributes(
     UserId: String,
     Tier: Option[String] = None,
     RecurringContributionPaymentPlan: Option[String] = None,
-    RecurringContributionAmount: Option[ContributionAmount] = None,
+    HighContributor: Option[Boolean] = None,
     OneOffContributionDate: Option[LocalDate] = None,
     MembershipJoinDate: Option[LocalDate] = None,
     SupporterPlusExpiryDate: Option[LocalDate] = None,
@@ -60,7 +60,6 @@ case class Attributes(
   lazy val isGuardianWeeklySubscriber = GuardianWeeklySubscriptionExpiryDate.exists(_.isAfter(now))
   lazy val isPremiumLiveAppSubscriber = LiveAppSubscriptionExpiryDate.exists(_.isAfter(now))
   lazy val isGuardianPatron = GuardianPatronExpiryDate.exists(_.isAfter(now))
-  lazy val isMonthlyRecurringContributor = RecurringContributionPaymentPlan.contains("Monthly Contribution")
 
   lazy val contentAccess = ContentAccess(
     member = isPaidTier || isFriendTier,
@@ -90,13 +89,11 @@ case class Attributes(
 
 object Attributes {
 
-  import models.ContributionAmount._
-
   implicit val jsAttributesWrites: OWrites[Attributes] = (
     (__ \ "userId").write[String] and
       (__ \ "tier").writeNullable[String] and
       (__ \ "recurringContributionPaymentPlan").writeNullable[String] and
-      JsPath.writeNullable[ContributionAmount].contramap[Option[ContributionAmount]](_ => None) and // do not serialize the amount
+      JsPath.writeNullable[Boolean].contramap[Option[Boolean]](_ => None) and // do not serialize highContributor
       (__ \ "oneOffContributionDate").writeNullable[LocalDate] and
       (__ \ "membershipJoinDate").writeNullable[LocalDate] and
       (__ \ "supporterPlusExpiryDate").writeNullable[LocalDate] and

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -59,6 +59,7 @@ case class Attributes(
   lazy val isGuardianWeeklySubscriber = GuardianWeeklySubscriptionExpiryDate.exists(_.isAfter(now))
   lazy val isPremiumLiveAppSubscriber = LiveAppSubscriptionExpiryDate.exists(_.isAfter(now))
   lazy val isGuardianPatron = GuardianPatronExpiryDate.exists(_.isAfter(now))
+  lazy val isMonthlyRecurringContributor = RecurringContributionPaymentPlan.contains("Monthly Contribution")
 
   lazy val contentAccess = ContentAccess(
     member = isPaidTier || isFriendTier,

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -96,7 +96,7 @@ object Attributes {
       JsPath.writeNullable[Boolean].contramap[Option[Boolean]](_ => None) and // do not serialize highContributor
       (__ \ "oneOffContributionDate").writeNullable[LocalDate] and
       (__ \ "membershipJoinDate").writeNullable[LocalDate] and
-      (__ \ "supporterPlusExpiryDate").writeNullable[LocalDate] and
+      JsPath.writeNullable[LocalDate].contramap[Option[LocalDate]](_ => None) and // do not serialize supporterPlusExpiryDate
       (__ \ "digitalSubscriptionExpiryDate").writeNullable[LocalDate] and
       (__ \ "paperSubscriptionExpiryDate").writeNullable[LocalDate] and
       (__ \ "guardianWeeklyExpiryDate").writeNullable[LocalDate] and

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -96,7 +96,6 @@ object Attributes {
     (__ \ "userId").write[String] and
       (__ \ "tier").writeNullable[String] and
       (__ \ "recurringContributionPaymentPlan").writeNullable[String] and
-//      (__ \ "recurringContributionAmount").writeNullable[ContributionAmount] and
       JsPath.writeNullable[ContributionAmount].contramap[Option[ContributionAmount]](_ => None) and // do not serialize the amount
       (__ \ "oneOffContributionDate").writeNullable[LocalDate] and
       (__ \ "membershipJoinDate").writeNullable[LocalDate] and

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -32,6 +32,7 @@ case class Attributes(
     UserId: String,
     Tier: Option[String] = None,
     RecurringContributionPaymentPlan: Option[String] = None,
+    RecurringContributionAmount: Option[ContributionAmount] = None,
     OneOffContributionDate: Option[LocalDate] = None,
     MembershipJoinDate: Option[LocalDate] = None,
     SupporterPlusExpiryDate: Option[LocalDate] = None,
@@ -89,10 +90,14 @@ case class Attributes(
 
 object Attributes {
 
+  import models.ContributionAmount._
+
   implicit val jsAttributesWrites: OWrites[Attributes] = (
     (__ \ "userId").write[String] and
       (__ \ "tier").writeNullable[String] and
       (__ \ "recurringContributionPaymentPlan").writeNullable[String] and
+//      (__ \ "recurringContributionAmount").writeNullable[ContributionAmount] and
+      JsPath.writeNullable[ContributionAmount].contramap[Option[ContributionAmount]](_ => None) and // do not serialize the amount
       (__ \ "oneOffContributionDate").writeNullable[LocalDate] and
       (__ \ "membershipJoinDate").writeNullable[LocalDate] and
       (__ \ "supporterPlusExpiryDate").writeNullable[LocalDate] and

--- a/membership-attribute-service/app/models/DynamoSupporterRatePlanItem.scala
+++ b/membership-attribute-service/app/models/DynamoSupporterRatePlanItem.scala
@@ -1,6 +1,21 @@
 package models
 
+import com.gu.i18n.Currency
 import org.joda.time.LocalDate
+import play.api.libs.functional.syntax.unlift
+import play.api.libs.json.{OWrites, Writes, __}
+import play.api.libs.functional.syntax._
+
+case class ContributionAmount(amount: BigDecimal, currency: Currency)
+
+object ContributionAmount {
+    implicit val currencyWrite: Writes[Currency] = __.write[String].contramap(_.iso)
+
+    implicit val jsWrite: OWrites[ContributionAmount] = (
+      (__ \ "amount").write[BigDecimal] and
+        (__ \ "currency").write[Currency]
+      )(unlift(ContributionAmount.unapply))
+}
 
 case class DynamoSupporterRatePlanItem(
     subscriptionName: String, // Unique identifier for the subscription
@@ -8,4 +23,5 @@ case class DynamoSupporterRatePlanItem(
     productRatePlanId: String, // Unique identifier for the product in this rate plan
     termEndDate: LocalDate, // Date that this subscription term ends
     contractEffectiveDate: LocalDate, // Date that this subscription started
+    contributionAmount: Option[ContributionAmount]
 )

--- a/membership-attribute-service/app/models/DynamoSupporterRatePlanItem.scala
+++ b/membership-attribute-service/app/models/DynamoSupporterRatePlanItem.scala
@@ -2,19 +2,10 @@ package models
 
 import com.gu.i18n.Currency
 import org.joda.time.LocalDate
-import play.api.libs.functional.syntax.unlift
-import play.api.libs.json.{OWrites, Writes, __}
-import play.api.libs.functional.syntax._
+import play.api.libs.json.{Writes, __}
 
-case class ContributionAmount(amount: BigDecimal, currency: Currency)
-
-object ContributionAmount {
+object DynamoSupporterRatePlanItem {
     implicit val currencyWrite: Writes[Currency] = __.write[String].contramap(_.iso)
-
-    implicit val jsWrite: OWrites[ContributionAmount] = (
-      (__ \ "amount").write[BigDecimal] and
-        (__ \ "currency").write[Currency]
-      )(unlift(ContributionAmount.unapply))
 }
 
 case class DynamoSupporterRatePlanItem(
@@ -23,5 +14,6 @@ case class DynamoSupporterRatePlanItem(
     productRatePlanId: String, // Unique identifier for the product in this rate plan
     termEndDate: LocalDate, // Date that this subscription term ends
     contractEffectiveDate: LocalDate, // Date that this subscription started
-    contributionAmount: Option[ContributionAmount]
+    contributionAmount: Option[BigDecimal],
+    contributionCurrency: Option[Currency]
 )

--- a/membership-attribute-service/app/services/SupporterProductDataService.scala
+++ b/membership-attribute-service/app/services/SupporterProductDataService.scala
@@ -1,8 +1,9 @@
 package services
 
 import cats.data.EitherT
+import com.gu.i18n.Currency
 import com.typesafe.scalalogging.LazyLogging
-import models.{Attributes, DynamoSupporterRatePlanItem}
+import models.{Attributes, ContributionAmount, DynamoSupporterRatePlanItem}
 import monitoring.Metrics
 import org.joda.time.LocalDate
 import org.scanamo.DynamoReadError.describe
@@ -20,6 +21,8 @@ class SupporterProductDataService(client: DynamoDbAsyncClient, table: String, ma
 
   implicit val jodaStringFormat: DynamoFormat[LocalDate] =
     DynamoFormat.coercedXmap[LocalDate, String, IllegalArgumentException](LocalDate.parse, _.toString)
+  implicit val currencyFormat: DynamoFormat[Currency] = DynamoFormat.xmap[Currency,String](s => Currency.fromString(s).toRight(TypeCoercionError(new Throwable("Invalid currency"))), _.iso)
+  implicit val contributionAmountFormat: DynamoFormat[ContributionAmount] = deriveDynamoFormat
   implicit val dynamoSupporterRatePlanItem: DynamoFormat[DynamoSupporterRatePlanItem] = deriveDynamoFormat
 
   def getAttributes(identityId: String): Future[Either[String, Option[Attributes]]] =

--- a/membership-attribute-service/app/services/SupporterProductDataService.scala
+++ b/membership-attribute-service/app/services/SupporterProductDataService.scala
@@ -3,7 +3,7 @@ package services
 import cats.data.EitherT
 import com.gu.i18n.Currency
 import com.typesafe.scalalogging.LazyLogging
-import models.{Attributes, ContributionAmount, DynamoSupporterRatePlanItem}
+import models.{Attributes, DynamoSupporterRatePlanItem}
 import monitoring.Metrics
 import org.joda.time.LocalDate
 import org.scanamo.DynamoReadError.describe
@@ -22,7 +22,6 @@ class SupporterProductDataService(client: DynamoDbAsyncClient, table: String, ma
   implicit val jodaStringFormat: DynamoFormat[LocalDate] =
     DynamoFormat.coercedXmap[LocalDate, String, IllegalArgumentException](LocalDate.parse, _.toString)
   implicit val currencyFormat: DynamoFormat[Currency] = DynamoFormat.xmap[Currency,String](s => Currency.fromString(s).toRight(TypeCoercionError(new Throwable("Invalid currency"))), _.iso)
-  implicit val contributionAmountFormat: DynamoFormat[ContributionAmount] = deriveDynamoFormat
   implicit val dynamoSupporterRatePlanItem: DynamoFormat[DynamoSupporterRatePlanItem] = deriveDynamoFormat
 
   def getAttributes(identityId: String): Future[Either[String, Option[Attributes]]] =

--- a/membership-attribute-service/app/services/SupporterRatePlanToAttributesMapper.scala
+++ b/membership-attribute-service/app/services/SupporterRatePlanToAttributesMapper.scala
@@ -38,10 +38,10 @@ object SupporterRatePlanToAttributesMapper {
     attributes.copy(
       SupporterPlusExpiryDate = Some(supporterRatePlanItem.termEndDate),
     )
-  val monthlyContributionTransformer: AttributeTransformer = (attributes: Attributes, _: DynamoSupporterRatePlanItem) =>
-    attributes.copy(RecurringContributionPaymentPlan = Some("Monthly Contribution"))
-  val annualContributionTransformer: AttributeTransformer = (attributes: Attributes, _: DynamoSupporterRatePlanItem) =>
-    attributes.copy(RecurringContributionPaymentPlan = Some("Annual Contribution"))
+  val monthlyContributionTransformer: AttributeTransformer = (attributes: Attributes, supporterRatePlanItem: DynamoSupporterRatePlanItem) =>
+    attributes.copy(RecurringContributionPaymentPlan = Some("Monthly Contribution"), RecurringContributionAmount = supporterRatePlanItem.contributionAmount)
+  val annualContributionTransformer: AttributeTransformer = (attributes: Attributes, supporterRatePlanItem: DynamoSupporterRatePlanItem) =>
+    attributes.copy(RecurringContributionPaymentPlan = Some("Annual Contribution"), RecurringContributionAmount = supporterRatePlanItem.contributionAmount)
   val paperTransformer: AttributeTransformer = (attributes: Attributes, supporterRatePlanItem: DynamoSupporterRatePlanItem) =>
     attributes.copy(
       PaperSubscriptionExpiryDate = Some(supporterRatePlanItem.termEndDate),

--- a/membership-attribute-service/app/services/SupporterRatePlanToAttributesMapper.scala
+++ b/membership-attribute-service/app/services/SupporterRatePlanToAttributesMapper.scala
@@ -1,5 +1,6 @@
 package services
 
+import com.gu.i18n.Currency
 import models.{Attributes, DynamoSupporterRatePlanItem}
 import org.joda.time.LocalDate
 import services.MembershipTier.{Friend, Partner, Patron, Staff, Supporter, getMostValuableTier}
@@ -28,6 +29,23 @@ class SupporterRatePlanToAttributesMapper(stage: String) {
 
 object SupporterRatePlanToAttributesMapper {
 
+  private def isHighContributor(item: DynamoSupporterRatePlanItem, isMonthly: Boolean): Boolean = {
+    (item.contributionCurrency, item.contributionAmount) match {
+      case (Some(currency), Some(amount)) =>
+        val threshold = currency match {
+          case Currency.GBP | Currency.USD | Currency.EUR =>
+            if (isMonthly) 10 else 95
+          case Currency.CAD =>
+            if (isMonthly) 13 else 120
+          case Currency.AUD | Currency.NZD =>
+            if (isMonthly) 15 else 140
+        }
+        amount >= threshold
+
+      case _ => false
+    }
+  }
+
   type Stage = String
   type ProductRatePlanId = String
   val digitalSubTransformer: AttributeTransformer = (attributes: Attributes, supporterRatePlanItem: DynamoSupporterRatePlanItem) =>
@@ -39,9 +57,9 @@ object SupporterRatePlanToAttributesMapper {
       SupporterPlusExpiryDate = Some(supporterRatePlanItem.termEndDate),
     )
   val monthlyContributionTransformer: AttributeTransformer = (attributes: Attributes, supporterRatePlanItem: DynamoSupporterRatePlanItem) =>
-    attributes.copy(RecurringContributionPaymentPlan = Some("Monthly Contribution"), RecurringContributionAmount = supporterRatePlanItem.contributionAmount)
+    attributes.copy(RecurringContributionPaymentPlan = Some("Monthly Contribution"), HighContributor = Some(isHighContributor(supporterRatePlanItem, isMonthly = true)))
   val annualContributionTransformer: AttributeTransformer = (attributes: Attributes, supporterRatePlanItem: DynamoSupporterRatePlanItem) =>
-    attributes.copy(RecurringContributionPaymentPlan = Some("Annual Contribution"), RecurringContributionAmount = supporterRatePlanItem.contributionAmount)
+    attributes.copy(RecurringContributionPaymentPlan = Some("Annual Contribution"), HighContributor = Some(isHighContributor(supporterRatePlanItem, isMonthly = false)))
   val paperTransformer: AttributeTransformer = (attributes: Attributes, supporterRatePlanItem: DynamoSupporterRatePlanItem) =>
     attributes.copy(
       PaperSubscriptionExpiryDate = Some(supporterRatePlanItem.termEndDate),

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -3,12 +3,11 @@ package controllers
 import actions.{AuthAndBackendRequest, AuthenticatedUserAndBackendRequest, CommonActions, HowToHandleRecencyOfSignedIn}
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
-import com.gu.i18n.Currency
 import com.gu.identity.model.{StatusFields, User}
 import com.gu.identity.{RedirectAdviceResponse, SignedInRecently}
 import components.{TouchpointBackends, TouchpointComponents}
 import configuration.Config
-import models.{Attributes, ContributionAmount, MobileSubscriptionStatus}
+import models.{Attributes, MobileSubscriptionStatus}
 import org.joda.time.LocalDate
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
@@ -44,12 +43,14 @@ class AttributeControllerTest extends Specification with AfterAll with Mockito {
   private val userWithHighRecurringContributionAttributes = Attributes(
     UserId = userWithHighRecurringContributionId,
     RecurringContributionPaymentPlan = Some("Monthly Contribution"),
-    RecurringContributionAmount = Some(ContributionAmount(10, Currency.GBP))
+//    RecurringContributionAmount = Some(ContributionAmount(10, Currency.GBP))
+    HighContributor = Some(true)
   )
   private val userWithLowRecurringContributionAttributes = Attributes(
     UserId = userWithLowRecurringContributionId,
     RecurringContributionPaymentPlan = Some("Monthly Contribution"),
-    RecurringContributionAmount = Some(ContributionAmount(9, Currency.GBP))
+//    RecurringContributionAmount = Some(ContributionAmount(9, Currency.GBP))
+    HighContributor = Some(false)
   )
 
   private val validUserCookie = Cookie("validUser", "true")

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -43,13 +43,11 @@ class AttributeControllerTest extends Specification with AfterAll with Mockito {
   private val userWithHighRecurringContributionAttributes = Attributes(
     UserId = userWithHighRecurringContributionId,
     RecurringContributionPaymentPlan = Some("Monthly Contribution"),
-//    RecurringContributionAmount = Some(ContributionAmount(10, Currency.GBP))
     HighContributor = Some(true)
   )
   private val userWithLowRecurringContributionAttributes = Attributes(
     UserId = userWithLowRecurringContributionId,
     RecurringContributionPaymentPlan = Some("Monthly Contribution"),
-//    RecurringContributionAmount = Some(ContributionAmount(9, Currency.GBP))
     HighContributor = Some(false)
   )
 

--- a/membership-attribute-service/test/services/SupporterRatePlanToAttributesMapperTest.scala
+++ b/membership-attribute-service/test/services/SupporterRatePlanToAttributesMapperTest.scala
@@ -17,6 +17,7 @@ class SupporterRatePlanToAttributesMapperTest extends Specification {
     ratePlanId,
     termEndDate,
     LocalDate.now(),
+    None
   )
 
   "SupporterRatePlanToAttributesMapper" should {
@@ -259,6 +260,7 @@ class SupporterRatePlanToAttributesMapperTest extends Specification {
           identityId,
           Some("Supporter"),
           Some("Monthly Contribution"),
+          None,
           None,
           None,
           None,

--- a/membership-attribute-service/test/services/SupporterRatePlanToAttributesMapperTest.scala
+++ b/membership-attribute-service/test/services/SupporterRatePlanToAttributesMapperTest.scala
@@ -1,5 +1,6 @@
 package services
 
+import com.gu.i18n.Currency
 import models.{Attributes, DynamoSupporterRatePlanItem}
 import org.joda.time.LocalDate
 import org.specs2.mutable.Specification
@@ -17,7 +18,8 @@ class SupporterRatePlanToAttributesMapperTest extends Specification {
     ratePlanId,
     termEndDate,
     LocalDate.now(),
-    None
+    contributionCurrency = None,
+    contributionAmount = None
   )
 
   "SupporterRatePlanToAttributesMapper" should {
@@ -40,6 +42,20 @@ class SupporterRatePlanToAttributesMapperTest extends Specification {
         identityId,
         List(ratePlanItem("2c92a0fc5e1dc084015e37f58c200eea")),
       ) should beSome.which(_.RecurringContributionPaymentPlan should beSome("Annual Contribution"))
+    }
+
+    "identify a high monthly contribution" in {
+      mapper.attributesFromSupporterRatePlans(
+        identityId,
+        List(ratePlanItem("2c92a0fc5aacfadd015ad24db4ff5e97").copy(contributionAmount = Some(15), contributionCurrency = Some(Currency.GBP))),
+      ) should beSome.which(_.HighContributor should beSome(true))
+    }
+
+    "identify a low monthly contribution" in {
+      mapper.attributesFromSupporterRatePlans(
+        identityId,
+        List(ratePlanItem("2c92a0fc5aacfadd015ad24db4ff5e97").copy(contributionAmount = Some(5), contributionCurrency = Some(Currency.GBP))),
+      ) should beSome.which(_.HighContributor should beSome(false))
     }
 
     "identify a Digital Subscription" in {
@@ -260,7 +276,7 @@ class SupporterRatePlanToAttributesMapperTest extends Specification {
           identityId,
           Some("Supporter"),
           Some("Monthly Contribution"),
-          None,
+          Some(false),
           None,
           None,
           None,


### PR DESCRIPTION
Recurring contribution amount + currency [is being added to the supporter product data](https://github.com/guardian/support-frontend/pull/4189).

We have a requirement to exclude high-contributors from apps metering.
The apps will disable metering if the `supporterPlus` field is true in the response from MDAPI.

This PR changes MDAPI to set `supporterPlus` to true if:
- the request user-agent indicates it's from a mobile app
- the user has a recurring contribution with an amount above a certain threshold

### Low contributor:
![Screenshot 2022-09-15 at 13 21 46](https://user-images.githubusercontent.com/1513454/190402288-23c524b6-a4a4-4291-9b78-606ec90a7412.png)


### High contributor:
![Screenshot 2022-09-15 at 13 20 54](https://user-images.githubusercontent.com/1513454/190402209-18e2cbbe-3c58-4159-9afe-3cac77e61968.png)
