### PR TITLE
Adding Billing Country to Account Details

### DIFF
--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -153,7 +153,6 @@ object AccountDetails {
           "shouldDisplayEmail" -> selfServiceCancellation.shouldDisplayEmail,
           "phoneRegionsToDisplay" -> selfServiceCancellation.phoneRegionsToDisplay,
         ),
-        "billingCountry" -> billingCountry.iterator.mkString,
       ) ++
         regNumber.fold(Json.obj())({ reg => Json.obj("regNumber" -> reg) }) ++
         billingCountry.fold(Json.obj())({ bc => Json.obj("billingCountry" -> bc.name)}) ++

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -153,14 +153,15 @@ object AccountDetails {
           "shouldDisplayEmail" -> selfServiceCancellation.shouldDisplayEmail,
           "phoneRegionsToDisplay" -> selfServiceCancellation.phoneRegionsToDisplay,
         ),
+        "billingCountry" -> billingCountry.iterator.mkString,
       ) ++
         regNumber.fold(Json.obj())({ reg => Json.obj("regNumber" -> reg) }) ++
-        Json.obj(
+        billingCountry.fold(Json.obj())({ bc => Json.obj("billingCountry" -> bc.name)}) ++
+      Json.obj(
           "joinDate" -> paymentDetails.startDate,
           "optIn" -> !paymentDetails.pendingCancellation,
           "subscription" -> (paymentMethod ++ Json.obj(
             "contactId" -> accountDetails.contactId,
-            "billingCountry" -> billingCountry.iterator.mkString,
             "deliveryAddress" -> accountDetails.deliveryAddress,
             "safeToUpdatePaymentMethod" -> safeToUpdatePaymentMethod,
             "start" -> startDate,

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -156,7 +156,7 @@ object AccountDetails {
       ) ++
         regNumber.fold(Json.obj())({ reg => Json.obj("regNumber" -> reg) }) ++
         billingCountry.fold(Json.obj())({ bc => Json.obj("billingCountry" -> bc.name)}) ++
-      Json.obj(
+        Json.obj(
           "joinDate" -> paymentDetails.startDate,
           "optIn" -> !paymentDetails.pendingCancellation,
           "subscription" -> (paymentMethod ++ Json.obj(

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -160,6 +160,7 @@ object AccountDetails {
           "optIn" -> !paymentDetails.pendingCancellation,
           "subscription" -> (paymentMethod ++ Json.obj(
             "contactId" -> accountDetails.contactId,
+            "billingCountry" -> billingCountry.iterator.mkString,
             "deliveryAddress" -> accountDetails.deliveryAddress,
             "safeToUpdatePaymentMethod" -> safeToUpdatePaymentMethod,
             "start" -> startDate,


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
Adding Billing Country to Account Details as manage-frontend needs it to determine the correct Stripe Public Key to use, as it's currently only using the Delivery Country, which is wrong.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
 Adding Billing Country value, or empty string, to Account Details.

### trello card/screenshot/json/related PRs etc
https://trello.com/c/X0ulSbI9 and https://github.com/guardian/manage-frontend/pull/874