### PR TITLE
Supporter plus category update

### DIFF
--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -220,7 +220,7 @@ object AccountDetails {
     case _: Product.ZDigipack => "subscriptions"
     case _: Product.SupporterPlus => "recurringSupport"
     case _: Product.GuardianPatron => "subscriptions"
-    case _: Product.Contribution => "contributions"
+    case _: Product.Contribution => "recurringSupport"
     case _: Product.Membership => "membership"
     case _ => product.name // fallback
   }

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -218,7 +218,7 @@ object AccountDetails {
   def mmaCategoryFrom(product: Product): String = product match {
     case _: Product.Paper => "subscriptions" // Paper includes GW 🤦‍
     case _: Product.ZDigipack => "subscriptions"
-    case _: Product.SupporterPlus => "subscriptions"
+    case _: Product.SupporterPlus => "contributions"
     case _: Product.GuardianPatron => "subscriptions"
     case _: Product.Contribution => "contributions"
     case _: Product.Membership => "membership"

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -218,7 +218,7 @@ object AccountDetails {
   def mmaCategoryFrom(product: Product): String = product match {
     case _: Product.Paper => "subscriptions" // Paper includes GW 🤦‍
     case _: Product.ZDigipack => "subscriptions"
-    case _: Product.SupporterPlus => "contributions"
+    case _: Product.SupporterPlus => "recurringSupport"
     case _: Product.GuardianPatron => "subscriptions"
     case _: Product.Contribution => "contributions"
     case _: Product.Membership => "membership"


### PR DESCRIPTION
**Why do we need this?**

In this change the SupporterPlus category has been changed to contributions. This is due to the Product Groups within MMA being required to change to reflect new prop

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
A one line change in the `AccountDetails.scala ` to update the category

### trello card/screenshot/json/related PRs etc
https://trello.com/c/xo9c3UQ1/3557-mma-changes-amend-product-groups
