### PR TITLE
Add new method to get user and credentials from either Okta or Idapi

### DIFF
--- a/membership-attribute-service/test/services/IdentityAuthServiceTest.scala
+++ b/membership-attribute-service/test/services/IdentityAuthServiceTest.scala
@@ -1,0 +1,79 @@
+package services
+
+import cats.effect.IO
+import com.gu.identity.auth.{DefaultIdentityClaims, IdapiUserCredentials, InvalidOrExpiredToken, OktaUserCredentials, OktaValidationException}
+import com.gu.identity.play.IdentityPlayAuthService
+import com.gu.identity.play.IdentityPlayAuthService.UserCredentialsMissingError
+import models.AccessScope.readSelf
+import models.{ApiError, UserFromToken, UserFromTokenParser}
+import org.mockito.IdiomaticMockito
+import org.mockito.Mockito.when
+import org.specs2.mutable.Specification
+import play.api.test.FakeRequest
+
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.Duration
+
+class IdentityAuthServiceTest extends Specification with IdiomaticMockito {
+
+  "userFromOktaToken" should {
+
+    val requiredScopes = List(readSelf)
+
+    "give user and Okta credentials if Okta token is valid" in {
+      val request = FakeRequest()
+      val credentials = mock[OktaUserCredentials]
+      val user = mock[UserFromToken]
+      val identityPlayAuthService = mock[IdentityPlayAuthService[UserFromToken, DefaultIdentityClaims]]
+      when(identityPlayAuthService.validateCredentialsFromRequest(request, requiredScopes, UserFromTokenParser))
+        .thenReturn(IO.pure((credentials, user)))
+      val identityAuthService = new IdentityAuthService(identityPlayAuthService)
+      val result = identityAuthService.userAndCredentials(request, requiredScopes)
+      Await.result(result, Duration.Inf) shouldEqual Right(UserAndCredentials(user, credentials))
+    }
+
+    "give user and Idapi credentials if Idapi credentials are valid" in {
+      val request = FakeRequest()
+      val credentials = mock[IdapiUserCredentials]
+      val user = mock[UserFromToken]
+      val identityPlayAuthService = mock[IdentityPlayAuthService[UserFromToken, DefaultIdentityClaims]]
+      when(identityPlayAuthService.validateCredentialsFromRequest(request, requiredScopes, UserFromTokenParser))
+        .thenReturn(IO.pure(credentials, user))
+      val identityAuthService = new IdentityAuthService(identityPlayAuthService)
+      val result = identityAuthService.userAndCredentials(request, requiredScopes)
+      Await.result(result, Duration.Inf) shouldEqual Right(UserAndCredentials(user, credentials))
+    }
+
+    "give API error if Okta token is invalid" in {
+      val request = FakeRequest()
+      val identityPlayAuthService = mock[IdentityPlayAuthService[UserFromToken, DefaultIdentityClaims]]
+      when(identityPlayAuthService.validateCredentialsFromRequest(request, requiredScopes, UserFromTokenParser))
+        .thenReturn(IO.raiseError(OktaValidationException(InvalidOrExpiredToken)))
+      val identityAuthService = new IdentityAuthService(identityPlayAuthService)
+      val result = identityAuthService.userAndCredentials(request, requiredScopes)
+      Await.result(result, Duration.Inf) shouldEqual Left(ApiError("Token is invalid or expired", "", 401))
+    }
+
+    "give API error if Idapi credentials are invalid" in {
+      val request = FakeRequest()
+      val identityPlayAuthService = mock[IdentityPlayAuthService[UserFromToken, DefaultIdentityClaims]]
+      when(identityPlayAuthService.validateCredentialsFromRequest(request, requiredScopes, UserFromTokenParser))
+        .thenReturn(IO.raiseError(UserCredentialsMissingError("missing")))
+      val identityAuthService = new IdentityAuthService(identityPlayAuthService)
+      val result = identityAuthService.userAndCredentials(request, requiredScopes)
+      Await.result(result, Duration.Inf) shouldEqual Left(ApiError("Unauthorized", "Failed to authenticate", 401))
+    }
+
+    "throw an exception if validation failed for some other reason" in {
+      val request = FakeRequest()
+      val exception = new RuntimeException()
+      val identityPlayAuthService = mock[IdentityPlayAuthService[UserFromToken, DefaultIdentityClaims]]
+      when(identityPlayAuthService.validateCredentialsFromRequest(request, requiredScopes, UserFromTokenParser))
+        .thenReturn(IO.raiseError(exception))
+      val identityAuthService = new IdentityAuthService(identityPlayAuthService)
+      val result = identityAuthService.userAndCredentials(request, requiredScopes)
+      Await.result(result.failed, Duration.Inf) shouldEqual exception
+    }
+  }
+}


### PR DESCRIPTION
This is in preparation for modifying the [AuthAndBackendViaIdapiAction](https://github.com/guardian/members-data-api/blob/main/membership-attribute-service/app/actions/AuthAndBackendViaIdapiAction.scala) to support both Okta and Idapi credentials.

As the logic will depend on the source of the credentials, ie either an Okta token or Idapi cookies, we need a new method that will give us a set of access claims and tell us where those claims came from: either Idapi or Okta.

This change is to give us that new method: `IdentityAuthService.userAndCredentials`.

I have also refactored the IdentityAuthService constructor so that it takes an `IdentityPlayAuthService` rather than building it itself.  This is to decouple it slightly and make it easier to test.

https://trello.com/c/LzxN3jTi/4226-update-mdapi-endpoints-that-use-alternative-authentication-technique

Tested on Code.
