### PR TITLE
Rename secure auth scopes

### DIFF
--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -1,7 +1,6 @@
 package controllers
 
 import actions._
-import com.gu.identity.auth.AccessScope.membersDataApi.{readSelf, sensitiveReadSelf, updateSelf}
 import com.gu.memsub
 import com.gu.memsub.Subscription.Name
 import services.PaymentFailureAlerter._
@@ -26,6 +25,7 @@ import components.TouchpointComponents
 import configuration.Config
 import controllers.PaymentDetailMapper.paymentDetailsForSub
 import loghandling.DeprecatedRequestLogger
+import models.AccessScope.{completeReadSelf, readSelf, updateSelf}
 import models.AccountDetails._
 import models.ApiErrors._
 import models._
@@ -187,7 +187,7 @@ class AccountController(
 
   @Deprecated
   private def paymentDetails[P <: SubscriptionPlan.Paid: SubPlanReads, F <: SubscriptionPlan.Free: SubPlanReads] =
-    AuthAndBackendViaAuthLibAction(requiredScopes = List(sensitiveReadSelf)).async { implicit request =>
+    AuthAndBackendViaAuthLibAction(requiredScopes = List(completeReadSelf)).async { implicit request =>
       DeprecatedRequestLogger.logDeprecatedRequest(request)
 
       implicit val tp: TouchpointComponents = request.touchpoint

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -3,10 +3,10 @@ package controllers
 import actions._
 import akka.actor.ActorSystem
 import com.gu.identity.auth.AccessScope
-import com.gu.identity.auth.AccessScope.membersDataApi.{readSelf, sensitiveReadSelf}
 import filters.AddGuIdentityHeaders
 import loghandling.LoggingField.{LogField, LogFieldString}
 import loghandling.{DeprecatedRequestLogger, LoggingWithLogstashFields}
+import models.AccessScope.{completeReadSelf, readSelf}
 import models.ApiError._
 import models.ApiErrors._
 import models.Features._
@@ -202,7 +202,7 @@ class AttributeController(
     onSuccessMember = membershipAttributesFromAttributes,
     onSuccessSupporter = _ => ApiError("Not found", "User was found but they are not a member", 404),
     onNotFound = notFound,
-    requiredScopes = List(sensitiveReadSelf),
+    requiredScopes = List(completeReadSelf),
   )
   def attributes = lookup(
     endpointDescription = "attributes",
@@ -217,7 +217,7 @@ class AttributeController(
     onSuccessMember = Features.fromAttributes,
     onSuccessSupporter = _ => Features.unauthenticated,
     onNotFound = Features.unauthenticated,
-    requiredScopes = List(sensitiveReadSelf),
+    requiredScopes = List(completeReadSelf),
   )
 
   def oneOffContributions = {

--- a/membership-attribute-service/app/models/AccessScope.scala
+++ b/membership-attribute-service/app/models/AccessScope.scala
@@ -1,0 +1,32 @@
+package models
+
+import com.gu.identity.auth.{AccessScope => IdentityAccessScope}
+
+/** <p>Scope that endpoints need from access tokens before they can carry out requests. For background, see <a
+  * href="https://www.oauth.com/oauth2-servers/scope/defining-scopes">Oauth scopes</a></p>
+  *
+  * <p>To add scopes, the process is described in <a
+  * href="https://github.com/guardian/identity/blob/main/identity-auth-core/src/main/scala/com/gu/identity/auth/AccessScope.scala">IdentityAccessScope</a></p>
+  *
+  * <p><strong>Scope name values have to match the values stored in Okta.</strong></p>
+  */
+object AccessScope {
+
+  /** Allows the client to read basic non-sensitive data relating to the user's Guardian subscriptions and contributions.
+    */
+  case object readSelf extends IdentityAccessScope {
+    val name = "guardian.members-data-api.read.self"
+  }
+
+  /** Allows the client to read the complete data relating to the user's Guardian subscriptions and contributions.
+    */
+  case object completeReadSelf extends IdentityAccessScope {
+    val name = "guardian.members-data-api.complete.read.self.secure"
+  }
+
+  /** Allows the client to update data relating to the user's Guardian subscriptions and contributions.
+    */
+  case object updateSelf extends IdentityAccessScope {
+    val name = "guardian.members-data-api.update.self.secure"
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val awsClientV2Version = "2.16.86"
 
   val sentryLogback = "io.sentry" % "sentry-logback" % "1.7.5"
-  val identityAuth = "com.gu.identity" %% "identity-auth-play" % "4.4"
+  val identityAuth = "com.gu.identity" %% "identity-auth-play" % "4.5"
   val identityTestUsers = "com.gu" %% "identity-test-users" % "0.8"
   val postgres = "org.postgresql" % "postgresql" % "42.3.3"
   val jdbc = PlayImport.jdbc


### PR DESCRIPTION
We've updated some of the scope names to make it easier to determine which need special treatment during the authorisation process.  The scope names available to the API have also been brought down into this repo rather than being read from the Identity library to avoid having to release new versions of the Identity library whenever a new scope is added to an API.
