### PR TITLE
Adding call duration metrics to ContactRepository methods

### DIFF
--- a/membership-attribute-service/app/actions/CommonActions.scala
+++ b/membership-attribute-service/app/actions/CommonActions.scala
@@ -26,7 +26,10 @@ class CommonActions(touchpointBackends: TouchpointBackends, bodyParser: BodyPars
   def AuthorizeForScopes(requiredScopes: List[AccessScope]): ActionBuilder[AuthenticatedUserAndBackendRequest, AnyContent] =
     NoCacheAction andThen new AuthAndBackendViaAuthLibAction(touchpointBackends, requiredScopes, isTestUser)
 
-  def AuthorizeForRecentLogin(howToHandleRecencyOfSignedIn: HowToHandleRecencyOfSignedIn, requiredScopes: List[AccessScope]): ActionBuilder[AuthAndBackendRequest, AnyContent] =
+  def AuthorizeForRecentLogin(
+      howToHandleRecencyOfSignedIn: HowToHandleRecencyOfSignedIn,
+      requiredScopes: List[AccessScope],
+  ): ActionBuilder[AuthAndBackendRequest, AnyContent] =
     NoCacheAction andThen new AuthAndBackendViaIdapiAction(touchpointBackends, howToHandleRecencyOfSignedIn, isTestUser, requiredScopes)
 
   // TODO: Is this redundant, given that authoriseForRecentLogin checks for recency and scopes?

--- a/membership-attribute-service/app/components/TouchpointBackends.scala
+++ b/membership-attribute-service/app/components/TouchpointBackends.scala
@@ -2,12 +2,12 @@ package components
 
 import akka.actor.ActorSystem
 import com.gu.memsub.subsv2.services.{CatalogService, SubscriptionService}
-import com.gu.salesforce.SimpleContactRepository
 import com.gu.zuora.ZuoraSoapService
 import com.gu.zuora.rest.ZuoraRestService
 import com.typesafe.config.Config
 import configuration.Stage
 import monitoring.CreateMetrics
+import services.salesforce.ContactRepository
 import services.{BasicStripeService, HealthCheckableService, SupporterProductDataService}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -17,7 +17,7 @@ class TouchpointBackends(
     config: Config,
     createMetrics: CreateMetrics,
     supporterProductDataServiceOverride: Option[SupporterProductDataService] = None,
-    contactRepositoryOverride: Option[SimpleContactRepository] = None,
+    contactRepositoryOverride: Option[ContactRepository] = None,
     subscriptionServiceOverride: Option[SubscriptionService[Future]] = None,
     zuoraRestServiceOverride: Option[ZuoraRestService[Future]] = None,
     catalogServiceOverride: Option[CatalogService[Future]] = None,

--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -81,7 +81,7 @@ class TouchpointComponents(
   private lazy val salesforce = CreateScalaforce(tpConfig.salesforce, system.scheduler, configuration.ApplicationName.applicationName)
   private lazy val simpleContactRepository = new SimpleContactRepository(salesforce)
   private lazy val contactRepositoryWithMetrics = new ContactRepositoryWithMetrics(simpleContactRepository, createMetrics)
-  lazy val contactRepo: ContactRepository =
+  lazy val contactRepository: ContactRepository =
     contactRepositoryOverride.getOrElse(contactRepositoryWithMetrics)
   lazy val salesforceService: SalesforceService = new SalesforceService(salesforce)
 
@@ -167,7 +167,7 @@ class TouchpointComponents(
     new AccountDetailsFromZuora(
       createMetrics,
       zuoraRestService,
-      contactRepo,
+      contactRepository,
       subService,
       chooseStripeService,
       paymentDetailsForSubscription,

--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -134,7 +134,7 @@ class AccountController(
           identityId <- EitherT.right(identityId)
           cancellationReason <- EitherT.fromEither(handleInputBody(cancelForm))
           sfContact <- EitherT
-            .fromEither(tp.contactRepo.get(identityId).map(_.toEither.flatMap(_.toRight(s"No Salesforce user: $identityId"))))
+            .fromEither(tp.contactRepository.get(identityId).map(_.toEither.flatMap(_.toRight(s"No Salesforce user: $identityId"))))
             .leftMap(CancelError(_, 404))
           sfSub <- EitherT
             .fromEither(
@@ -200,7 +200,7 @@ class AccountController(
         logger.info(s"Deprecated function called: Attempting to retrieve payment details for identity user: ${userId.mkString}")
         (for {
           user <- OptionTEither.some(userId)
-          contact <- OptionTEither(tp.contactRepo.get(user))
+          contact <- OptionTEither(tp.contactRepository.get(user))
           freeOrPaidSub <- OptionTEither(
             tp.subService
               .either[F, P](contact)
@@ -306,7 +306,7 @@ class AccountController(
         request.redirectAdvice.userId match {
           case Some(identityId) =>
             (for {
-              contact <- OptionT(EitherT(tp.contactRepo.get(identityId)))
+              contact <- OptionT(EitherT(tp.contactRepository.get(identityId)))
               subs <- OptionT(EitherT(tp.subService.recentlyCancelled(contact)).map(Option(_)))
             } yield {
               Ok(Json.toJson(subs.map(CancelledSubscription(_))))
@@ -330,7 +330,7 @@ class AccountController(
         (for {
           newPrice <- SimpleEitherT.fromEither(validateContributionAmountUpdateForm)
           user <- SimpleEitherT.right(userId)
-          sfUser <- SimpleEitherT.fromFutureOption(tp.contactRepo.get(user), s"No SF user $user")
+          sfUser <- SimpleEitherT.fromFutureOption(tp.contactRepository.get(user), s"No SF user $user")
           subscription <- EitherT.fromEither(
             tp.subService
               .current[SubscriptionPlan.Contributor](sfUser)

--- a/membership-attribute-service/app/controllers/ContactController.scala
+++ b/membership-attribute-service/app/controllers/ContactController.scala
@@ -38,8 +38,8 @@ class ContactController(
               case Left(parsingFailure) => Future.successful(BadRequest(parsingFailure.getMessage))
               case Right(None) => Future.successful(BadRequest(s"Not json: ${request.body}"))
               case Right(Some(address)) =>
-                val contactRepo = request.touchpoint.contactRepo
-                update(contactRepo, contactId, address) map { _ =>
+                val contactRepository = request.touchpoint.contactRepository
+                update(contactRepository, contactId, address) map { _ =>
                   NoContent
                 } recover { case updateFailure =>
                   BadGateway(updateFailure.getMessage)
@@ -59,10 +59,10 @@ class ContactController(
       request: AuthAndBackendRequest[AnyContent],
       contactId: String,
   ): Future[Boolean] = {
-    val contactRepo = request.touchpoint.contactRepo
+    val contactRepository = request.touchpoint.contactRepository
     request.redirectAdvice.userId match {
       case Some(userId) =>
-        contactRepo.get(userId).map(_.toEither).map {
+        contactRepository.get(userId).map(_.toEither).map {
           case Right(Some(contact)) => contact.salesforceContactId == contactId
           case _ => false
         }
@@ -71,7 +71,7 @@ class ContactController(
   }
 
   private def update(
-      contactRepo: ContactRepository,
+      contactRepository: ContactRepository,
       contactId: String,
       address: DeliveryAddress,
   ): Future[Unit] = {
@@ -90,6 +90,6 @@ class ContactController(
         contactField("Delivery_Information__c", address.instructions) ++
         contactField("Address_Change_Information_Last_Quoted__c", address.addressChangeInformation)
     }
-    contactRepo.update(contactId, contactFields)
+    contactRepository.update(contactId, contactFields)
   }
 }

--- a/membership-attribute-service/app/controllers/ContactController.scala
+++ b/membership-attribute-service/app/controllers/ContactController.scala
@@ -1,12 +1,12 @@
 package controllers
 
 import actions.{AuthAndBackendRequest, CommonActions, Return401IfNotSignedInRecently}
-import com.gu.salesforce.{SFContactId, SimpleContactRepository}
 import com.typesafe.scalalogging.LazyLogging
 import models.AccessScope.updateSelf
 import models.DeliveryAddress
 import monitoring.CreateMetrics
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
+import services.salesforce.ContactRepository
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.Exception
@@ -71,7 +71,7 @@ class ContactController(
   }
 
   private def update(
-      contactRepo: SimpleContactRepository,
+      contactRepo: ContactRepository,
       contactId: String,
       address: DeliveryAddress,
   ): Future[Unit] = {
@@ -90,6 +90,6 @@ class ContactController(
         contactField("Delivery_Information__c", address.instructions) ++
         contactField("Address_Change_Information_Last_Quoted__c", address.addressChangeInformation)
     }
-    contactRepo.salesforce.Contact.update(SFContactId(contactId), contactFields)
+    contactRepo.update(contactId, contactFields)
   }
 }

--- a/membership-attribute-service/app/controllers/ExistingPaymentOptionsController.scala
+++ b/membership-attribute-service/app/controllers/ExistingPaymentOptionsController.scala
@@ -23,6 +23,7 @@ import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 import scalaz.-\/
 import scalaz.std.scalaFuture._
 import scalaz.syntax.monadPlus._
+import services.salesforce.ContactRepository
 import utils.ListTEither
 import utils.SimpleEitherT.SimpleEitherT
 
@@ -41,7 +42,7 @@ class ExistingPaymentOptionsController(
   def allSubscriptionsSince(
       date: LocalDate,
       maybeUserId: Option[String],
-      contactRepo: SimpleContactRepository,
+      contactRepo: ContactRepository,
       subService: SubscriptionService[Future],
   ): SimpleEitherT[Map[AccountId, List[Subscription[SubscriptionPlan.AnyPlan]]]] =
     (for {

--- a/membership-attribute-service/app/controllers/PaymentUpdateController.scala
+++ b/membership-attribute-service/app/controllers/PaymentUpdateController.scala
@@ -49,7 +49,7 @@ class PaymentUpdateController(commonActions: CommonActions, override val control
             Future.successful(updateForm.orElse(legacyForm).toRight("no 'stripePaymentMethodID' and 'stripePublicKey' submitted with request")),
           )
           (stripeCardIdentifier, stripePublicKey) = stripeDetails
-          sfUser <- EitherT.fromEither(tp.contactRepo.get(user).map(_.toEither).map(_.flatMap(_.toRight(s"no SF user $user"))))
+          sfUser <- EitherT.fromEither(tp.contactRepository.get(user).map(_.toEither).map(_.flatMap(_.toRight(s"no SF user $user"))))
           subscription <- EitherT.fromEither(
             tp.subService
               .current[SubscriptionPlan.AnyPlan](sfUser)
@@ -132,7 +132,7 @@ class PaymentUpdateController(commonActions: CommonActions, override val control
             Future.successful(updateForm.bindFromRequest().value.toRight("no direct debit details submitted with request")),
           )
           (bankAccountName, bankAccountNumber, bankSortCode) = directDebitDetails
-          sfUser <- EitherT.fromEither(tp.contactRepo.get(user).map(_.toEither.flatMap(_.toRight(s"no SF user $user"))))
+          sfUser <- EitherT.fromEither(tp.contactRepository.get(user).map(_.toEither.flatMap(_.toRight(s"no SF user $user"))))
           subscription <- EitherT.fromEither(
             tp.subService
               .current[SubscriptionPlan.AnyPlan](sfUser)

--- a/membership-attribute-service/app/monitoring/Metrics.scala
+++ b/membership-attribute-service/app/monitoring/Metrics.scala
@@ -3,6 +3,8 @@ package monitoring
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsync
 import com.amazonaws.services.cloudwatch.model.StandardUnit
 import configuration.ApplicationName
+import utils.SimpleEitherT
+import utils.SimpleEitherT.SimpleEitherT
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -10,6 +12,9 @@ case class Metrics(service: String, stage: String, cloudwatch: AmazonCloudWatchA
   val application = ApplicationName.applicationName // This sets the namespace for Custom Metrics in AWS (see CloudWatch)
 
   def incrementCount(metricName: String): Unit = put(metricName + " count", 1, StandardUnit.Count)
+
+  def measureDurationEither[T](metricName: String)(block: => SimpleEitherT[T])(implicit ec: ExecutionContext): SimpleEitherT[T] =
+    SimpleEitherT(measureDuration(metricName)(block.run))
 
   def measureDuration[T](metricName: String)(block: => Future[T])(implicit ec: ExecutionContext): Future[T] = {
     logger.debug(s"$metricName started...")

--- a/membership-attribute-service/app/services/AccountDetailsFromZuora.scala
+++ b/membership-attribute-service/app/services/AccountDetailsFromZuora.scala
@@ -5,7 +5,7 @@ import com.gu.memsub.Subscription.Name
 import com.gu.memsub.subsv2.SubscriptionPlan.AnyPlan
 import com.gu.memsub.subsv2.services.SubscriptionService
 import com.gu.memsub.subsv2.{Subscription, SubscriptionPlan}
-import com.gu.salesforce.{Contact, SimpleContactRepository}
+import com.gu.salesforce.Contact
 import com.gu.services.model.PaymentDetails
 import com.gu.zuora.rest.ZuoraRestService
 import com.gu.zuora.rest.ZuoraRestService.PaymentMethodId
@@ -13,9 +13,11 @@ import controllers.AccountController
 import controllers.AccountHelpers.{FilterByProductType, FilterBySubName, NoFilter, OptionalSubscriptionsFilter}
 import models.{AccountDetails, ContactAndSubscription, DeliveryAddress}
 import monitoring.CreateMetrics
+import scalaz.ListT
 import scalaz.std.scalaFuture._
 import services.DifferentiateSubscription.differentiateSubscription
 import services.PaymentFailureAlerter.{accountHasMissedPayments, alertText, safeToAllowPaymentUpdate}
+import services.salesforce.ContactRepository
 import utils.ListTEither.ListTEither
 import utils.SimpleEitherT.SimpleEitherT
 import utils.{ListTEither, SimpleEitherT}
@@ -25,7 +27,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class AccountDetailsFromZuora(
     createMetrics: CreateMetrics,
     zuoraRestService: ZuoraRestService[Future],
-    contactRepository: SimpleContactRepository,
+    contactRepository: ContactRepository,
     subscriptionService: SubscriptionService[Future],
     chooseStripeService: ChooseStripeService,
     paymentDetailsForSubscription: PaymentDetailsForSubscription,
@@ -33,46 +35,53 @@ class AccountDetailsFromZuora(
   private val metrics = createMetrics.forService(classOf[AccountController])
 
   def fetch(userId: String, filter: OptionalSubscriptionsFilter): SimpleEitherT[List[AccountDetails]] = {
-    SimpleEitherT(metrics.measureDuration("accountDetailsFromZuora") {
-      (for {
-        contactAndSubscription <- allCurrentSubscriptions(userId, filter)
-        freeOrPaidSub = differentiateSubscription(contactAndSubscription)
-        detailsResultsTriple <- ListTEither.single(getAccountDetailsParallel(contactAndSubscription))
-        (paymentDetails, accountSummary, effectiveCancellationDate) = detailsResultsTriple
-        country = accountSummary.billToContact.country
-        stripePublicKey = chooseStripeService.forCountry(country).publicKey
-        alertText <- ListTEither.singleRightT(alertText(accountSummary, contactAndSubscription.subscription, getPaymentMethod))
-        isAutoRenew = contactAndSubscription.subscription.autoRenew
-      } yield AccountDetails(
-        contactId = contactAndSubscription.contact.salesforceContactId,
-        regNumber = None,
-        email = accountSummary.billToContact.email,
-        deliveryAddress = Some(DeliveryAddress.fromContact(contactAndSubscription.contact)),
-        subscription = contactAndSubscription.subscription,
-        paymentDetails = paymentDetails,
-        billingCountry = accountSummary.billToContact.country,
-        stripePublicKey = stripePublicKey,
-        accountHasMissedRecentPayments = freeOrPaidSub.isRight &&
-          accountHasMissedPayments(contactAndSubscription.subscription.accountId, accountSummary.invoices, accountSummary.payments),
-        safeToUpdatePaymentMethod = safeToAllowPaymentUpdate(contactAndSubscription.subscription.accountId, accountSummary.invoices),
-        isAutoRenew = isAutoRenew,
-        alertText = alertText,
-        accountId = accountSummary.id.get,
-        effectiveCancellationDate,
-      )).toList.run
-    })
+    metrics.measureDurationEither("accountDetailsFromZuora") {
+      SimpleEitherT.fromListT(accountDetailsFromZuoraFor(userId, filter))
+    }
   }
 
-  def getPaymentMethod(id: PaymentMethodId): Future[Either[String, ZuoraRestService.PaymentMethodResponse]] =
+  private def accountDetailsFromZuoraFor(userId: String, filter: OptionalSubscriptionsFilter): ListT[SimpleEitherT, AccountDetails] = {
+    for {
+      contactAndSubscription <- allCurrentSubscriptions(userId, filter)
+      freeOrPaidSub = differentiateSubscription(contactAndSubscription)
+      detailsResultsTriple <- ListTEither.single(getAccountDetailsParallel(contactAndSubscription))
+      (paymentDetails, accountSummary, effectiveCancellationDate) = detailsResultsTriple
+      country = accountSummary.billToContact.country
+      stripePublicKey = chooseStripeService.forCountry(country).publicKey
+      alertText <- ListTEither.singleRightT(alertText(accountSummary, contactAndSubscription.subscription, getPaymentMethod))
+      isAutoRenew = contactAndSubscription.subscription.autoRenew
+    } yield AccountDetails(
+      contactId = contactAndSubscription.contact.salesforceContactId,
+      regNumber = None,
+      email = accountSummary.billToContact.email,
+      deliveryAddress = Some(DeliveryAddress.fromContact(contactAndSubscription.contact)),
+      subscription = contactAndSubscription.subscription,
+      paymentDetails = paymentDetails,
+      billingCountry = accountSummary.billToContact.country,
+      stripePublicKey = stripePublicKey,
+      accountHasMissedRecentPayments = freeOrPaidSub.isRight &&
+        accountHasMissedPayments(contactAndSubscription.subscription.accountId, accountSummary.invoices, accountSummary.payments),
+      safeToUpdatePaymentMethod = safeToAllowPaymentUpdate(contactAndSubscription.subscription.accountId, accountSummary.invoices),
+      isAutoRenew = isAutoRenew,
+      alertText = alertText,
+      accountId = accountSummary.id.get,
+      effectiveCancellationDate,
+    )
+  }
+
+  private def getPaymentMethod(id: PaymentMethodId): Future[Either[String, ZuoraRestService.PaymentMethodResponse]] =
     zuoraRestService.getPaymentMethod(id.get).map(_.toEither)
 
-  def nonGiftContactAndSubscriptionsFor(contact: Contact): Future[List[ContactAndSubscription]] = {
+  private def nonGiftContactAndSubscriptionsFor(contact: Contact): Future[List[ContactAndSubscription]] = {
     subscriptionService
       .current[SubscriptionPlan.AnyPlan](contact)
       .map(_.map(ContactAndSubscription(contact, _, isGiftRedemption = false)))
   }
 
-  def applyFilter(filter: OptionalSubscriptionsFilter, contactAndSubscriptions: List[ContactAndSubscription]): List[ContactAndSubscription] = {
+  private def applyFilter(
+      filter: OptionalSubscriptionsFilter,
+      contactAndSubscriptions: List[ContactAndSubscription],
+  ): List[ContactAndSubscription] = {
     filter match {
       case FilterBySubName(subscriptionName) =>
         contactAndSubscriptions.find(_.subscription.name == subscriptionName).toList
@@ -88,7 +97,7 @@ class AccountDetailsFromZuora(
     }
   }
 
-  def subscriptionsFor(userId: String, contact: Contact, filter: OptionalSubscriptionsFilter): SimpleEitherT[List[ContactAndSubscription]] = {
+  private def subscriptionsFor(userId: String, contact: Contact, filter: OptionalSubscriptionsFilter): SimpleEitherT[List[ContactAndSubscription]] = {
     for {
       nonGiftContactAndSubscriptions <- SimpleEitherT.rightT(nonGiftContactAndSubscriptionsFor(contact))
       contactAndSubscriptions <- checkForGiftSubscription(userId, nonGiftContactAndSubscriptions, contact)

--- a/membership-attribute-service/app/services/SalesforceService.scala
+++ b/membership-attribute-service/app/services/SalesforceService.scala
@@ -1,7 +1,7 @@
 package services
 
-import com.gu.salesforce.ContactRepository
+import com.gu.salesforce.Scalaforce
 
-class SalesforceService(contactRepository: ContactRepository) extends HealthCheckableService {
-  override def checkHealth: Boolean = contactRepository.salesforce.isAuthenticated
+class SalesforceService(salesforce: Scalaforce) extends HealthCheckableService {
+  override def checkHealth: Boolean = salesforce.isAuthenticated
 }

--- a/membership-attribute-service/app/services/salesforce/ContactRepository.scala
+++ b/membership-attribute-service/app/services/salesforce/ContactRepository.scala
@@ -1,0 +1,21 @@
+package services.salesforce
+
+import com.gu.salesforce.{Contact, ContactId}
+import play.api.libs.json._
+import scalaz.\/
+
+import scala.concurrent.Future
+
+trait ContactRepository {
+  def upsert(userId: Option[String], values: JsObject): Future[ContactId]
+
+  def updateIdentityId(contact: ContactId, newIdentityId: String): Future[Throwable \/ Unit]
+
+  def get(identityId: String): Future[String \/ Option[Contact]]
+
+  def getByContactId(contactId: String): Future[\/[String, Contact]]
+
+  def getByAccountId(accountId: String): Future[String \/ Contact]
+
+  def update(contactId: String, contactFields: Map[String, String]): Future[Unit]
+}

--- a/membership-attribute-service/app/services/salesforce/ContactRepositoryWithMetrics.scala
+++ b/membership-attribute-service/app/services/salesforce/ContactRepositoryWithMetrics.scala
@@ -1,0 +1,32 @@
+package services.salesforce
+
+import com.gu.salesforce.{Contact, ContactId}
+import monitoring.CreateMetrics
+import play.api.libs.json.JsObject
+import scalaz.\/
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class ContactRepositoryWithMetrics(private val wrapped: ContactRepository, private val createMetrics: CreateMetrics)(implicit
+    val executionContext: ExecutionContext,
+) extends ContactRepository {
+  lazy val metrics = createMetrics.forService(wrapped.getClass)
+
+  override def upsert(userId: Option[String], values: JsObject): Future[ContactId] =
+    metrics.measureDuration("upsert")(wrapped.upsert(userId, values))
+
+  override def updateIdentityId(contact: ContactId, newIdentityId: String): Future[Throwable \/ Unit] =
+    metrics.measureDuration("updateIdentityId")(wrapped.updateIdentityId(contact, newIdentityId))
+
+  override def get(identityId: String): Future[String \/ Option[Contact]] =
+    metrics.measureDuration("get")(wrapped.get(identityId))
+
+  override def getByContactId(contactId: String): Future[String \/ Contact] =
+    metrics.measureDuration("getByContactId")(wrapped.getByContactId(contactId))
+
+  override def getByAccountId(accountId: String): Future[String \/ Contact] =
+    metrics.measureDuration("getByAccountId")(wrapped.getByAccountId(accountId))
+
+  override def update(contactId: String, contactFields: Map[String, String]): Future[Unit] =
+    metrics.measureDuration("update")(wrapped.update(contactId, contactFields))
+}

--- a/membership-attribute-service/app/services/salesforce/SimpleContactRepository.scala
+++ b/membership-attribute-service/app/services/salesforce/SimpleContactRepository.scala
@@ -1,0 +1,125 @@
+package services.salesforce
+
+import akka.actor.Scheduler
+import com.gu.okhttp.RequestRunners
+import com.gu.salesforce.ContactDeserializer._
+import com.gu.salesforce.{Contact, ContactId, SFContactId, SalesforceConfig, Scalaforce}
+import okhttp3.{Request, Response}
+import play.api.libs.json._
+import scalaz.std.scalaFuture.futureInstance
+import scalaz.{-\/, EitherT, \/, \/-}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class SimpleContactRepository(private val salesforce: Scalaforce)(implicit executionContext: ExecutionContext) extends ContactRepository {
+
+  def upsert(userId: Option[String], values: JsObject): Future[ContactId] = {
+    for {
+      result <- salesforce.Contact.upsert(userId.map(Keys.IDENTITY_ID -> _), values)
+    } yield new ContactId {
+      override def salesforceContactId: String = result.Id
+
+      override def salesforceAccountId: String = result.AccountId
+    }
+  }
+
+  def updateIdentityId(contact: ContactId, newIdentityId: String): Future[Throwable \/ Unit] = {
+    salesforce.Contact
+      .update(SFContactId(contact.salesforceContactId), Keys.IDENTITY_ID, newIdentityId)
+      .map(\/.r[Throwable].apply)
+      .recover { case e: Throwable => \/.l[Unit](e) }
+  }
+
+  import com.gu.memsub.subsv2.reads.Trace.{Traceable => T1}
+  import com.gu.memsub.subsv2.services.Trace.Traceable
+
+  private def toEither[A](j: JsResult[A]): String \/ A = j.fold(
+    { errors =>
+      \/.left[String, A](errors.toString)
+    },
+    \/.right,
+  )
+
+  private def get(key: String, value: String): Future[String \/ Option[Contact]] = {
+    salesforce.Contact.read(key, value).map { failableJsonContact =>
+      (for {
+        resultOpt <- failableJsonContact
+        maybeContact <- resultOpt match {
+          case Some(jsValue) =>
+            toEither(jsValue.validate[Contact].withTrace(s"SF001: Invalid read Contact response from Salesforce for $key $value: $jsValue"))
+              .map[Option[Contact]](Some.apply)
+          case None => \/.r[String](None: Option[Contact])
+        }
+      } yield maybeContact).withTrace(s"SF002: could not get read contact response for $key $value")
+    }
+  }
+
+  def get(identityId: String): Future[String \/ Option[Contact]] = // this returns right of None if the person isn't a member
+    get(Keys.IDENTITY_ID, identityId)
+
+  def getByContactId(contactId: String): Future[\/[String, Contact]] =
+    get(Keys.CONTACT_ID, contactId).map {
+      case \/-(Some(theContact)) => \/-(theContact)
+      case \/-(None) => -\/(s"SF004: contact $contactId not found")
+      case -\/(error) => -\/(s"Error retrieving contact: $contactId. Error: $error")
+    }
+
+  def getByAccountId(accountId: String): Future[String \/ Contact] = {
+    val handler = new GetByAccountIdHandler(accountId)
+    (for {
+      responseJson <- EitherT(salesforce.Query.execute(handler.query))
+      personContactId <- EitherT(Future.successful(handler.responseParser(responseJson)))
+      buyerContact <- EitherT(getByContactId(personContactId.get))
+    } yield buyerContact).run
+  }
+
+  private class GetByAccountIdHandler(accountId: String) {
+
+    case class PersonContactId(get: String)
+
+    case class PersonContactIdResponse(records: List[PersonContactId])
+
+    implicit val PersonContactIdFormatter = new Reads[PersonContactId] {
+      override def reads(json: JsValue) = JsSuccess(
+        PersonContactId(
+          get = (json \ "Person_Contact__c").as[String],
+        ),
+      )
+    }
+
+    implicit val PersonContactIdResponseFormatter = new Reads[PersonContactIdResponse] {
+      override def reads(json: JsValue) = JsSuccess(
+        PersonContactIdResponse(
+          records = (json \ "records").as[List[PersonContactId]],
+        ),
+      )
+    }
+
+    val query = s"SELECT Person_Contact__c FROM Account WHERE Account.Id = '$accountId'"
+
+    def responseParser(responseJson: JsValue): \/[String, PersonContactId] = {
+      responseJson.asOpt[PersonContactIdResponse] match {
+        case Some(personContactIds) =>
+          personContactIds.records.headOption.map(\/.r[String].apply).getOrElse(\/.l[PersonContactId](s"Account: $accountId has no Person Contact."))
+        case None => \/.l[PersonContactId](s"Query: $query returned an invalid response")
+      }
+    }
+  }
+
+  override def update(contactId: String, contactFields: Map[String, String]): Future[Unit] =
+    salesforce.Contact.update(SFContactId(contactId), contactFields)
+}
+
+object CreateScalaforce {
+  def apply(salesforceConfig: SalesforceConfig, scheduler: Scheduler, appName: String)(implicit executionContext: ExecutionContext): Scalaforce = {
+    val salesforce: Scalaforce = new Scalaforce {
+      val application: String = appName
+      val stage: String = salesforceConfig.envName
+      val sfConfig: SalesforceConfig = salesforceConfig
+      val httpClient: (Request) => Future[Response] = RequestRunners.futureRunner
+      val sfScheduler = scheduler
+    }
+    salesforce.startAuth()
+    salesforce
+  }
+}

--- a/membership-attribute-service/app/utils/SimpleEitherT.scala
+++ b/membership-attribute-service/app/utils/SimpleEitherT.scala
@@ -1,9 +1,10 @@
 package utils
 
+import scalaz.std.scalaFuture._
 import scalaz.{EitherT, \/}
+import utils.ListTEither.ListTEither
 
 import scala.concurrent.{ExecutionContext, Future}
-import scalaz.std.scalaFuture._
 
 object SimpleEitherT {
   type SimpleEitherT[A] = EitherT[String, Future, A]
@@ -36,4 +37,5 @@ object SimpleEitherT {
   def fromEither[T](either: Either[String, T])(implicit ec: ExecutionContext): SimpleEitherT[T] =
     apply(Future.successful(either))
 
+  def fromListT[T](value: ListTEither[T])(implicit ec: ExecutionContext): SimpleEitherT[List[T]] = SimpleEitherT(value.toList.run)
 }

--- a/membership-attribute-service/app/wiring/AppLoader.scala
+++ b/membership-attribute-service/app/wiring/AppLoader.scala
@@ -3,7 +3,6 @@ package wiring
 import actions.CommonActions
 import akka.actor.ActorSystem
 import com.gu.memsub.subsv2.services.{CatalogService, SubscriptionService}
-import com.gu.salesforce.SimpleContactRepository
 import com.gu.zuora.ZuoraSoapService
 import com.gu.zuora.rest.ZuoraRestService
 import components.TouchpointBackends
@@ -20,6 +19,7 @@ import play.api.mvc.EssentialFilter
 import play.filters.cors.{CORSConfig, CORSFilter}
 import play.filters.csrf.CSRFComponents
 import router.Routes
+import services.salesforce.ContactRepository
 import services.{
   BasicStripeService,
   ContributionsStoreDatabaseService,
@@ -58,7 +58,7 @@ class MyComponents(context: Context)
   lazy val createMetrics = new CreateMetrics(stage)
 
   lazy val supporterProductDataServiceOverride: Option[SupporterProductDataService] = None
-  lazy val contactRepositoryOverride: Option[SimpleContactRepository] = None
+  lazy val contactRepositoryOverride: Option[ContactRepository] = None
   lazy val subscriptionServiceOverride: Option[SubscriptionService[Future]] = None
   lazy val zuoraRestServiceOverride: Option[ZuoraRestService[Future]] = None
   lazy val catalogServiceOverride: Option[CatalogService[Future]] = None

--- a/membership-attribute-service/test/acceptance/AccountControllerAcceptanceTest.scala
+++ b/membership-attribute-service/test/acceptance/AccountControllerAcceptanceTest.scala
@@ -15,7 +15,6 @@ import com.gu.i18n.Currency
 import com.gu.memsub.subsv2.services.{CatalogService, SubscriptionService}
 import com.gu.memsub.subsv2.{CovariantNonEmptyList, SubscriptionPlan}
 import com.gu.memsub.{Product, Subscription}
-import com.gu.salesforce.SimpleContactRepository
 import com.gu.zuora.ZuoraSoapService
 import com.gu.zuora.rest.ZuoraRestService
 import com.gu.zuora.rest.ZuoraRestService.GiftSubscriptionsFromIdentityIdRecord
@@ -28,6 +27,7 @@ import org.mockserver.model.HttpResponse.response
 import play.api.ApplicationLoader.Context
 import play.api.libs.json.{JsArray, Json}
 import scalaz.\/
+import services.salesforce.ContactRepository
 import services.{
   BasicStripeService,
   ContributionsStoreDatabaseService,
@@ -42,7 +42,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class AccountControllerAcceptanceTest extends AcceptanceTest {
-  var contactRepositoryMock: SimpleContactRepository = _
+  var contactRepositoryMock: ContactRepository = _
   var subscriptionServiceMock: SubscriptionService[Future] = _
   var zuoraRestServiceMock: ZuoraRestService[Future] = _
   var catalogServiceMock: CatalogService[Future] = _
@@ -52,7 +52,7 @@ class AccountControllerAcceptanceTest extends AcceptanceTest {
   var patronsStripeServiceMock: BasicStripeService = _
 
   override protected def before: Unit = {
-    contactRepositoryMock = mock[SimpleContactRepository]
+    contactRepositoryMock = mock[ContactRepository]
     subscriptionServiceMock = mock[SubscriptionService[Future]]
     zuoraRestServiceMock = mock[ZuoraRestService[Future]]
     catalogServiceMock = mock[CatalogService[Future]]


### PR DESCRIPTION
Adding call duration metrics to ContactRepository method calls so we can identify and possibly optimize slow ones.

Bringing in ContactRepository from membership-common.
A wrapper for ContacyRepository created that adds call duration metrics.

ContactRepository is now a trait.
SimpleContactRepository its implementation.
ContactRepositoryWithMetrics wraps ContactRepository and adds call duration metrics.