### PR TITLE
Simplify User model

### DIFF
--- a/membership-attribute-service/app/actions/AuthAndBackendViaAuthLibAction.scala
+++ b/membership-attribute-service/app/actions/AuthAndBackendViaAuthLibAction.scala
@@ -1,8 +1,8 @@
 package actions
 
-import com.gu.identity.model.User
 import components.{TouchpointBackends, TouchpointComponents}
 import filters.AddGuIdentityHeaders
+import models.AccessClaims
 import play.api.mvc.{ActionRefiner, Request, Result, Results}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -14,8 +14,8 @@ class AuthAndBackendViaAuthLibAction(touchpointBackends: TouchpointBackends)(imp
   override protected def refine[A](request: Request[A]): Future[Either[Result, AuthenticatedUserAndBackendRequest[A]]] = {
     // On each request via this action, we make a call to IDAPI and see if we can authenticate the user.
     // The test config and the normal config are the same for IDAPI.
-    touchpointBackends.normal.identityAuthService.user(request) map { user: Option[User] =>
-      val backendConf: TouchpointComponents = if (AddGuIdentityHeaders.isTestUser(user.flatMap(_.publicFields.displayName))) {
+    touchpointBackends.normal.identityAuthService.user(request) map { user: Option[AccessClaims] =>
+      val backendConf: TouchpointComponents = if (AddGuIdentityHeaders.isTestUser(user.map(_.userName))) {
         touchpointBackends.test
       } else {
         touchpointBackends.normal

--- a/membership-attribute-service/app/actions/CommonActions.scala
+++ b/membership-attribute-service/app/actions/CommonActions.scala
@@ -1,9 +1,9 @@
 package actions
 import akka.stream.Materializer
 import com.gu.identity.RedirectAdviceResponse
-import com.gu.identity.model.User
 import components.{TouchpointBackends, TouchpointComponents}
 import controllers.NoCache
+import models.AccessClaims
 import play.api.mvc._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -30,7 +30,7 @@ class CommonActions(touchpointBackends: TouchpointBackends, bodyParser: BodyPars
 class BackendRequest[A](val touchpoint: TouchpointComponents, request: Request[A]) extends WrappedRequest[A](request)
 
 class AuthenticatedUserAndBackendRequest[A](
-    val user: Option[User],
+    val user: Option[AccessClaims],
     val touchpoint: TouchpointComponents,
     request: Request[A],
 ) extends WrappedRequest[A](request)

--- a/membership-attribute-service/app/filters/AddGuIdentityHeaders.scala
+++ b/membership-attribute-service/app/filters/AddGuIdentityHeaders.scala
@@ -1,8 +1,8 @@
 package filters
 
 import akka.stream.Materializer
-import com.gu.identity.model.User
 import configuration.Config
+import models.AccessClaims
 import play.api.mvc._
 import services.IdentityAuthService
 
@@ -39,9 +39,9 @@ object AddGuIdentityHeaders {
       }
   }
 
-  def fromUser(result: Result, user: User) = result.withHeaders(
+  def fromUser(result: Result, user: AccessClaims) = result.withHeaders(
     xGuIdentityIdHeaderName -> user.id,
-    xGuMembershipTestUserHeaderName -> isTestUser(user.publicFields.displayName).toString,
+    xGuMembershipTestUserHeaderName -> isTestUser(Some(user.userName)).toString,
   )
 
   def hasIdentityHeaders(result: Result) = identityHeaderNames.forall(result.header.headers.contains)

--- a/membership-attribute-service/app/models/AccessClaims.scala
+++ b/membership-attribute-service/app/models/AccessClaims.scala
@@ -1,0 +1,19 @@
+package models
+
+/** Claims that are used to determine which resources the user is authorised to access.
+  *
+  * @param primaryEmailAddress
+  *   primary email address
+  * @param id
+  *   Identity ID
+  * @param userName
+  *   User name, a synonym for display name. Also used to determine if this is a test user.
+  * @param hasValidatedEmail
+  *   true iff the user has validated their email address
+  */
+case class AccessClaims(
+    primaryEmailAddress: String,
+    id: String,
+    userName: String,
+    hasValidatedEmail: Boolean,
+)

--- a/membership-attribute-service/app/services/AuthenticationService.scala
+++ b/membership-attribute-service/app/services/AuthenticationService.scala
@@ -1,10 +1,10 @@
 package services
 
-import com.gu.identity.model.User
+import models.AccessClaims
 import play.api.mvc.RequestHeader
 
 import scala.concurrent.Future
 
 trait AuthenticationService {
-  def user(implicit request: RequestHeader): Future[Option[User]]
+  def user(implicit request: RequestHeader): Future[Option[AccessClaims]]
 }

--- a/membership-attribute-service/test/filters/AddGuIdentityHeadersTest.scala
+++ b/membership-attribute-service/test/filters/AddGuIdentityHeadersTest.scala
@@ -1,7 +1,7 @@
 package filters
 
-import com.gu.identity.model.{PublicFields, User}
 import configuration.Config.testUsernames
+import models.AccessClaims
 import org.mockito.Mockito.{times, verify, verifyNoInteractions, when}
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
@@ -9,21 +9,19 @@ import play.api.mvc.Results.Ok
 import play.api.mvc.{RequestHeader, Result}
 import services.IdentityAuthService
 
-import scala.concurrent.{Await, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
 
 class AddGuIdentityHeadersTest extends Specification with Mockito {
 
   val XGuIdentityId = "X-Gu-Identity-Id"
   val XGuMembershipTestUser = "X-Gu-Membership-Test-User"
-  val user = User(
+  val user = AccessClaims(
     primaryEmailAddress = "someUser@email.com",
     id = "testUserId",
-    publicFields = PublicFields(
-      username = Some("testUserName"),
-      displayName = Some("testUserName"),
-    ),
+    userName = "testUserName",
+    hasValidatedEmail = false,
   )
 
   val identityService = mock[IdentityAuthService]
@@ -37,9 +35,9 @@ class AddGuIdentityHeadersTest extends Specification with Mockito {
 
   def assertHeadersSet(actualResult: Result, testUser: Boolean = false) = {
     val actualHeaders = actualResult.header.headers
-    actualHeaders.get("previousHeader") should beEqualTo(Some("previousHeaderValue"))
-    actualHeaders.get(XGuIdentityId) should beEqualTo(Some("testUserId"))
-    actualHeaders.get(XGuMembershipTestUser) should beEqualTo(Some(testUser.toString))
+    actualHeaders.get("previousHeader") should beSome("previousHeaderValue")
+    actualHeaders.get(XGuIdentityId) should beSome("testUserId")
+    actualHeaders.get(XGuMembershipTestUser) should beSome(testUser.toString)
     actualHeaders.size should beEqualTo(3)
   }
 
@@ -51,13 +49,8 @@ class AddGuIdentityHeadersTest extends Specification with Mockito {
     }
 
     "add headers for test user " in {
-      val testUsername = testUsernames.generate();
-      val testUser = user.copy(publicFields =
-        PublicFields(
-          username = Some(testUsername),
-          displayName = Some(testUsername),
-        ),
-      )
+      val testUsername = testUsernames.generate()
+      val testUser = user.copy(userName = testUsername)
       val actualResult = AddGuIdentityHeaders.fromUser(resultWithoutIdentityHeaders, testUser)
       assertHeadersSet(actualResult, testUser = true)
     }
@@ -70,7 +63,7 @@ class AddGuIdentityHeadersTest extends Specification with Mockito {
     }
 
     "detect test users" in {
-      val testUsername = testUsernames.generate();
+      val testUsername = testUsernames.generate()
       AddGuIdentityHeaders.isTestUser(Some(testUsername)) should beTrue
     }
     "detect non test users" in {
@@ -103,7 +96,7 @@ class AddGuIdentityHeadersTest extends Specification with Mockito {
     val actualResult = Await.result(futureActualResult, 5.seconds)
     verify(notFoundIdentityService, times(1)).user(request)
     actualResult.header.headers.size should beEqualTo(1)
-    actualResult.header.headers.get("previousHeader") should beEqualTo(Some("previousHeaderValue"))
+    actualResult.header.headers.get("previousHeader") should beSome("previousHeaderValue")
   }
 
 }


### PR DESCRIPTION
This is enabling work for the movement of the authentication mechanism from Idapi to Okta.
The [User](https://github.com/guardian/identity/blob/main/identity-model/src/main/scala/com/gu/identity/model/Model.scala#L51-L83) model is very complicated and uses all sorts of fields that we don't intend to make available in Okta Access tokens.
So, here we replace it with a simpler local model: [AccessClaims](https://github.com/guardian/members-data-api/compare/kc/user?expand=1#diff-590be6f5b78842588c6a40afa9eebf29506732d21acaa2d05ecefb064fb3a4a0R14-R19).

Open to better naming of course.

https://trello.com/c/NLwIqfd7/4163-create-new-minimal-user-type-in-mdapi

Tested read and write endpoints in Code, signed in and signed out.
