### PR TITLE
Hide support messaging for Supporter Plus

### DIFF
--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -75,6 +75,7 @@ case class Attributes(
   // TODO in future this could become more sophisticated (e.g. two weeks before their products expire)
   lazy val showSupportMessaging = !(
     isPaidTier
+      || isSupporterPlus
       || isRecurringContributor
       || isRecentOneOffContributor
       || digitalSubscriberHasActivePlan

--- a/membership-attribute-service/test/models/AttributesTest.scala
+++ b/membership-attribute-service/test/models/AttributesTest.scala
@@ -1,5 +1,6 @@
 package models
 
+import org.joda.time.LocalDate
 import org.specs2.mutable.Specification
 
 class AttributesTest extends Specification {
@@ -34,6 +35,16 @@ class AttributesTest extends Specification {
 
       "false if the user is not a Contributor but a member" in {
         attrs.copy(Tier = Some("Friend"), RecurringContributionPaymentPlan = None).isRecurringContributor shouldEqual false
+      }
+    }
+
+    "showSupportMessaging returns" should {
+      "false if user has Supporter Plus" in {
+        attrs.copy(SupporterPlusExpiryDate = Some(new LocalDate(2099, 1, 1))).showSupportMessaging shouldEqual false
+      }
+
+      "true if user has expired Supporter Plus" in {
+        attrs.copy(SupporterPlusExpiryDate = Some(new LocalDate(2010, 1, 1))).showSupportMessaging shouldEqual true
       }
     }
   }


### PR DESCRIPTION
Supporter plus customers were still seeing support messaging as it hadn't been included in the logic to exclude them.