### PR TITLE
Support Okta authorisation for all endpoints

### DIFF
--- a/membership-attribute-service/app/actions/AuthAndBackendViaAuthLibAction.scala
+++ b/membership-attribute-service/app/actions/AuthAndBackendViaAuthLibAction.scala
@@ -1,9 +1,10 @@
 package actions
 
 import com.gu.identity.auth.AccessScope
-import components.TouchpointBackends
+import components.{TouchpointBackends, TouchpointComponents}
 import filters.AddGuIdentityHeaders
-import play.api.mvc.{ActionRefiner, Request, Result, Results}
+import models.UserFromToken
+import play.api.mvc.{ActionRefiner, Request, Result, Results, WrappedRequest}
 import services.AuthenticationFailure
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -12,7 +13,35 @@ class AuthAndBackendViaAuthLibAction(touchpointBackends: TouchpointBackends, req
     extends ActionRefiner[Request, AuthenticatedUserAndBackendRequest] {
   override val executionContext = ex
 
-  override protected def refine[A](request: Request[A]): Future[Either[Result, AuthenticatedUserAndBackendRequest[A]]] = {
+  override protected def refine[A](request: Request[A]): Future[Either[Result, AuthenticatedUserAndBackendRequest[A]]] =
+    AuthAndBackendViaAuthLibAction.refine(touchpointBackends, requiredScopes, request) { case (backendConf, authenticatedUser) =>
+      new AuthenticatedUserAndBackendRequest(Right(authenticatedUser), backendConf, request)
+    }
+}
+
+object AuthAndBackendViaAuthLibAction {
+
+  /** Enriches a request with additional user details if the client has permission to call the endpoint being requested.
+    *
+    * @param touchpointBackends
+    *   Gives access to various upstream APIs
+    * @param requiredScopes
+    *   Scopes that an access token must have to call the endpoint being requested
+    * @param request
+    *   Request for a protected endpoint
+    * @param refined
+    *   Function giving enriched user details if authorisation is successful
+    * @tparam A
+    *   Type of incoming request
+    * @tparam R
+    *   Type of request after enrichment with additional user details
+    * @return
+    *   Enriched request if authorisation is successful. Otherwise a failure result, which can be [[Results.Unauthorized]] if authentication fails or
+    *   [[Results.Forbidden]] if client doesn't have permission to call the endpoint being requested.
+    */
+  def refine[A, R[_] <: WrappedRequest[_]](touchpointBackends: TouchpointBackends, requiredScopes: List[AccessScope], request: Request[A])(
+      refined: (TouchpointComponents, UserFromToken) => R[A],
+  )(implicit ec: ExecutionContext): Future[Either[Result, R[A]]] = {
     touchpointBackends.normal.identityAuthService.user(requiredScopes)(request) map {
       case Left(AuthenticationFailure.Unauthorised) => Left(Results.Unauthorized)
       case Left(AuthenticationFailure.Forbidden) => Left(Results.Forbidden)
@@ -22,7 +51,7 @@ class AuthAndBackendViaAuthLibAction(touchpointBackends: TouchpointBackends, req
         } else {
           touchpointBackends.normal
         }
-        Right(new AuthenticatedUserAndBackendRequest[A](Right(authenticatedUser), backendConf, request))
+        Right(refined(backendConf, authenticatedUser))
     }
   }
 }

--- a/membership-attribute-service/app/actions/AuthAndBackendViaIdapiAction.scala
+++ b/membership-attribute-service/app/actions/AuthAndBackendViaIdapiAction.scala
@@ -1,6 +1,7 @@
 package actions
 
-import com.gu.identity.{IdapiService, SignedInRecently}
+import com.gu.identity.auth.AccessScope
+import com.gu.identity.{IdapiService, RedirectAdviceResponse, SignedInRecently}
 import components.TouchpointBackends
 import filters.AddGuIdentityHeaders
 import play.api.mvc.{ActionRefiner, Request, Result, Results}
@@ -10,25 +11,42 @@ import scala.concurrent.{ExecutionContext, Future}
 class AuthAndBackendViaIdapiAction(
     touchpointBackends: TouchpointBackends,
     howToHandleRecencyOfSignedIn: HowToHandleRecencyOfSignedIn,
+    requiredScopes: List[AccessScope],
 )(implicit
     ex: ExecutionContext,
 ) extends ActionRefiner[Request, AuthAndBackendRequest] {
 
-  override val executionContext = ex
+  override protected val executionContext: ExecutionContext = ex
+
+  private def hasAuthHeader[A](request: Request[A]): Boolean = request.headers.hasHeader("Authorization")
+
   override protected def refine[A](request: Request[A]): Future[Either[Result, AuthAndBackendRequest[A]]] =
+    if (hasAuthHeader(request)) {
+      // Authenticate with Okta instead of Idapi, using the AuthAndBackendViaAuthLibAction
+      AuthAndBackendViaAuthLibAction.refine(touchpointBackends, requiredScopes, request) { case (backendConf, authenticatedUser) =>
+        new AuthAndBackendRequest(
+          redirectAdvice = RedirectAdviceResponse(
+            // Okta token lifecycle is managed elsewhere so can safely consider sign-in status always to be recent
+            signInStatus = SignedInRecently,
+            userId = Some(authenticatedUser.identityId),
+            displayName = authenticatedUser.username,
+            emailValidated = authenticatedUser.userEmailValidated,
+            // Okta token lifecycle is managed elsewhere so never any need to redirect away here
+            redirect = None,
+          ),
+          touchpoint = backendConf,
+          request,
+        )
+      }
+    } else idapiRefine(request)
+
+  private def idapiRefine[A](request: Request[A])(implicit ex: ExecutionContext): Future[Either[Result, AuthAndBackendRequest[A]]] =
     touchpointBackends.normal.idapiService.RedirectAdvice
       .getRedirectAdvice(
         request.headers.get(IdapiService.HeaderNameCookie).getOrElse(""),
         request.headers.get(IdapiService.HeaderNameIdapiForwardedScope),
       )
-      .map(redirectAdvice => {
-
-        val backendConf = if (AddGuIdentityHeaders.isTestUser(redirectAdvice.displayName)) {
-          touchpointBackends.test
-        } else {
-          touchpointBackends.normal
-        }
-
+      .map(redirectAdvice =>
         howToHandleRecencyOfSignedIn match {
           case Return401IfNotSignedInRecently if redirectAdvice.signInStatus != SignedInRecently =>
             Left(
@@ -37,8 +55,12 @@ class AuthAndBackendViaIdapiAction(
               ),
             )
           case _ =>
+            val backendConf = if (AddGuIdentityHeaders.isTestUser(redirectAdvice.displayName)) {
+              touchpointBackends.test
+            } else {
+              touchpointBackends.normal
+            }
             Right(new AuthAndBackendRequest[A](redirectAdvice, backendConf, request))
-        }
-
-      })
+        },
+      )
 }

--- a/membership-attribute-service/app/actions/CommonActions.scala
+++ b/membership-attribute-service/app/actions/CommonActions.scala
@@ -20,8 +20,8 @@ class CommonActions(touchpointBackends: TouchpointBackends, bodyParser: BodyPars
   val NoCacheAction = resultModifier(noCache)
   def AuthAndBackendViaAuthLibAction(requiredScopes: List[AccessScope]) =
     NoCacheAction andThen new AuthAndBackendViaAuthLibAction(touchpointBackends, requiredScopes)
-  def AuthAndBackendViaIdapiAction(howToHandleRecencyOfSignedIn: HowToHandleRecencyOfSignedIn) =
-    NoCacheAction andThen new AuthAndBackendViaIdapiAction(touchpointBackends, howToHandleRecencyOfSignedIn)
+  def AuthAndBackendViaIdapiAction(howToHandleRecencyOfSignedIn: HowToHandleRecencyOfSignedIn, requiredScopes: List[AccessScope]) =
+    NoCacheAction andThen new AuthAndBackendViaIdapiAction(touchpointBackends, howToHandleRecencyOfSignedIn, requiredScopes)
 
   private def resultModifier(f: Result => Result) = new ActionBuilder[Request, AnyContent] {
     override val parser = bodyParser

--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -344,18 +344,19 @@ class AccountController(
     }
   } yield filteredIfApplicable
 
-  def reminders: Action[AnyContent] = AuthAndBackendViaIdapiAction(Return401IfNotSignedInRecently).async { implicit request =>
-    request.redirectAdvice.userId match {
-      case Some(userId) =>
-        contributionsStoreDatabaseService.getSupportReminders(userId).map {
-          case Left(databaseError) =>
-            log.error(databaseError)
-            InternalServerError
-          case Right(supportReminders) =>
-            Ok(Json.toJson(supportReminders))
-        }
-      case None => Future.successful(InternalServerError)
-    }
+  def reminders: Action[AnyContent] = AuthAndBackendViaIdapiAction(Return401IfNotSignedInRecently, requiredScopes = List(completeReadSelf)).async {
+    implicit request =>
+      request.redirectAdvice.userId match {
+        case Some(userId) =>
+          contributionsStoreDatabaseService.getSupportReminders(userId).map {
+            case Left(databaseError) =>
+              log.error(databaseError)
+              InternalServerError
+            case Right(supportReminders) =>
+              Ok(Json.toJson(supportReminders))
+          }
+        case None => Future.successful(InternalServerError)
+      }
   }
 
   def getAccountDetailsParallel(
@@ -442,7 +443,7 @@ class AccountController(
   }
 
   def anyPaymentDetails(filter: OptionalSubscriptionsFilter): Action[AnyContent] =
-    AuthAndBackendViaIdapiAction(Return401IfNotSignedInRecently).async { implicit request =>
+    AuthAndBackendViaIdapiAction(Return401IfNotSignedInRecently, requiredScopes = List(completeReadSelf)).async { implicit request =>
       implicit val tp: TouchpointComponents = request.touchpoint
       val maybeUserId = request.redirectAdvice.userId
 
@@ -466,7 +467,7 @@ class AccountController(
     }
 
   def cancelledSubscriptionsImpl(): Action[AnyContent] =
-    AuthAndBackendViaIdapiAction(Return401IfNotSignedInRecently).async { implicit request =>
+    AuthAndBackendViaIdapiAction(Return401IfNotSignedInRecently, requiredScopes = List(completeReadSelf)).async { implicit request =>
       implicit val tp: TouchpointComponents = request.touchpoint
       val emptyResponse = Ok("[]")
       request.redirectAdvice.userId match {

--- a/membership-attribute-service/app/controllers/ContactController.scala
+++ b/membership-attribute-service/app/controllers/ContactController.scala
@@ -3,6 +3,7 @@ package controllers
 import actions.{AuthAndBackendRequest, CommonActions, Return401IfNotSignedInRecently}
 import com.gu.salesforce.{SFContactId, SimpleContactRepository}
 import com.typesafe.scalalogging.LazyLogging
+import models.AccessScope.updateSelf
 import models.DeliveryAddress
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 
@@ -20,7 +21,7 @@ class ContactController(
   private implicit val ec: ExecutionContext = controllerComponents.executionContext
 
   def updateDeliveryAddress(contactId: String): Action[AnyContent] =
-    AuthAndBackendViaIdapiAction(Return401IfNotSignedInRecently).async { request =>
+    AuthAndBackendViaIdapiAction(Return401IfNotSignedInRecently, requiredScopes = List(updateSelf)).async { request =>
       logger.info(s"Updating delivery address for contact $contactId")
 
       isContactOwnedByRequester(request, contactId) flatMap { valid =>

--- a/membership-attribute-service/app/controllers/ExistingPaymentOptionsController.scala
+++ b/membership-attribute-service/app/controllers/ExistingPaymentOptionsController.scala
@@ -10,17 +10,17 @@ import com.gu.memsub.subsv2.reads.SubPlanReads._
 import com.gu.memsub.subsv2.services.SubscriptionService
 import com.gu.memsub.subsv2.{Subscription, SubscriptionPlan}
 import com.gu.salesforce.SimpleContactRepository
-import com.gu.zuora.rest.ZuoraRestService
 import com.typesafe.scalalogging.LazyLogging
 import components.TouchpointComponents
+import models.AccessScope.completeReadSelf
 import models.ExistingPaymentOption
 import org.joda.time.LocalDate
 import org.joda.time.LocalDate.now
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
+import scalaz.OptionT
 import scalaz.std.scalaFuture._
 import scalaz.syntax.monadPlus._
-import scalaz.OptionT
 import utils.{ListEither, OptionEither}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -71,7 +71,7 @@ class ExistingPaymentOptionsController(commonActions: CommonActions, override va
     new LocalDate(cardDetails.expiryYear, cardDetails.expiryMonth, 1).isAfter(now.plusMonths(1))
 
   def existingPaymentOptions(currencyFilter: Option[String]): Action[AnyContent] =
-    AuthAndBackendViaIdapiAction(ContinueRegardlessOfSignInRecency).async { implicit request =>
+    AuthAndBackendViaIdapiAction(ContinueRegardlessOfSignInRecency, requiredScopes = List(completeReadSelf)).async { implicit request =>
       implicit val tp: TouchpointComponents = request.touchpoint
       val maybeUserId = request.redirectAdvice.userId
       val isSignedInRecently = request.redirectAdvice.signInStatus == SignedInRecently

--- a/membership-attribute-service/app/controllers/PaymentUpdateController.scala
+++ b/membership-attribute-service/app/controllers/PaymentUpdateController.scala
@@ -9,12 +9,13 @@ import com.gu.monitoring.SafeLogger._
 import com.gu.zuora.api.GoCardlessZuoraInstance
 import com.gu.zuora.soap.models.Commands.{BankTransfer, CreatePaymentMethod}
 import json.PaymentCardUpdateResultWriters._
+import models.AccessScope.updateSelf
 import play.api.data.Form
 import play.api.data.Forms._
 import play.api.libs.json.Json
 import play.api.mvc.{BaseController, ControllerComponents}
-import scalaz.std.scalaFuture._
 import scalaz.EitherT
+import scalaz.std.scalaFuture._
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -23,141 +24,145 @@ class PaymentUpdateController(commonActions: CommonActions, override val control
   import commonActions._
   implicit val executionContext: ExecutionContext = controllerComponents.executionContext
 
-  def updateCard(subscriptionName: String) = AuthAndBackendViaIdapiAction(Return401IfNotSignedInRecently).async { implicit request =>
-    // TODO - refactor to use the Zuora-only based lookup, like in AttributeController.pickAttributes - https://trello.com/c/RlESb8jG
-    val legacyForm = Form { tuple("stripeToken" -> nonEmptyText, "publicKey" -> nonEmptyText) }.bindFromRequest().value
-    val updateForm = Form { tuple("stripePaymentMethodID" -> nonEmptyText, "stripePublicKey" -> nonEmptyText) }.bindFromRequest().value
-    val tp = request.touchpoint
-    val setPaymentCardFunction =
-      if (updateForm.isDefined) tp.paymentService.setPaymentCardWithStripePaymentMethod _ else tp.paymentService.setPaymentCardWithStripeToken _
-    val maybeUserId = request.redirectAdvice.userId
-    SafeLogger.info(s"Attempting to update card for $maybeUserId")
-    (for {
-      user <- EitherT.fromEither(Future.successful(maybeUserId.toRight("no identity cookie for user")))
-      stripeDetails <- EitherT.fromEither(
-        Future.successful(updateForm.orElse(legacyForm).toRight("no 'stripePaymentMethodID' and 'stripePublicKey' submitted with request")),
-      )
-      (stripeCardIdentifier, stripePublicKey) = stripeDetails
-      sfUser <- EitherT.fromEither(tp.contactRepo.get(user).map(_.toEither).map(_.flatMap(_.toRight(s"no SF user $user"))))
-      subscription <- EitherT.fromEither(
-        tp.subService
-          .current[SubscriptionPlan.AnyPlan](sfUser)
-          .map(subs => subscriptionSelector(Some(memsub.Subscription.Name(subscriptionName)), s"the sfUser $sfUser")(subs)),
-      )
-      stripeService <- EitherT.fromEither(
-        Future.successful(tp.stripeServicesByPublicKey.get(stripePublicKey)).map(_.toRight(s"No Stripe service for public key: $stripePublicKey")),
-      )
-      updateResult <- EitherT.fromEither(
-        setPaymentCardFunction(subscription.accountId, stripeCardIdentifier, stripeService).map(
-          _.toRight("something was missing when attempting to update payment card in Zuora"),
-        ),
-      )
-    } yield updateResult match {
-      case success: CardUpdateSuccess => {
-        SafeLogger.info(s"Successfully updated card for identity user: $user")
-        Ok(Json.toJson(success))
-      }
-      case failure: CardUpdateFailure => {
-        SafeLogger.error(scrub"Failed to update card for identity user: $user due to $failure")
-        Forbidden(Json.toJson(failure))
-      }
-    }).run.map(_.toEither).map {
-      case Left(message) =>
-        SafeLogger.warn(s"Failed to update card for user $maybeUserId, due to $message")
-        InternalServerError(s"Failed to update card for user $maybeUserId")
-      case Right(result) => result
-    }
-  }
-
-  def updateDirectDebit(subscriptionName: String) = AuthAndBackendViaIdapiAction(Return401IfNotSignedInRecently).async { implicit request =>
-    // TODO - refactor to use the Zuora-only based lookup, like in AttributeController.pickAttributes - https://trello.com/c/RlESb8jG
-
-    def checkDirectDebitUpdateResult(
-        maybeUserId: Option[String],
-        freshDefaultPaymentMethodOption: Option[PaymentMethod],
-        bankAccountName: String,
-        bankAccountNumber: String,
-        bankSortCode: String,
-    ) = freshDefaultPaymentMethodOption match {
-      case Some(dd: GoCardless)
-          if bankAccountName == dd.accountName &&
-            dd.accountNumber.length > 3 && bankAccountNumber.endsWith(dd.accountNumber.substring(dd.accountNumber.length - 3)) &&
-            bankSortCode == dd.sortCode =>
-        SafeLogger.info(s"Successfully updated direct debit for identity user: $maybeUserId")
-        Ok(
-          Json.obj(
-            "accountName" -> dd.accountName,
-            "accountNumber" -> dd.accountNumber,
-            "sortCode" -> dd.sortCode,
+  def updateCard(subscriptionName: String) = AuthAndBackendViaIdapiAction(Return401IfNotSignedInRecently, requiredScopes = List(updateSelf)).async {
+    implicit request =>
+      // TODO - refactor to use the Zuora-only based lookup, like in AttributeController.pickAttributes - https://trello.com/c/RlESb8jG
+      val legacyForm = Form { tuple("stripeToken" -> nonEmptyText, "publicKey" -> nonEmptyText) }.bindFromRequest().value
+      val updateForm = Form { tuple("stripePaymentMethodID" -> nonEmptyText, "stripePublicKey" -> nonEmptyText) }.bindFromRequest().value
+      val tp = request.touchpoint
+      val setPaymentCardFunction =
+        if (updateForm.isDefined) tp.paymentService.setPaymentCardWithStripePaymentMethod _ else tp.paymentService.setPaymentCardWithStripeToken _
+      val maybeUserId = request.redirectAdvice.userId
+      SafeLogger.info(s"Attempting to update card for $maybeUserId")
+      (for {
+        user <- EitherT.fromEither(Future.successful(maybeUserId.toRight("no identity cookie for user")))
+        stripeDetails <- EitherT.fromEither(
+          Future.successful(updateForm.orElse(legacyForm).toRight("no 'stripePaymentMethodID' and 'stripePublicKey' submitted with request")),
+        )
+        (stripeCardIdentifier, stripePublicKey) = stripeDetails
+        sfUser <- EitherT.fromEither(tp.contactRepo.get(user).map(_.toEither).map(_.flatMap(_.toRight(s"no SF user $user"))))
+        subscription <- EitherT.fromEither(
+          tp.subService
+            .current[SubscriptionPlan.AnyPlan](sfUser)
+            .map(subs => subscriptionSelector(Some(memsub.Subscription.Name(subscriptionName)), s"the sfUser $sfUser")(subs)),
+        )
+        stripeService <- EitherT.fromEither(
+          Future.successful(tp.stripeServicesByPublicKey.get(stripePublicKey)).map(_.toRight(s"No Stripe service for public key: $stripePublicKey")),
+        )
+        updateResult <- EitherT.fromEither(
+          setPaymentCardFunction(subscription.accountId, stripeCardIdentifier, stripeService).map(
+            _.toRight("something was missing when attempting to update payment card in Zuora"),
           ),
         )
-      case Some(_) =>
-        SafeLogger.error(scrub"New payment method for user $maybeUserId, does not match the posted Direct Debit details")
-        InternalServerError("")
-      case None =>
-        SafeLogger.error(
-          scrub"default-payment-method-lost: Default payment method for user $maybeUserId, was set to nothing, when attempting to update Direct Debit details",
-        )
-        InternalServerError("")
-    }
-
-    val updateForm = Form {
-      tuple(
-        "accountName" -> nonEmptyText,
-        "accountNumber" -> nonEmptyText,
-        "sortCode" -> nonEmptyText,
-      )
-    }
-
-    val tp = request.touchpoint
-    val maybeUserId = request.redirectAdvice.userId
-    SafeLogger.info(s"Attempting to update direct debit for $maybeUserId")
-    (for {
-      user <- EitherT.fromEither(Future.successful(maybeUserId.toRight("no identity cookie for user")))
-      directDebitDetails <- EitherT.fromEither(
-        Future.successful(updateForm.bindFromRequest().value.toRight("no direct debit details submitted with request")),
-      )
-      (bankAccountName, bankAccountNumber, bankSortCode) = directDebitDetails
-      sfUser <- EitherT.fromEither(tp.contactRepo.get(user).map(_.toEither.flatMap(_.toRight(s"no SF user $user"))))
-      subscription <- EitherT.fromEither(
-        tp.subService
-          .current[SubscriptionPlan.AnyPlan](sfUser)
-          .map(subs => subscriptionSelector(Some(memsub.Subscription.Name(subscriptionName)), s"the sfUser $sfUser")(subs)),
-      )
-      account <- EitherT.fromEither(
-        annotateFailableFuture(tp.zuoraService.getAccount(subscription.accountId), s"get account with id ${subscription.accountId}"),
-      )
-      billToContact <- EitherT.fromEither(
-        annotateFailableFuture(tp.zuoraService.getContact(account.billToId), s"get billTo contact with id ${account.billToId}"),
-      )
-      bankTransferPaymentMethod = BankTransfer(
-        accountHolderName = bankAccountName,
-        accountNumber = bankAccountNumber,
-        sortCode = bankSortCode,
-        firstName = billToContact.firstName,
-        lastName = billToContact.lastName,
-        countryCode = "GB",
-      )
-      createPaymentMethod = CreatePaymentMethod(
-        accountId = subscription.accountId,
-        paymentMethod = bankTransferPaymentMethod,
-        paymentGateway = GoCardlessZuoraInstance,
-        billtoContact = billToContact,
-        invoiceTemplateOverride = None,
-      )
-      _ <- EitherT.fromEither(annotateFailableFuture(tp.zuoraService.createPaymentMethod(createPaymentMethod), "create direct debit payment method"))
-      freshDefaultPaymentMethodOption <- EitherT.fromEither(
-        annotateFailableFuture(tp.paymentService.getPaymentMethod(subscription.accountId), "get fresh default payment method"),
-      )
-    } yield checkDirectDebitUpdateResult(maybeUserId, freshDefaultPaymentMethodOption, bankAccountName, bankAccountNumber, bankSortCode)).run
-      .map(_.toEither)
-      .map {
+      } yield updateResult match {
+        case success: CardUpdateSuccess => {
+          SafeLogger.info(s"Successfully updated card for identity user: $user")
+          Ok(Json.toJson(success))
+        }
+        case failure: CardUpdateFailure => {
+          SafeLogger.error(scrub"Failed to update card for identity user: $user due to $failure")
+          Forbidden(Json.toJson(failure))
+        }
+      }).run.map(_.toEither).map {
         case Left(message) =>
-          SafeLogger.warn(s"default-payment-method-lost: failed to update direct debit for user $maybeUserId, due to $message")
-          InternalServerError("")
+          SafeLogger.warn(s"Failed to update card for user $maybeUserId, due to $message")
+          InternalServerError(s"Failed to update card for user $maybeUserId")
         case Right(result) => result
       }
-
   }
+
+  def updateDirectDebit(subscriptionName: String) =
+    AuthAndBackendViaIdapiAction(Return401IfNotSignedInRecently, requiredScopes = List(updateSelf)).async { implicit request =>
+      // TODO - refactor to use the Zuora-only based lookup, like in AttributeController.pickAttributes - https://trello.com/c/RlESb8jG
+
+      def checkDirectDebitUpdateResult(
+          maybeUserId: Option[String],
+          freshDefaultPaymentMethodOption: Option[PaymentMethod],
+          bankAccountName: String,
+          bankAccountNumber: String,
+          bankSortCode: String,
+      ) = freshDefaultPaymentMethodOption match {
+        case Some(dd: GoCardless)
+            if bankAccountName == dd.accountName &&
+              dd.accountNumber.length > 3 && bankAccountNumber.endsWith(dd.accountNumber.substring(dd.accountNumber.length - 3)) &&
+              bankSortCode == dd.sortCode =>
+          SafeLogger.info(s"Successfully updated direct debit for identity user: $maybeUserId")
+          Ok(
+            Json.obj(
+              "accountName" -> dd.accountName,
+              "accountNumber" -> dd.accountNumber,
+              "sortCode" -> dd.sortCode,
+            ),
+          )
+        case Some(_) =>
+          SafeLogger.error(scrub"New payment method for user $maybeUserId, does not match the posted Direct Debit details")
+          InternalServerError("")
+        case None =>
+          SafeLogger.error(
+            scrub"default-payment-method-lost: Default payment method for user $maybeUserId, was set to nothing, when attempting to update Direct Debit details",
+          )
+          InternalServerError("")
+      }
+
+      val updateForm = Form {
+        tuple(
+          "accountName" -> nonEmptyText,
+          "accountNumber" -> nonEmptyText,
+          "sortCode" -> nonEmptyText,
+        )
+      }
+
+      val tp = request.touchpoint
+      val maybeUserId = request.redirectAdvice.userId
+      SafeLogger.info(s"Attempting to update direct debit for $maybeUserId")
+      (for {
+        user <- EitherT.fromEither(Future.successful(maybeUserId.toRight("no identity cookie for user")))
+        directDebitDetails <- EitherT.fromEither(
+          Future.successful(updateForm.bindFromRequest().value.toRight("no direct debit details submitted with request")),
+        )
+        (bankAccountName, bankAccountNumber, bankSortCode) = directDebitDetails
+        sfUser <- EitherT.fromEither(tp.contactRepo.get(user).map(_.toEither.flatMap(_.toRight(s"no SF user $user"))))
+        subscription <- EitherT.fromEither(
+          tp.subService
+            .current[SubscriptionPlan.AnyPlan](sfUser)
+            .map(subs => subscriptionSelector(Some(memsub.Subscription.Name(subscriptionName)), s"the sfUser $sfUser")(subs)),
+        )
+        account <- EitherT.fromEither(
+          annotateFailableFuture(tp.zuoraService.getAccount(subscription.accountId), s"get account with id ${subscription.accountId}"),
+        )
+        billToContact <- EitherT.fromEither(
+          annotateFailableFuture(tp.zuoraService.getContact(account.billToId), s"get billTo contact with id ${account.billToId}"),
+        )
+        bankTransferPaymentMethod = BankTransfer(
+          accountHolderName = bankAccountName,
+          accountNumber = bankAccountNumber,
+          sortCode = bankSortCode,
+          firstName = billToContact.firstName,
+          lastName = billToContact.lastName,
+          countryCode = "GB",
+        )
+        createPaymentMethod = CreatePaymentMethod(
+          accountId = subscription.accountId,
+          paymentMethod = bankTransferPaymentMethod,
+          paymentGateway = GoCardlessZuoraInstance,
+          billtoContact = billToContact,
+          invoiceTemplateOverride = None,
+        )
+        _ <- EitherT.fromEither(
+          annotateFailableFuture(tp.zuoraService.createPaymentMethod(createPaymentMethod), "create direct debit payment method"),
+        )
+        freshDefaultPaymentMethodOption <- EitherT.fromEither(
+          annotateFailableFuture(tp.paymentService.getPaymentMethod(subscription.accountId), "get fresh default payment method"),
+        )
+      } yield checkDirectDebitUpdateResult(maybeUserId, freshDefaultPaymentMethodOption, bankAccountName, bankAccountNumber, bankSortCode)).run
+        .map(_.toEither)
+        .map {
+          case Left(message) =>
+            SafeLogger.warn(s"default-payment-method-lost: failed to update direct debit for user $maybeUserId, due to $message")
+            InternalServerError("")
+          case Right(result) => result
+        }
+
+    }
 
 }

--- a/membership-attribute-service/test/actions/AuthAndBackendViaAuthLibActionTest.scala
+++ b/membership-attribute-service/test/actions/AuthAndBackendViaAuthLibActionTest.scala
@@ -1,0 +1,70 @@
+package actions
+
+import components.{TouchpointBackends, TouchpointComponents}
+import models.AccessScope.readSelf
+import models.UserFromToken
+import org.mockito.Mockito.when
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import play.api.mvc.Results.{Forbidden, Unauthorized}
+import play.api.mvc.{AnyContent, WrappedRequest}
+import play.api.test.FakeRequest
+import services.{AuthenticationFailure, IdentityAuthService}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
+
+class AuthAndBackendViaAuthLibActionTest extends Specification with Mockito {
+
+  "AuthAndBackendViaAuthLibAction.refine" should {
+
+    "give a wrapped request when authorisation is successful" in {
+      val request = FakeRequest()
+      val requiredScopes = List(readSelf)
+      val user = mock[UserFromToken]
+      when(user.username).thenReturn(None)
+      val authService = mock[IdentityAuthService]
+      when(authService.user(requiredScopes)(request)).thenReturn(Future.successful(Right(user)))
+      val components = mock[TouchpointComponents]
+      when(components.identityAuthService).thenReturn(authService)
+      val backends = mock[TouchpointBackends]
+      when(backends.normal).thenReturn(components)
+      val wrappedRequest = new WrappedRequest(request)
+      val result = AuthAndBackendViaAuthLibAction.refine[AnyContent, WrappedRequest](backends, requiredScopes, request)((_, _) => wrappedRequest)
+      Await.result(result, Duration.Inf) should beRight(wrappedRequest)
+    }
+
+    "give an unauthorized result when authentication fails" in {
+      val request = FakeRequest()
+      val requiredScopes = List(readSelf)
+      val user = mock[UserFromToken]
+      when(user.username).thenReturn(None)
+      val authService = mock[IdentityAuthService]
+      when(authService.user(requiredScopes)(request)).thenReturn(Future.successful(Left(AuthenticationFailure.Unauthorised)))
+      val components = mock[TouchpointComponents]
+      when(components.identityAuthService).thenReturn(authService)
+      val backends = mock[TouchpointBackends]
+      when(backends.normal).thenReturn(components)
+      val wrappedRequest = new WrappedRequest(request)
+      val result = AuthAndBackendViaAuthLibAction.refine[AnyContent, WrappedRequest](backends, requiredScopes, request)((_, _) => wrappedRequest)
+      Await.result(result, Duration.Inf) should beLeft(Unauthorized)
+    }
+
+    "give a forbidden result when authorisation fails" in {
+      val request = FakeRequest()
+      val requiredScopes = List(readSelf)
+      val user = mock[UserFromToken]
+      when(user.username).thenReturn(None)
+      val authService = mock[IdentityAuthService]
+      when(authService.user(requiredScopes)(request)).thenReturn(Future.successful(Left(AuthenticationFailure.Forbidden)))
+      val components = mock[TouchpointComponents]
+      when(components.identityAuthService).thenReturn(authService)
+      val backends = mock[TouchpointBackends]
+      when(backends.normal).thenReturn(components)
+      val wrappedRequest = new WrappedRequest(request)
+      val result = AuthAndBackendViaAuthLibAction.refine[AnyContent, WrappedRequest](backends, requiredScopes, request)((_, _) => wrappedRequest)
+      Await.result(result, Duration.Inf) should beLeft(Forbidden)
+    }
+  }
+}

--- a/membership-attribute-service/test/actions/AuthAndBackendViaIdapiActionTest.scala
+++ b/membership-attribute-service/test/actions/AuthAndBackendViaIdapiActionTest.scala
@@ -1,0 +1,38 @@
+package actions
+
+import components.{TouchpointBackends, TouchpointComponents}
+import models.AccessScope.readSelf
+import models.UserFromToken
+import org.mockito.Mockito.when
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import play.api.mvc.{AnyContent, Results}
+import play.api.test.FakeRequest
+import services.IdentityAuthService
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
+
+class AuthAndBackendViaIdapiActionTest extends Specification with Mockito {
+
+  "AuthAndBackendViaIdapiAction.refine" should {
+
+    "delegate to AuthAndBackendViaAuthLibAction if request has an auth header" in {
+      val request = FakeRequest().withHeaders("Authorization" -> "Bearer abcdef")
+      val requiredScopes = List(readSelf)
+      val user = mock[UserFromToken]
+      when(user.username).thenReturn(None)
+      val authService = mock[IdentityAuthService]
+      when(authService.user(requiredScopes)(request)).thenReturn(Future.successful(Right(user)))
+      val components = mock[TouchpointComponents]
+      when(components.identityAuthService).thenReturn(authService)
+      val backends = mock[TouchpointBackends]
+      when(backends.normal).thenReturn(components)
+      val action = new AuthAndBackendViaIdapiAction(backends, Return401IfNotSignedInRecently, requiredScopes)
+      val block = { _: AuthAndBackendRequest[AnyContent] => Future.successful(Results.Ok) }
+      val result = action.invokeBlock(request, block)
+      Await.result(result, Duration.Inf) shouldEqual Results.Ok
+    }
+  }
+}

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -146,7 +146,7 @@ class AttributeControllerTest extends Specification with AfterAll with Mockito {
   private val ex = scala.concurrent.ExecutionContext.global
   private val commonActions = new CommonActions(touchpointBackends, stubParser)(scala.concurrent.ExecutionContext.global, ActorMaterializer()) {
     override def AuthAndBackendViaAuthLibAction(requiredScopes: List[AccessScope]) = NoCacheAction andThen FakeAuthAndBackendViaAuthLibAction
-    override def AuthAndBackendViaIdapiAction(howToHandleRecencyOfSignedIn: HowToHandleRecencyOfSignedIn) =
+    override def AuthAndBackendViaIdapiAction(howToHandleRecencyOfSignedIn: HowToHandleRecencyOfSignedIn, requiredScopes: List[AccessScope]) =
       NoCacheAction andThen FakeAuthAndBackendViaIdapiAction
   }
 


### PR DESCRIPTION
This finishes off the remaining endpoints that use the `AuthAndBackendViaIdapiAction` for authorisation so that all endpoints now support Okta authorisation.  While we're in transition, Idapi cookies are also supported for all endpoints.

The strategy of this change is to delegate requests that have an Okta token to the `AuthAndBackendViaAuthLibAction`.  This is safe to do because the lifecycle of the Okta token will be managed in the client app rather than in this API so the check for the age of the token is redundant.  For example, MMA will have short-lived non-refreshable tokens and will respond to a 401 response by re-authenticating and requesting a new token.

As requests to this API authorised by Idapi don't use the `authorization` header, it seems reasonable to assume that as far as this API is concerned that header is only ever used for Okta tokens.  So the presence of the header is used as the indicator of an Okta token.

This change won't affect the existing behaviour of the API with Idapi cookies.

The expected behaviour is:
1. With an Idapi cookie, no change.
2. With an Okta token in the authorization header:
    1. If token is invalid: return 401
    2. If token doesn't have required scopes for endpoint: return 403
    3. Otherwise action goes ahead

The scopes for each endpoint are those agreed in [this sheet](https://docs.google.com/spreadsheets/d/17Zo1aVBV6yzOcVp3hC_nnYcwrt5PMsSrgInGY9D7i_A/edit#gid=0).

Tested on Code with Idapi cookies and Okta tokens.
