### PR TITLE
Currency and Currency ISO objects added to subscription body 

### DIFF
--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -166,6 +166,8 @@ object AccountDetails {
             "start" -> startDate,
             "end" -> endDate,
             "nextPaymentPrice" -> paymentDetails.nextPaymentPrice,
+            "paymentCurrencyGlyph" -> paymentDetails.plan.price.currency.glyph,
+            "paymentCurrencyISO" -> paymentDetails.plan.price.currency.iso,
             "nextPaymentDate" -> paymentDetails.nextPaymentDate,
             "lastPaymentDate" -> paymentDetails.lastPaymentDate,
             "chargedThroughDate" -> paymentDetails.chargedThroughDate,


### PR DESCRIPTION
In this commit new currency and currency iso objects added to subscription body. This is the first step to removing the plan object from the account details

<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
This is the first step to removing the plan object from the API response body to MMA

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
Currency and CurrencyISO objects have been copied into the subscription body.

### trello card/screenshot/json/related PRs etc
https://trello.com/c/Jb7VYDSc/3592-remove-plan-property-from-members-data-api-response