### PR TITLE
Using ExpensiveMetrics for AttributeConttroller.attributes endpoint (to save on AWS metrics cost).

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -11,7 +11,7 @@ import models.ApiError._
 import models.ApiErrors._
 import models.Features._
 import models._
-import monitoring.CreateMetrics
+import monitoring.{CreateMetrics, BatchedMetrics}
 import org.joda.time.LocalDate
 import play.api.libs.json.Json
 import play.api.mvc._
@@ -36,6 +36,7 @@ class AttributeController(
   import commonActions._
   implicit val executionContext: ExecutionContext = controllerComponents.executionContext
   lazy val metrics = createMetrics.forService(classOf[AttributeController])
+  lazy val expensiveMetrics = createMetrics.batchedForService(classOf[AttributeController])
 
   private def getLatestOneOffContributionDate(identityId: String, user: UserFromToken)(implicit
       executionContext: ExecutionContext,
@@ -58,11 +59,11 @@ class AttributeController(
   )(implicit executionContext: ExecutionContext): Future[Option[MobileSubscriptionStatus]] = {
     mobileSubscriptionService.getSubscriptionStatusForUser(identityId).transform {
       case Failure(error) =>
-        metrics.put(s"mobile-subscription-fetch-exception", 1)
+        metrics.increaseCount(s"mobile-subscription-fetch-exception")
         log.warn("Exception while fetching mobile subscription, assuming none", error)
         Success(None)
       case Success(Left(error)) =>
-        metrics.put(s"mobile-subscription-fetch-error-non-http-200", 1)
+        metrics.increaseCount(s"mobile-subscription-fetch-error-non-http-200")
         log.warn(s"Unable to fetch mobile subscription, assuming none: $error")
         Success(None)
       case Success(Right(status)) => Success(status)
@@ -96,98 +97,106 @@ class AttributeController(
       sendAttributesIfNotFound: Boolean = false,
       requiredScopes: List[AccessScope],
       metricName: String,
-  ) = {
-    AuthAndBackendViaAuthLibAction(requiredScopes).async { implicit request =>
-      if (endpointDescription == "membership" || endpointDescription == "features") {
-        DeprecatedRequestLogger.logDeprecatedRequest(request)
-      }
+      useExpensiveMetrics: Boolean = false,
+  ): Action[AnyContent] = {
+    AuthAndBackendViaAuthLibAction(requiredScopes).async { request =>
+      val future: Future[Result] = {
+        if (endpointDescription == "membership" || endpointDescription == "features") {
+          DeprecatedRequestLogger.logDeprecatedRequest(request)
+        }
 
-      metrics.measureDuration(metricName)(request.user match {
-        case Right(user) =>
-          // execute futures outside of the for comprehension so they are executed in parallel rather than in sequence
-          val futureSupporterAttributes = getSupporterProductDataAttributes(user.identityId)
-          val futureOneOffContribution = getLatestOneOffContributionDate(user.identityId, user)
-          val futureMobileSubscriptionStatus = getLatestMobileSubscription(user.identityId)
+        request.user match {
+          case Right(user) =>
+            // execute futures outside of the for comprehension so they are executed in parallel rather than in sequence
+            val futureSupporterAttributes = getSupporterProductDataAttributes(user.identityId)(request)
+            val futureOneOffContribution = getLatestOneOffContributionDate(user.identityId, user)
+            val futureMobileSubscriptionStatus = getLatestMobileSubscription(user.identityId)
 
-          (for {
-            // Fetch one-off data independently of zuora data so that we can handle users with no zuora record
-            (fromWhere: String, supporterAttributes: Option[Attributes]) <- futureSupporterAttributes
-            latestOneOffDate: Option[LocalDate] <- futureOneOffContribution
-            latestMobileSubscription: Option[MobileSubscriptionStatus] <- futureMobileSubscriptionStatus
-            supporterOrStaffAttributes: Option[Attributes] = maybeAllowAccessToDigipackForGuardianEmployees(
-              // transforming to Option here because type of failure is no longer relevant at this point
-              request.user.toOption,
-              supporterAttributes,
-              user.identityId,
-            )
-            allProductAttributes: Option[Attributes] = supporterOrStaffAttributes.map(
-              addOneOffAndMobile(_, latestOneOffDate, latestMobileSubscription),
-            )
-          } yield {
+            (for {
+              // Fetch one-off data independently of zuora data so that we can handle users with no zuora record
+              (fromWhere: String, supporterAttributes: Option[Attributes]) <- futureSupporterAttributes
+              latestOneOffDate: Option[LocalDate] <- futureOneOffContribution
+              latestMobileSubscription: Option[MobileSubscriptionStatus] <- futureMobileSubscriptionStatus
+              supporterOrStaffAttributes: Option[Attributes] = maybeAllowAccessToDigipackForGuardianEmployees(
+                // transforming to Option here because type of failure is no longer relevant at this point
+                request.user.toOption,
+                supporterAttributes,
+                user.identityId,
+              )
+              allProductAttributes: Option[Attributes] = supporterOrStaffAttributes.map(
+                addOneOffAndMobile(_, latestOneOffDate, latestMobileSubscription),
+              )
+            } yield {
 
-            def customFields(supporterType: String): List[LogField] = List(
-              LogFieldString("lookup-endpoint-description", endpointDescription),
-              LogFieldString("supporter-type", supporterType),
-              LogFieldString("data-source", fromWhere),
-            )
+              def customFields(supporterType: String): List[LogField] = List(
+                LogFieldString("lookup-endpoint-description", endpointDescription),
+                LogFieldString("supporter-type", supporterType),
+                LogFieldString("data-source", fromWhere),
+              )
 
-            val result = allProductAttributes match {
-              case Some(attrs @ Attributes(_, Some(tier), _, _, _, _, _, _, _, _, _, _)) =>
-                logInfoWithCustomFields(
-                  s"${user.identityId} is a $tier member - $endpointDescription - $attrs found via $fromWhere",
-                  customFields("member"),
-                )
-                onSuccessMember(attrs).withHeaders(
-                  "X-Gu-Membership-Tier" -> tier,
-                  "X-Gu-Membership-Is-Paid-Tier" -> attrs.isPaidTier.toString,
-                )
-              case Some(attrs) =>
-                attrs.DigitalSubscriptionExpiryDate.foreach { date =>
-                  logInfoWithCustomFields(s"${user.identityId} is a digital subscriber expiring $date", customFields("digital-subscriber"))
-                }
-                attrs.PaperSubscriptionExpiryDate.foreach { date =>
-                  logInfoWithCustomFields(s"${user.identityId} is a paper subscriber expiring $date", customFields("paper-subscriber"))
-                }
-                attrs.GuardianWeeklySubscriptionExpiryDate.foreach { date =>
+              val result = allProductAttributes match {
+                case Some(attrs @ Attributes(_, Some(tier), _, _, _, _, _, _, _, _, _, _)) =>
                   logInfoWithCustomFields(
-                    s"${user.identityId} is a Guardian Weekly subscriber expiring $date",
-                    customFields("guardian-weekly-subscriber"),
+                    s"${user.identityId} is a $tier member - $endpointDescription - $attrs found via $fromWhere",
+                    customFields("member"),
                   )
-                }
-                attrs.GuardianPatronExpiryDate.foreach { date =>
-                  logInfoWithCustomFields(s"${user.identityId} is a Guardian Patron expiring $date", customFields("guardian-patron"))
-                }
-                attrs.RecurringContributionPaymentPlan.foreach { paymentPlan =>
-                  logInfoWithCustomFields(s"${user.identityId} is a regular $paymentPlan contributor", customFields("contributor"))
-                }
-                logInfoWithCustomFields(s"${user.identityId} supports the guardian - $attrs - found via $fromWhere", customFields("supporter"))
-                onSuccessSupporter(attrs)
-              case None if sendAttributesIfNotFound =>
-                val attr = addOneOffAndMobile(Attributes(user.identityId), latestOneOffDate, latestMobileSubscription)
-                log.logger.info(s"${user.identityId} does not have zuora attributes - $attr - found via $fromWhere")
-                Ok(Json.toJson(attr))
-              case _ =>
-                onNotFound
+                  onSuccessMember(attrs).withHeaders(
+                    "X-Gu-Membership-Tier" -> tier,
+                    "X-Gu-Membership-Is-Paid-Tier" -> attrs.isPaidTier.toString,
+                  )
+                case Some(attrs) =>
+                  attrs.DigitalSubscriptionExpiryDate.foreach { date =>
+                    logInfoWithCustomFields(s"${user.identityId} is a digital subscriber expiring $date", customFields("digital-subscriber"))
+                  }
+                  attrs.PaperSubscriptionExpiryDate.foreach { date =>
+                    logInfoWithCustomFields(s"${user.identityId} is a paper subscriber expiring $date", customFields("paper-subscriber"))
+                  }
+                  attrs.GuardianWeeklySubscriptionExpiryDate.foreach { date =>
+                    logInfoWithCustomFields(
+                      s"${user.identityId} is a Guardian Weekly subscriber expiring $date",
+                      customFields("guardian-weekly-subscriber"),
+                    )
+                  }
+                  attrs.GuardianPatronExpiryDate.foreach { date =>
+                    logInfoWithCustomFields(s"${user.identityId} is a Guardian Patron expiring $date", customFields("guardian-patron"))
+                  }
+                  attrs.RecurringContributionPaymentPlan.foreach { paymentPlan =>
+                    logInfoWithCustomFields(s"${user.identityId} is a regular $paymentPlan contributor", customFields("contributor"))
+                  }
+                  logInfoWithCustomFields(s"${user.identityId} supports the guardian - $attrs - found via $fromWhere", customFields("supporter"))
+                  onSuccessSupporter(attrs)
+                case None if sendAttributesIfNotFound =>
+                  val attr = addOneOffAndMobile(Attributes(user.identityId), latestOneOffDate, latestMobileSubscription)
+                  log.logger.info(s"${user.identityId} does not have zuora attributes - $attr - found via $fromWhere")
+                  Ok(Json.toJson(attr))
+                case _ =>
+                  onNotFound
+              }
+              addGuIdentityHeaders.fromUser(result, user)
+            }).recover { case e =>
+              // This branch indicates a serious error to be investigated ASAP, because it likely means we could not
+              // serve from either Zuora or DynamoDB cache. Likely multi-system outage in progress or logic error.
+              val errMsg = s"Failed to serve entitlements either from cache or directly. Urgently notify Retention team: $e"
+              metrics.increaseCount(s"$endpointDescription-failed-to-serve-entitlements")
+              log.error(errMsg, e)
+              InternalServerError(errMsg)
             }
-            addGuIdentityHeaders.fromUser(result, user)
 
-          }).recover { case e =>
-            // This branch indicates a serious error to be investigated ASAP, because it likely means we could not
-            // serve from either Zuora or DynamoDB cache. Likely multi-system outage in progress or logic error.
-            val errMsg = s"Failed to serve entitlements either from cache or directly. Urgently notify Retention team: $e"
-            metrics.put(s"$endpointDescription-failed-to-serve-entitlements", 1)
-            log.error(errMsg, e)
-            InternalServerError(errMsg)
-          }
+          case Left(AuthenticationFailure.Unauthorised) =>
+            metrics.increaseCount(s"$endpointDescription-cookie-auth-failed")
+            Future(unauthorized)
 
-        case Left(AuthenticationFailure.Unauthorised) =>
-          metrics.put(s"$endpointDescription-cookie-auth-failed", 1)
-          Future(unauthorized)
-
-        case Left(AuthenticationFailure.Forbidden) =>
-          metrics.put(s"$endpointDescription-cookie-auth-failed", 1)
-          Future(forbidden)
-      })
+          case Left(AuthenticationFailure.Forbidden) =>
+            metrics.increaseCount(s"$endpointDescription-cookie-auth-failed")
+            Future(forbidden)
+        }
+      }
+      if (useExpensiveMetrics) {
+        expensiveMetrics.increaseCount(metricName)
+        future
+      } else {
+        metrics.measureDuration(metricName)(future)
+      }
     }
   }
 
@@ -219,6 +228,7 @@ class AttributeController(
       sendAttributesIfNotFound = true,
       requiredScopes = List(readSelf),
       metricName = "GET /user-attributes/me",
+      useExpensiveMetrics = true,
     )
 
   def features =

--- a/membership-attribute-service/app/monitoring/BatchedMetrics.scala
+++ b/membership-attribute-service/app/monitoring/BatchedMetrics.scala
@@ -2,7 +2,6 @@ package monitoring
 
 import akka.actor.ActorSystem
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsync
-import com.typesafe.scalalogging.LazyLogging
 import configuration.ApplicationName
 
 import java.util.concurrent.ConcurrentHashMap
@@ -11,28 +10,28 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
 // Designed for high-frequency metrics, for example, 1000 per minute is about $400 per month
-final class ExpensiveMetrics(
+final class BatchedMetrics(
     val service: String,
     val stage: String,
     val cloudwatch: AmazonCloudWatchAsync,
 )(implicit system: ActorSystem, ec: ExecutionContext)
     extends CloudWatch {
   import scala.jdk.CollectionConverters._
-  private val chm = new ConcurrentHashMap[String, AtomicInteger]().asScala // keep it first in the constructor
+  private val countMap = new ConcurrentHashMap[String, AtomicInteger]().asScala // keep it first in the constructor
 
   val application = ApplicationName.applicationName
 
   system.scheduler.scheduleAtFixedRate(5.seconds, 60.seconds)(() => publishAllMetrics())
 
-  def countRequest(key: String): Unit =
-    chm.getOrElseUpdate(key, new AtomicInteger(1)).incrementAndGet()
+  def increaseCount(metricName: String): Unit =
+    countMap.getOrElseUpdate(metricName, new AtomicInteger(1)).incrementAndGet()
 
   private def resetCount(key: String): Unit =
-    chm.getOrElseUpdate(key, new AtomicInteger(0)).set(0)
+    countMap.getOrElseUpdate(key, new AtomicInteger(0)).set(0)
 
   private def publishAllMetrics(): Unit =
-    chm foreach { case (key, value) =>
-      put(key, value.doubleValue())
+    countMap.foreach { case (key, value) =>
+      put(key, value.doubleValue(), "count")
       resetCount(key)
     }
 }

--- a/membership-attribute-service/app/monitoring/CloudWatch.scala
+++ b/membership-attribute-service/app/monitoring/CloudWatch.scala
@@ -1,15 +1,9 @@
 package monitoring
 
-import akka.actor.ActorSystem
 import com.amazonaws.handlers.AsyncHandler
-import com.amazonaws.regions.Regions.EU_WEST_1
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsync
 import com.amazonaws.services.cloudwatch.model.{Dimension, MetricDatum, PutMetricDataRequest, PutMetricDataResult}
-import com.amazonaws.services.cloudwatch.{AmazonCloudWatchAsync, AmazonCloudWatchAsyncClient}
-import com.gu.aws.CredentialsProvider
 import com.typesafe.scalalogging.StrictLogging
-import configuration.Stage
-
-import scala.concurrent.{ExecutionContext, Future}
 
 trait CloudWatch extends StrictLogging {
   val stage: String
@@ -20,63 +14,28 @@ trait CloudWatch extends StrictLogging {
   lazy val servicesDimension = new Dimension().withName("Services").withValue(service)
   def mandatoryDimensions: Seq[Dimension] = Seq(stageDimension, servicesDimension)
 
-  trait LoggingAsyncHandler extends AsyncHandler[PutMetricDataRequest, PutMetricDataResult] {
-    def onError(exception: Exception) {
-      logger.info(s"CloudWatch PutMetricDataRequest error: ${exception.getMessage}}")
-    }
-    def onSuccess(request: PutMetricDataRequest, result: PutMetricDataResult) {
-      logger.debug("CloudWatch PutMetricDataRequest - success")
-      CloudWatchHealth.hasPushedMetricSuccessfully = true
-    }
-  }
+  val loggingAsyncHandler = new LoggingAsyncHandler()
 
-  object LoggingAsyncHandler extends LoggingAsyncHandler
-
-  def put(name: String, count: Double, extraDimensions: Dimension*): java.util.concurrent.Future[PutMetricDataResult] = {
+  protected def put(name: String, count: Double, unit: String): Unit = {
     val metric =
       new MetricDatum()
         .withValue(count)
         .withMetricName(name)
-        .withUnit("Count")
-        .withDimensions((mandatoryDimensions ++ extraDimensions): _*)
+        .withUnit(unit)
+        .withDimensions(mandatoryDimensions: _*)
 
     val request = new PutMetricDataRequest().withNamespace(application).withMetricData(metric)
 
-    cloudwatch.putMetricDataAsync(request, LoggingAsyncHandler)
-  }
-
-  def put(name: String, count: Double, responseMethod: String) {
-    put(name, count, new Dimension().withName("ResponseMethod").withValue(responseMethod))
-  }
-
-  def measureDuration[T](metricName: String)(block: => Future[T])(implicit ec: ExecutionContext): Future[T] = {
-    logger.debug(s"$metricName started...")
-    put(metricName + " count", 1)
-    val startTime = System.currentTimeMillis()
-
-    def recordEnd[A](name: String)(value: A): A = {
-      val duration = System.currentTimeMillis() - startTime
-      put(name + " duration ms", duration)
-      logger.debug(s"${service} $name completed in $duration ms")
-
-      value
-    }
-
-    block.transform(recordEnd(metricName), recordEnd(s"$metricName failed"))
+    cloudwatch.putMetricDataAsync(request, loggingAsyncHandler)
   }
 }
 
-class CreateMetrics(stage: Stage) {
-  val cloudwatch: AmazonCloudWatchAsync = AmazonCloudWatchAsyncClient.asyncBuilder
-    .withCredentials(CredentialsProvider)
-    .withRegion(EU_WEST_1)
-    .build()
+class LoggingAsyncHandler extends AsyncHandler[PutMetricDataRequest, PutMetricDataResult] with StrictLogging {
+  def onError(exception: Exception) {
+    logger.info(s"CloudWatch PutMetricDataRequest error: ${exception.getMessage}}")
+  }
 
-  def forService(service: Class[_]): Metrics = Metrics(service.getSimpleName, stage.value, cloudwatch)
-  def expensiveForService(service: Class[_])(implicit system: ActorSystem, ec: ExecutionContext): ExpensiveMetrics =
-    new ExpensiveMetrics(service.getSimpleName, stage.value, cloudwatch)
-}
-
-object CloudWatchHealth {
-  var hasPushedMetricSuccessfully = false
+  def onSuccess(request: PutMetricDataRequest, result: PutMetricDataResult) {
+    logger.trace("CloudWatch PutMetricDataRequest - success")
+  }
 }

--- a/membership-attribute-service/app/monitoring/CreateMetrics.scala
+++ b/membership-attribute-service/app/monitoring/CreateMetrics.scala
@@ -1,0 +1,21 @@
+package monitoring
+
+import akka.actor.ActorSystem
+import com.amazonaws.regions.Regions.EU_WEST_1
+import com.amazonaws.services.cloudwatch.{AmazonCloudWatchAsync, AmazonCloudWatchAsyncClient}
+import com.gu.aws.CredentialsProvider
+import configuration.Stage
+
+import scala.concurrent.ExecutionContext
+
+class CreateMetrics(stage: Stage) {
+  val cloudwatch: AmazonCloudWatchAsync = AmazonCloudWatchAsyncClient.asyncBuilder
+    .withCredentials(CredentialsProvider)
+    .withRegion(EU_WEST_1)
+    .build()
+
+  def forService(service: Class[_]): Metrics = Metrics(service.getSimpleName, stage.value, cloudwatch)
+
+  def batchedForService(service: Class[_])(implicit system: ActorSystem, ec: ExecutionContext): BatchedMetrics =
+    new BatchedMetrics(service.getSimpleName, stage.value, cloudwatch)
+}

--- a/membership-attribute-service/app/monitoring/Metrics.scala
+++ b/membership-attribute-service/app/monitoring/Metrics.scala
@@ -3,6 +3,28 @@ package monitoring
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsync
 import configuration.ApplicationName
 
+import scala.concurrent.{ExecutionContext, Future}
+
 case class Metrics(service: String, stage: String, cloudwatch: AmazonCloudWatchAsync) extends CloudWatch {
   val application = ApplicationName.applicationName // This sets the namespace for Custom Metrics in AWS (see CloudWatch)
+
+  def increaseCount(metricName: String): Unit = put(metricName + " count", 1, "count")
+
+  def reportDuration(metricName: String, duration: Long): Unit = put(metricName + " duration ms", duration, "ms")
+
+  def measureDuration[T](metricName: String)(block: => Future[T])(implicit ec: ExecutionContext): Future[T] = {
+    logger.debug(s"$metricName started...")
+    increaseCount(metricName)
+    val startTime = System.currentTimeMillis()
+
+    def recordEnd[A](metricName: String)(value: A): A = {
+      val duration = System.currentTimeMillis() - startTime
+      reportDuration(metricName, duration)
+      logger.debug(s"${service} $metricName completed in $duration ms")
+
+      value
+    }
+
+    block.transform(recordEnd(metricName), recordEnd(s"$metricName failed"))
+  }
 }

--- a/membership-attribute-service/app/services/DynamoSupporterProductDataService.scala
+++ b/membership-attribute-service/app/services/DynamoSupporterProductDataService.scala
@@ -74,7 +74,7 @@ class DynamoSupporterProductDataService(
   private def alertOnDynamoReadErrors(identityId: String, errors: List[DynamoReadError]) =
     if (errors.nonEmpty) {
       logger.error(errorMessage(identityId, errors))
-      metrics.put("SupporterProductDataDynamoError", 1) // referenced in CloudFormation
+      metrics.increaseCount("SupporterProductDataDynamoError") // referenced in CloudFormation
     }
 }
 


### PR DESCRIPTION
Using ExpensiveMetrics for AttributeConttroller.attributes endpoint (to save on AWS metrics cost).

Metrics refactored - put method made private, replaced by increaseCount and reportDuration.