### PR TITLE
Add authTime to Okta access claims

### DIFF
--- a/membership-attribute-service/app/models/UserFromToken.scala
+++ b/membership-attribute-service/app/models/UserFromToken.scala
@@ -3,6 +3,8 @@ package models
 import com.gu.identity.auth._
 import com.gu.identity.model.User
 
+import java.time.{Instant, ZoneId, ZonedDateTime}
+
 /** Claims that are used to determine which resources the user is authorised to access.
   *
   * @param primaryEmailAddress
@@ -13,12 +15,15 @@ import com.gu.identity.model.User
   *   User name, a synonym for display name. Also used to determine if this is a test user.
   * @param userEmailValidated
   *   true iff the user has validated their email address
+  * @param authTime
+  *   The time the user was last authenticated.
   */
 case class UserFromToken(
     primaryEmailAddress: String,
     identityId: String,
     username: Option[String] = None,
     userEmailValidated: Option[Boolean] = None,
+    authTime: Option[ZonedDateTime], // optional because not available from Idapi
 ) extends AccessClaims
 
 object UserFromTokenParser extends AccessClaimsParser[UserFromToken] {
@@ -26,20 +31,24 @@ object UserFromTokenParser extends AccessClaimsParser[UserFromToken] {
   override def fromDefaultAndUnparsed(
       defaultClaims: DefaultAccessClaims,
       unparsedClaims: UnparsedClaims,
-  ): Either[ValidationError, UserFromToken] =
-    Right(
-      UserFromToken(
-        primaryEmailAddress = defaultClaims.primaryEmailAddress,
-        identityId = defaultClaims.identityId,
-        username = defaultClaims.username,
-        userEmailValidated = unparsedClaims.getOptional[Boolean]("email_validated"),
-      ),
+  ): Either[ValidationError, UserFromToken] = {
+    def toUtcTime(unixTimeStamp: Long) = Instant.ofEpochSecond(unixTimeStamp).atZone(ZoneId.of("UTC"))
+    for {
+      authTime <- unparsedClaims.getRequired[Long]("auth_time")
+    } yield UserFromToken(
+      primaryEmailAddress = defaultClaims.primaryEmailAddress,
+      identityId = defaultClaims.identityId,
+      username = defaultClaims.username,
+      userEmailValidated = unparsedClaims.getOptional[Boolean]("email_validated"),
+      authTime = Some(toUtcTime(authTime)),
     )
+  }
 
   override def fromUser(user: User): UserFromToken = UserFromToken(
     primaryEmailAddress = user.primaryEmailAddress,
     identityId = user.id,
     username = user.publicFields.username,
     userEmailValidated = user.statusFields.userEmailValidated,
+    authTime = None,
   )
 }

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -50,21 +50,25 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
     primaryEmailAddress = "test@gu.com",
     identityId = validUserId,
     userEmailValidated = Some(true),
+    authTime = None,
   )
   private val unvalidatedEmailUser = UserFromToken(
     primaryEmailAddress = "unvalidatedEmail@gu.com",
     identityId = unvalidatedEmailUserId,
     userEmailValidated = Some(false),
+    authTime = None,
   )
   private val userWithoutAttributes = UserFromToken(
     primaryEmailAddress = "notcached@gu.com",
     identityId = userWithoutAttributesUserId,
+    authTime = None,
   )
 
   private val guardianEmployeeUser = UserFromToken(
     primaryEmailAddress = "foo@guardian.co.uk",
     identityId = "1234321",
     userEmailValidated = Some(true),
+    authTime = None,
   )
   private val guardianEmployeeCookie = Cookie("employeeDigiPackHack", "true")
 
@@ -72,6 +76,7 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
     primaryEmailAddress = "foo@theguardian.com",
     identityId = "123theguardiancom",
     userEmailValidated = Some(true),
+    authTime = None,
   )
   private val guardianEmployeeCookieTheguardian = Cookie("employeeDigiPackHackTheguardian", "true")
 
@@ -79,6 +84,7 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
     primaryEmailAddress = "bar@theguardian.com",
     identityId = "userWithRealProducts",
     userEmailValidated = Some(true),
+    authTime = None,
   )
   private val validEmployeeUserCookie = Cookie("userWithRealProducts", "true")
 

--- a/membership-attribute-service/test/filters/AddGuIdentityHeadersTest.scala
+++ b/membership-attribute-service/test/filters/AddGuIdentityHeadersTest.scala
@@ -24,6 +24,7 @@ class AddGuIdentityHeadersTest extends Specification with IdiomaticMockito {
     identityId = "testUserId",
     username = Some("testUserName"),
     userEmailValidated = None,
+    authTime = None,
   )
 
   val identityService = mock[IdentityAuthService]

--- a/membership-attribute-service/test/models/UserFromTokenTest.scala
+++ b/membership-attribute-service/test/models/UserFromTokenTest.scala
@@ -4,6 +4,8 @@ import com.gu.identity.auth.{MissingRequiredClaim, UnparsedClaims}
 import com.gu.identity.model.{PublicFields, StatusFields, User}
 import org.specs2.mutable.Specification
 
+import java.time.{ZoneId, ZonedDateTime}
+
 class UserFromTokenTest extends Specification {
 
   val identityId = "someIdentityId"
@@ -15,6 +17,7 @@ class UserFromTokenTest extends Specification {
     "sub" -> email,
     "email_validated" -> Boolean.box(true),
     "unused" -> "unusedValue",
+    "auth_time" -> Long.box(1672917908),
   )
 
   val parsedClaims = UserFromToken(
@@ -22,6 +25,7 @@ class UserFromTokenTest extends Specification {
     username = Some(username),
     primaryEmailAddress = email,
     userEmailValidated = Some(true),
+    authTime = Some(ZonedDateTime.of(2023, 1, 5, 11, 25, 8, 0, ZoneId.of("UTC"))),
   )
 
   "UserFromTokenParser.fromUnparsed" should {
@@ -30,7 +34,7 @@ class UserFromTokenTest extends Specification {
 
       val Right(actual) = UserFromTokenParser.fromUnparsed(unparsedClaims)
 
-      actual shouldEqual (parsedClaims)
+      actual shouldEqual parsedClaims
     }
     "parse claims without optional fields" in {
       val onlyRequiredRawClaims = rawClaims.removedAll(List("identity_username", "email_validated"))
@@ -39,7 +43,7 @@ class UserFromTokenTest extends Specification {
       val Right(actual) = UserFromTokenParser.fromUnparsed(onlyRequiredUnparsed)
 
       val onlyRequiredAccessClaims = parsedClaims.copy(username = None, userEmailValidated = None)
-      actual shouldEqual (onlyRequiredAccessClaims)
+      actual shouldEqual onlyRequiredAccessClaims
     }
 
     def assertErrorReturnedOnMissingRequiredClaim(requiredClaimName: String) = {
@@ -67,7 +71,7 @@ class UserFromTokenTest extends Specification {
         ),
       )
 
-      UserFromTokenParser.fromUser(testUser) shouldEqual parsedClaims
+      UserFromTokenParser.fromUser(testUser) shouldEqual parsedClaims.copy(authTime = None)
 
     }
   }


### PR DESCRIPTION
This change adds a new claim to the set of access claims extracted from the Okta access token.
The `auth_time` claim gives us a Unix timestamp for the last time the owner of the access token last authenticated.
We can then use this in a future PR to compare with the current time and decide if the client should be allowed access or sent a 401 as a hint to reauthenticate.

https://trello.com/c/LzxN3jTi/4226-update-mdapi-endpoints-that-use-alternative-authentication-technique
