### PR TITLE
Filter out cancelled Patrons subs when generating user attributes

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -82,7 +82,7 @@ class AttributeController(
   protected def getSupporterProductDataAttributes(identityId: String)(implicit request: AuthenticatedUserAndBackendRequest[AnyContent]) = {
     log.info(s"Fetching attributes from supporter-product-data table for user $identityId")
     request.touchpoint.supporterProductDataService
-      .getAttributes(identityId)
+      .getNonCancelledAttributes(identityId)
       .map(maybeAttributes => ("supporter-product-data", maybeAttributes.getOrElse(None)))
   }
 

--- a/membership-attribute-service/app/models/DynamoSupporterRatePlanItem.scala
+++ b/membership-attribute-service/app/models/DynamoSupporterRatePlanItem.scala
@@ -14,6 +14,7 @@ case class DynamoSupporterRatePlanItem(
     productRatePlanId: String, // Unique identifier for the product in this rate plan
     termEndDate: LocalDate, // Date that this subscription term ends
     contractEffectiveDate: LocalDate, // Date that this subscription started
+    cancellationDate: Option[LocalDate], // If this subscription has been cancelled this will be set
     contributionAmount: Option[BigDecimal],
     contributionCurrency: Option[Currency],
 )

--- a/membership-attribute-service/app/services/SupporterProductDataService.scala
+++ b/membership-attribute-service/app/services/SupporterProductDataService.scala
@@ -5,7 +5,7 @@ import com.gu.i18n.Currency
 import com.typesafe.scalalogging.LazyLogging
 import models.{Attributes, DynamoSupporterRatePlanItem}
 import monitoring.Metrics
-import org.joda.time.LocalDate
+import org.joda.time.{DateTimeZone, LocalDate}
 import org.scanamo.DynamoReadError.describe
 import org.scanamo.{DynamoReadError, _}
 import org.scanamo.generic.semiauto._
@@ -27,7 +27,7 @@ class SupporterProductDataService(client: DynamoDbAsyncClient, table: String, ma
 
   def getNonCancelledAttributes(identityId: String): Future[Either[String, Option[Attributes]]] = {
     getSupporterRatePlanItems(identityId).map { ratePlanItems =>
-      val nonCancelled = ratePlanItems.filter(_.cancellationDate.isEmpty)
+      val nonCancelled = ratePlanItems.filter(item => !item.cancellationDate.exists(_.isBefore(LocalDate.now(DateTimeZone.UTC))))
       mapper.attributesFromSupporterRatePlans(identityId, nonCancelled)
     }.value
   }

--- a/membership-attribute-service/test/services/SupporterProductDataIntegrationTest.scala
+++ b/membership-attribute-service/test/services/SupporterProductDataIntegrationTest.scala
@@ -20,7 +20,7 @@ import software.amazon.awssdk.services.dynamodb.{DynamoDbAsyncClient, DynamoDbAs
 
 class SupporterProductDataIntegrationTest(implicit ee: ExecutionEnv) extends Specification with LazyLogging {
 
-  val stage = "PROD" // Whichever stage is specified here, you will need config for it in /etc/gu/members-data-api.private.conf
+  val stage = "DEV" // Whichever stage is specified here, you will need config for it in /etc/gu/members-data-api.private.conf
   lazy val CredentialsProvider = AwsCredentialsProviderChain.builder
     .credentialsProviders(
       ProfileCredentialsProvider.builder.profileName(ProfileName).build,
@@ -33,7 +33,7 @@ class SupporterProductDataIntegrationTest(implicit ee: ExecutionEnv) extends Spe
     .credentialsProvider(CredentialsProvider)
     .region(Region.EU_WEST_1)
   lazy val mapper = new SupporterRatePlanToAttributesMapper(stage)
-  lazy val supporterProductDataTable = "SupporterProductData-PROD"
+  lazy val supporterProductDataTable = s"SupporterProductData-$stage"
   lazy val supporterProductDataService = new SupporterProductDataService(dynamoClientBuilder.build(), supporterProductDataTable, mapper)
 
   implicit private val actorSystem: ActorSystem = ActorSystem()
@@ -42,7 +42,7 @@ class SupporterProductDataIntegrationTest(implicit ee: ExecutionEnv) extends Spe
 
   "SupporterProductData" should {
     "get attributes by identity id" in {
-      supporterProductDataService.getAttributes("3355555").map {
+      supporterProductDataService.getNonCancelledAttributes("3355555").map {
         case Right(attributes) =>
           SafeLogger.info(attributes.toString)
           ok

--- a/membership-attribute-service/test/services/SupporterRatePlanToAttributesMapperTest.scala
+++ b/membership-attribute-service/test/services/SupporterRatePlanToAttributesMapperTest.scala
@@ -18,6 +18,7 @@ class SupporterRatePlanToAttributesMapperTest extends Specification {
     ratePlanId,
     termEndDate,
     LocalDate.now(),
+    cancellationDate = None,
     contributionCurrency = None,
     contributionAmount = None,
   )


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
Up until recently Guardian Patrons which were cancelled were not removed from the SupporterProductData dynamo table until the end of the current term meaning that they would continue to receive benefits even after they had cancelled. Since [this PR](https://github.com/guardian/support-frontend/pull/4298) however cancelled Patrons have a cancellation date set in the data store. 

This PR filters out cancelled Patrons from the user attributes endpoint at `/user/me`


### [Trello card](https://trello.com/c/n9FN7Ubc/58-make-mdapi-show-cancellation-status-of-patron-subscriptions)

