### PR TITLE
Return isRecurringSupporter field

### DIFF
--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -94,7 +94,7 @@ case class Attributes(
       || isGuardianWeeklySubscriber
       || isPremiumLiveAppSubscriber
       || isGuardianPatron
-    )
+  )
 
 }
 

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -85,6 +85,17 @@ case class Attributes(
       || isGuardianPatron
   )
 
+  lazy val isRecurringSupporter = (
+    isPaidTier
+      || isRecurringContributor
+      || digitalSubscriberHasActivePlan
+      || isSupporterPlus
+      || isPaperSubscriber
+      || isGuardianWeeklySubscriber
+      || isPremiumLiveAppSubscriber
+      || isGuardianPatron
+    )
+
 }
 
 object Attributes {
@@ -105,6 +116,7 @@ object Attributes {
   )(unlift(Attributes.unapply))
     .addNullableField("digitalSubscriptionExpiryDate", _.latestDigitalSubscriptionExpiryDate)
     .addField("showSupportMessaging", _.showSupportMessaging)
+    .addField("isRecurringSupporter", _.isRecurringSupporter)
     .addField("contentAccess", _.contentAccess)
 }
 

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -87,9 +87,9 @@ case class Attributes(
 
   lazy val isRecurringSupporter = (
     isPaidTier
+      || isSupporterPlus
       || isRecurringContributor
       || digitalSubscriberHasActivePlan
-      || isSupporterPlus
       || isPaperSubscriber
       || isGuardianWeeklySubscriber
       || isPremiumLiveAppSubscriber

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -221,6 +221,7 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
                    |   "paperSubscriptionExpiryDate":"2099-01-01",
                    |   "guardianWeeklyExpiryDate":"2099-01-01",
                    |   "showSupportMessaging": false,
+                   |   "isRecurringSupporter": true,
                    |   "contentAccess": {
                    |     "member": true,
                    |     "paidMember": true,
@@ -282,6 +283,7 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
                      |{
                      |  "userId": "456",
                      |  "showSupportMessaging": true,
+                     |  "isRecurringSupporter": false,
                      |  "contentAccess": {
                      |    "member": false,
                      |    "paidMember": false,


### PR DESCRIPTION
The existing `showSupportMessaging` field no longer serves the needs of RRCP targeting.
We need to separate single contributors from other types of support.

The new `isRecurringSupporter` enables us to do this. It's different from `showSupportMessaging` in that it does not include single contributors (unless they currently support us in some other way)