### PR TITLE
Revert: Give recurring contributors SupporterPlus on apps

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -86,12 +86,6 @@ class AttributeController(
       .map(maybeAttributes => ("supporter-product-data", maybeAttributes.getOrElse(None)))
   }
 
-  private def isLiveApp(ua: String): Boolean = ua.matches("""^Guardian(News)?\/.*""")
-  private def upgradeRecurringContributorsOnApps(userAgent: Option[String], attributes: Attributes): Attributes =
-    if (attributes.HighContributor.contains(true) && userAgent.exists(isLiveApp)) {
-      attributes.copy(SupporterPlusExpiryDate = Some(LocalDate.now().plusDays(1)))
-    } else attributes
-
   private def lookup(
       endpointDescription: String,
       onSuccessMember: Attributes => Result,
@@ -123,9 +117,9 @@ class AttributeController(
               supporterAttributes,
               user.identityId,
             )
-            allProductAttributes: Option[Attributes] = supporterOrStaffAttributes
-              .map(addOneOffAndMobile(_, latestOneOffDate, latestMobileSubscription))
-              .map(upgradeRecurringContributorsOnApps(request.headers.get(USER_AGENT), _))
+            allProductAttributes: Option[Attributes] = supporterOrStaffAttributes.map(
+              addOneOffAndMobile(_, latestOneOffDate, latestMobileSubscription),
+            )
           } yield {
 
             def customFields(supporterType: String): List[LogField] = List(
@@ -135,7 +129,7 @@ class AttributeController(
             )
 
             val result = allProductAttributes match {
-              case Some(attrs @ Attributes(_, Some(tier), _, _, _, _, _, _, _, _, _, _, _)) =>
+              case Some(attrs @ Attributes(_, Some(tier), _, _, _, _, _, _, _, _, _, _)) =>
                 logInfoWithCustomFields(
                   s"${user.identityId} is a $tier member - $endpointDescription - $attrs found via $fromWhere",
                   customFields("member"),

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -32,7 +32,6 @@ case class Attributes(
     UserId: String,
     Tier: Option[String] = None,
     RecurringContributionPaymentPlan: Option[String] = None,
-    HighContributor: Option[Boolean] = None,
     OneOffContributionDate: Option[LocalDate] = None,
     MembershipJoinDate: Option[LocalDate] = None,
     SupporterPlusExpiryDate: Option[LocalDate] = None,
@@ -93,7 +92,6 @@ object Attributes {
     (__ \ "userId").write[String] and
       (__ \ "tier").writeNullable[String] and
       (__ \ "recurringContributionPaymentPlan").writeNullable[String] and
-      JsPath.writeNullable[Boolean].contramap[Option[Boolean]](_ => None) and // do not serialize highContributor
       (__ \ "oneOffContributionDate").writeNullable[LocalDate] and
       (__ \ "membershipJoinDate").writeNullable[LocalDate] and
       JsPath.writeNullable[LocalDate].contramap[Option[LocalDate]](_ => None) and // do not serialize supporterPlusExpiryDate

--- a/membership-attribute-service/app/services/SupporterRatePlanToAttributesMapper.scala
+++ b/membership-attribute-service/app/services/SupporterRatePlanToAttributesMapper.scala
@@ -1,6 +1,5 @@
 package services
 
-import com.gu.i18n.Currency
 import models.{Attributes, DynamoSupporterRatePlanItem}
 import org.joda.time.LocalDate
 import services.MembershipTier.{Friend, Partner, Patron, Staff, Supporter, getMostValuableTier}
@@ -29,23 +28,6 @@ class SupporterRatePlanToAttributesMapper(stage: String) {
 
 object SupporterRatePlanToAttributesMapper {
 
-  private def isHighContributor(item: DynamoSupporterRatePlanItem, isMonthly: Boolean): Boolean = {
-    (item.contributionCurrency, item.contributionAmount) match {
-      case (Some(currency), Some(amount)) =>
-        val threshold = currency match {
-          case Currency.GBP | Currency.USD | Currency.EUR =>
-            if (isMonthly) 10 else 95
-          case Currency.CAD =>
-            if (isMonthly) 13 else 120
-          case Currency.AUD | Currency.NZD =>
-            if (isMonthly) 15 else 140
-        }
-        amount >= threshold
-
-      case _ => false
-    }
-  }
-
   type Stage = String
   type ProductRatePlanId = String
   val digitalSubTransformer: AttributeTransformer = (attributes: Attributes, supporterRatePlanItem: DynamoSupporterRatePlanItem) =>
@@ -56,16 +38,10 @@ object SupporterRatePlanToAttributesMapper {
     attributes.copy(
       SupporterPlusExpiryDate = Some(supporterRatePlanItem.termEndDate),
     )
-  val monthlyContributionTransformer: AttributeTransformer = (attributes: Attributes, supporterRatePlanItem: DynamoSupporterRatePlanItem) =>
-    attributes.copy(
-      RecurringContributionPaymentPlan = Some("Monthly Contribution"),
-      HighContributor = Some(isHighContributor(supporterRatePlanItem, isMonthly = true)),
-    )
-  val annualContributionTransformer: AttributeTransformer = (attributes: Attributes, supporterRatePlanItem: DynamoSupporterRatePlanItem) =>
-    attributes.copy(
-      RecurringContributionPaymentPlan = Some("Annual Contribution"),
-      HighContributor = Some(isHighContributor(supporterRatePlanItem, isMonthly = false)),
-    )
+  val monthlyContributionTransformer: AttributeTransformer = (attributes: Attributes, _: DynamoSupporterRatePlanItem) =>
+    attributes.copy(RecurringContributionPaymentPlan = Some("Monthly Contribution"))
+  val annualContributionTransformer: AttributeTransformer = (attributes: Attributes, _: DynamoSupporterRatePlanItem) =>
+    attributes.copy(RecurringContributionPaymentPlan = Some("Annual Contribution"))
   val paperTransformer: AttributeTransformer = (attributes: Attributes, supporterRatePlanItem: DynamoSupporterRatePlanItem) =>
     attributes.copy(
       PaperSubscriptionExpiryDate = Some(supporterRatePlanItem.termEndDate),

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -29,8 +29,6 @@ class AttributeControllerTest extends Specification with AfterAll with Mockito {
   private val validUserId = "123"
   private val userWithoutAttributesUserId = "456"
   private val unvalidatedEmailUserId = "789"
-  private val userWithHighRecurringContributionId = "987"
-  private val userWithLowRecurringContributionId = "654"
 
   private val testAttributes = Attributes(
     UserId = validUserId,
@@ -41,22 +39,10 @@ class AttributeControllerTest extends Specification with AfterAll with Mockito {
     PaperSubscriptionExpiryDate = Some(new LocalDate(2099, 1, 1)),
     GuardianWeeklySubscriptionExpiryDate = Some(new LocalDate(2099, 1, 1)),
   )
-  private val userWithHighRecurringContributionAttributes = Attributes(
-    UserId = userWithHighRecurringContributionId,
-    RecurringContributionPaymentPlan = Some("Monthly Contribution"),
-    HighContributor = Some(true),
-  )
-  private val userWithLowRecurringContributionAttributes = Attributes(
-    UserId = userWithLowRecurringContributionId,
-    RecurringContributionPaymentPlan = Some("Monthly Contribution"),
-    HighContributor = Some(false),
-  )
 
   private val validUserCookie = Cookie("validUser", "true")
   private val validUnvalidatedEmailCookie = Cookie("unvalidatedEmailUser", "true")
   private val userWithoutAttributesCookie = Cookie("invalidUser", "true")
-  private val userWithHighRecurringContributionCookie = Cookie("userWithHighRecurringContribution", "true")
-  private val userWithLowRecurringContributionCookie = Cookie("userWithLowRecurringContribution", "true")
   private val validUser = UserFromToken(
     primaryEmailAddress = "test@gu.com",
     identityId = validUserId,
@@ -70,14 +56,6 @@ class AttributeControllerTest extends Specification with AfterAll with Mockito {
   private val userWithoutAttributes = UserFromToken(
     primaryEmailAddress = "notcached@gu.com",
     identityId = userWithoutAttributesUserId,
-  )
-  private val userWithHighRecurringContribution = UserFromToken(
-    primaryEmailAddress = "userWithHighRecurringContribution@gu.com",
-    identityId = userWithHighRecurringContributionId,
-  )
-  private val userWithLowRecurringContribution = UserFromToken(
-    primaryEmailAddress = "userWithLowRecurringContribution@gu.com",
-    identityId = userWithLowRecurringContributionId,
   )
 
   private val guardianEmployeeUser = UserFromToken(
@@ -110,8 +88,6 @@ class AttributeControllerTest extends Specification with AfterAll with Mockito {
         case Some(c) if c == guardianEmployeeCookie => Future.successful(Right(guardianEmployeeUser))
         case Some(c) if c == guardianEmployeeCookieTheguardian => Future.successful(Right(guardianEmployeeUserTheguardian))
         case Some(c) if c == validEmployeeUserCookie => Future.successful(Right(validEmployeeUser))
-        case Some(c) if c == userWithHighRecurringContributionCookie => Future.successful(Right(userWithHighRecurringContribution))
-        case Some(c) if c == userWithLowRecurringContributionCookie => Future.successful(Right(userWithLowRecurringContribution))
         case _ => Future.successful(Left(Unauthorised))
       }
   }
@@ -163,10 +139,6 @@ class AttributeControllerTest extends Specification with AfterAll with Mockito {
       )(implicit request: AuthenticatedUserAndBackendRequest[AnyContent]): Future[(String, Option[Attributes])] = Future {
         if (identityId == validUserId || identityId == validEmployeeUser.identityId)
           ("Zuora", Some(testAttributes))
-        else if (identityId == userWithHighRecurringContributionId)
-          ("Zuora", Some(userWithHighRecurringContributionAttributes))
-        else if (identityId == userWithLowRecurringContributionId)
-          ("Zuora", Some(userWithLowRecurringContributionAttributes))
         else
           ("Zuora", None)
       }
@@ -390,36 +362,6 @@ class AttributeControllerTest extends Specification with AfterAll with Mockito {
       contentAsJson(controller.attributes(req)) shouldEqual
         Json.toJson(testAttributes.copy(DigitalSubscriptionExpiryDate = digipackAllowEmployeeAccessDateHack))
     }
-
-    "allow SupporterPlus access for recurring contributors on apps if amount >=£10" in {
-      val req = FakeRequest()
-        .withCookies(userWithHighRecurringContributionCookie)
-        .withHeaders(USER_AGENT -> "Guardian/18447 CFNetwork/1333.0.4 Darwin/21.5.0")
-
-      val attribsWithSupporterPlus =
-        userWithHighRecurringContributionAttributes.copy(
-          SupporterPlusExpiryDate = Some(LocalDate.now().plusDays(1)),
-        )
-
-      contentAsJson(controller.attributes(req)) shouldEqual Json.toJson(attribsWithSupporterPlus)
-    }
-
-    "do not allow SupporterPlus access for recurring contributors on apps if amount <£10" in {
-      val req = FakeRequest()
-        .withCookies(userWithLowRecurringContributionCookie)
-        .withHeaders(USER_AGENT -> "Guardian/18447 CFNetwork/1333.0.4 Darwin/21.5.0")
-
-      contentAsJson(controller.attributes(req)) shouldEqual Json.toJson(userWithLowRecurringContributionAttributes)
-    }
-
-    "do not allow SupporterPlus access for recurring contributors if not on apps" in {
-      val req = FakeRequest()
-        .withCookies(userWithHighRecurringContributionCookie)
-        .withHeaders(USER_AGENT -> "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:102.0) Gecko/20100101 Firefox/102.0")
-
-      contentAsJson(controller.attributes(req)) shouldEqual Json.toJson(userWithHighRecurringContributionAttributes)
-    }
-
   }
 
   override def afterAll(): Unit = as.terminate()

--- a/membership-attribute-service/test/services/SupporterRatePlanToAttributesMapperTest.scala
+++ b/membership-attribute-service/test/services/SupporterRatePlanToAttributesMapperTest.scala
@@ -1,6 +1,5 @@
 package services
 
-import com.gu.i18n.Currency
 import models.{Attributes, DynamoSupporterRatePlanItem}
 import org.joda.time.LocalDate
 import org.specs2.mutable.Specification
@@ -43,20 +42,6 @@ class SupporterRatePlanToAttributesMapperTest extends Specification {
         identityId,
         List(ratePlanItem("2c92a0fc5e1dc084015e37f58c200eea")),
       ) should beSome.which(_.RecurringContributionPaymentPlan should beSome("Annual Contribution"))
-    }
-
-    "identify a high monthly contribution" in {
-      mapper.attributesFromSupporterRatePlans(
-        identityId,
-        List(ratePlanItem("2c92a0fc5aacfadd015ad24db4ff5e97").copy(contributionAmount = Some(15), contributionCurrency = Some(Currency.GBP))),
-      ) should beSome.which(_.HighContributor should beSome(true))
-    }
-
-    "identify a low monthly contribution" in {
-      mapper.attributesFromSupporterRatePlans(
-        identityId,
-        List(ratePlanItem("2c92a0fc5aacfadd015ad24db4ff5e97").copy(contributionAmount = Some(5), contributionCurrency = Some(Currency.GBP))),
-      ) should beSome.which(_.HighContributor should beSome(false))
     }
 
     "identify a Digital Subscription" in {
@@ -277,7 +262,6 @@ class SupporterRatePlanToAttributesMapperTest extends Specification {
           identityId,
           Some("Supporter"),
           Some("Monthly Contribution"),
-          Some(false),
           None,
           None,
           None,


### PR DESCRIPTION
A [previous PR](https://github.com/guardian/members-data-api/pull/780) gave recurring contributors with an amount above a certain threshold Supporter+ access in the app.
We no longer want this feature.

I've kept the contributionAmount and currency in the `DynamoSupporterRatePlanItem` model, though they're no longer being used.