### PR TITLE
Refactor names of response properties

### DIFF
--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -111,10 +111,10 @@ object AccountDetails {
         case paidPlan: PaidSubscriptionPlan[_, _] =>
           Json.obj(
             "chargedThrough" -> paidPlan.chargedThrough,
-            "amount" -> paidPlan.charges.price.prices.head.amount * 100,
+            "price" -> paidPlan.charges.price.prices.head.amount * 100,
             "currency" -> paidPlan.charges.price.prices.head.currency.glyph,
             "currencyISO" -> paidPlan.charges.price.prices.head.currency.iso,
-            "interval" -> paidPlan.charges.billingPeriod.noun,
+            "billingPeriod" -> paidPlan.charges.billingPeriod.noun,
           )
         case _ => Json.obj()
       }) ++ (plan.charges match {
@@ -178,10 +178,10 @@ object AccountDetails {
             "autoRenew" -> isAutoRenew,
             "plan" -> Json.obj( // TODO remove once nothing is using this key (same time as removing old deprecated endpoints)
               "name" -> paymentDetails.plan.name,
-              "amount" -> paymentDetails.plan.price.amount * 100,
+              "price" -> paymentDetails.plan.price.amount * 100,
               "currency" -> paymentDetails.plan.price.currency.glyph,
               "currencyISO" -> paymentDetails.plan.price.currency.iso,
-              "interval" -> paymentDetails.plan.interval.mkString,
+              "billingPeriod" -> paymentDetails.plan.interval.mkString,
             ),
             "currentPlans" -> currentPlans.map(jsonifyPlan),
             "futurePlans" -> futurePlans.map(jsonifyPlan),

--- a/membership-attribute-service/app/models/ContributionData.scala
+++ b/membership-attribute-service/app/models/ContributionData.scala
@@ -17,7 +17,7 @@ object ContributionData {
     override def writes(o: ContributionData): JsValue = Json.obj(
       "created" -> o.created,
       "currency" -> o.currency.toString,
-      "amount" -> o.amount,
+      "price" -> o.amount,
       "status" -> o.status,
     )
   }

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -254,7 +254,7 @@ class AttributeControllerTest extends Specification with AfterAll with Mockito {
                    | {
                    |   "created":1638057600000,
                    |   "currency":"GBP",
-                   |   "amount":11,
+                   |   "price":11,
                    |   "status":"statusValue"
                    | }
                    | ]


### PR DESCRIPTION
Refactors the names of API response properties to be more in-line with Zuora's naming conventions (specifically the conventions in their REST API). That is, we are changing the property `amount` to be named `price`, and the property `interval` to be named `billingPeriod`. Refer to some examples of Zuora rest API responses [here](https://github.com/guardian/price-migration-engine/blob/main/lambda/src/test/resources/GuardianWeekly/CappedPriceIncrease/Subscription.json) and [here](https://github.com/guardian/price-migration-engine/blob/main/lambda/src/test/resources/GuardianWeekly/CappedPriceIncrease/Catalogue.json).

PR for the frontend [here](https://github.com/guardian/manage-frontend/pull/947).