### PR TITLE
Call duration metrics for SubscriptionService

### DIFF
--- a/membership-attribute-service/app/components/TouchpointBackends.scala
+++ b/membership-attribute-service/app/components/TouchpointBackends.scala
@@ -1,13 +1,14 @@
 package components
 
 import akka.actor.ActorSystem
-import com.gu.memsub.subsv2.services.{CatalogService, SubscriptionService}
+import com.gu.memsub.subsv2.services.CatalogService
 import com.gu.zuora.ZuoraSoapService
 import com.gu.zuora.rest.ZuoraRestService
 import com.typesafe.config.Config
 import configuration.Stage
 import monitoring.CreateMetrics
 import services.salesforce.ContactRepository
+import services.subscription.SubscriptionService
 import services.{BasicStripeService, HealthCheckableService, SupporterProductDataService}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -18,7 +19,7 @@ class TouchpointBackends(
     createMetrics: CreateMetrics,
     supporterProductDataServiceOverride: Option[SupporterProductDataService] = None,
     contactRepositoryOverride: Option[ContactRepository] = None,
-    subscriptionServiceOverride: Option[SubscriptionService[Future]] = None,
+    subscriptionServiceOverride: Option[SubscriptionService] = None,
     zuoraRestServiceOverride: Option[ZuoraRestService[Future]] = None,
     catalogServiceOverride: Option[CatalogService[Future]] = None,
     zuoraServiceOverride: Option[ZuoraSoapService with HealthCheckableService] = None,

--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -138,7 +138,7 @@ class TouchpointComponents(
 
   private lazy val zuoraSubscriptionService = new ZuoraSubscriptionService(productIds, futureCatalog, zuoraRestClient, zuoraService.getAccountIds)
 
-  lazy val subService: SubscriptionService = subscriptionServiceOverride.getOrElse(
+  lazy val subscriptionService: SubscriptionService = subscriptionServiceOverride.getOrElse(
     new SubscriptionServiceWithMetrics(zuoraSubscriptionService, createMetrics),
   )
   lazy val paymentService: PaymentService = new PaymentService(zuoraService, catalogService.unsafeCatalog.productMap)
@@ -172,7 +172,7 @@ class TouchpointComponents(
       createMetrics,
       zuoraRestService,
       contactRepository,
-      subService,
+      subscriptionService,
       chooseStripeService,
       paymentDetailsForSubscription,
     )

--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -105,7 +105,7 @@ class AccountController(
         def disableAutoPayOnlyIfAccountHasOneSubscription(
             accountId: memsub.Subscription.AccountId,
         ): SimpleEitherT[Unit] = {
-          EitherT(tp.subService.subscriptionsForAccountId[P](accountId)).flatMap { currentSubscriptions =>
+          EitherT(tp.subscriptionService.subscriptionsForAccountId[P](accountId)).flatMap { currentSubscriptions =>
             if (currentSubscriptions.size <= 1)
               SimpleEitherT(tp.zuoraRestService.disableAutoPay(accountId).map(_.toEither))
             else // do not disable auto pay
@@ -138,7 +138,7 @@ class AccountController(
             .leftMap(CancelError(_, 404))
           sfSub <- EitherT
             .fromEither(
-              tp.subService.current[P](sfContact).map(subs => subscriptionSelector(Some(subscriptionName), s"Salesforce user $sfContact")(subs)),
+              tp.subscriptionService.current[P](sfContact).map(subs => subscriptionSelector(Some(subscriptionName), s"Salesforce user $sfContact")(subs)),
             )
             .leftMap(CancelError(_, 404))
           accountId <- EitherT.fromEither(
@@ -147,7 +147,7 @@ class AccountController(
               else Left(CancelError(s"$subscriptionName does not belong to $identityId", 503)),
             ),
           )
-          cancellationEffectiveDate <- tp.subService.decideCancellationEffectiveDate[P](subscriptionName).leftMap(CancelError(_, 500))
+          cancellationEffectiveDate <- tp.subscriptionService.decideCancellationEffectiveDate[P](subscriptionName).leftMap(CancelError(_, 500))
           _ <- EitherT.fromEither(executeCancellation(cancellationEffectiveDate, cancellationReason, accountId, sfSub.termEndDate))
           result = cancellationEffectiveDate.getOrElse("now").toString
         } yield result).run.map(_.toEither).map {
@@ -168,7 +168,7 @@ class AccountController(
         val userId = request.user.identityId
 
         (for {
-          cancellationEffectiveDate <- tp.subService
+          cancellationEffectiveDate <- tp.subscriptionService
             .decideCancellationEffectiveDate[P](subscriptionName)
             .leftMap(error => ApiError("Failed to determine effectiveCancellationDate", error, 500))
           result = cancellationEffectiveDate.getOrElse("now").toString
@@ -202,7 +202,7 @@ class AccountController(
           user <- OptionTEither.some(userId)
           contact <- OptionTEither(tp.contactRepository.get(user))
           freeOrPaidSub <- OptionTEither(
-            tp.subService
+            tp.subscriptionService
               .either[F, P](contact)
               .map(_.leftMap(message => s"couldn't read sub from zuora for crmId ${contact.salesforceAccountId} due to $message")),
           ).map(_.toEither)
@@ -307,7 +307,7 @@ class AccountController(
           case Some(identityId) =>
             (for {
               contact <- OptionT(EitherT(tp.contactRepository.get(identityId)))
-              subs <- OptionT(EitherT(tp.subService.recentlyCancelled(contact)).map(Option(_)))
+              subs <- OptionT(EitherT(tp.subscriptionService.recentlyCancelled(contact)).map(Option(_)))
             } yield {
               Ok(Json.toJson(subs.map(CancelledSubscription(_))))
             }).getOrElse(emptyResponse).leftMap(_ => emptyResponse).merge // we discard errors as this is not critical endpoint
@@ -332,7 +332,7 @@ class AccountController(
           user <- SimpleEitherT.right(userId)
           sfUser <- SimpleEitherT.fromFutureOption(tp.contactRepository.get(user), s"No SF user $user")
           subscription <- EitherT.fromEither(
-            tp.subService
+            tp.subscriptionService
               .current[SubscriptionPlan.Contributor](sfUser)
               .map(subs => subscriptionSelector(subscriptionNameOption, s"the sfUser $sfUser")(subs)),
           )

--- a/membership-attribute-service/app/controllers/ExistingPaymentOptionsController.scala
+++ b/membership-attribute-service/app/controllers/ExistingPaymentOptionsController.scala
@@ -6,7 +6,6 @@ import com.gu.identity.SignedInRecently
 import com.gu.memsub.Subscription.AccountId
 import com.gu.memsub.subsv2.reads.ChargeListReads._
 import com.gu.memsub.subsv2.reads.SubPlanReads._
-import com.gu.memsub.subsv2.services.SubscriptionService
 import com.gu.memsub.subsv2.{Subscription, SubscriptionPlan}
 import com.gu.memsub.{GoCardless, PayPalMethod, PaymentCard, PaymentCardDetails, PaymentMethod}
 import com.gu.zuora.rest.ZuoraRestService.ObjectAccount
@@ -23,6 +22,7 @@ import scalaz.-\/
 import scalaz.std.scalaFuture._
 import scalaz.syntax.monadPlus._
 import services.salesforce.ContactRepository
+import services.subscription.SubscriptionService
 import utils.ListTEither
 import utils.SimpleEitherT.SimpleEitherT
 
@@ -42,7 +42,7 @@ class ExistingPaymentOptionsController(
       date: LocalDate,
       maybeUserId: Option[String],
       contactRepository: ContactRepository,
-      subService: SubscriptionService[Future],
+      subService: SubscriptionService,
   ): SimpleEitherT[Map[AccountId, List[Subscription[SubscriptionPlan.AnyPlan]]]] =
     (for {
       user <- ListTEither.fromOption(maybeUserId)

--- a/membership-attribute-service/app/controllers/PaymentUpdateController.scala
+++ b/membership-attribute-service/app/controllers/PaymentUpdateController.scala
@@ -51,7 +51,7 @@ class PaymentUpdateController(commonActions: CommonActions, override val control
           (stripeCardIdentifier, stripePublicKey) = stripeDetails
           sfUser <- EitherT.fromEither(tp.contactRepository.get(user).map(_.toEither).map(_.flatMap(_.toRight(s"no SF user $user"))))
           subscription <- EitherT.fromEither(
-            tp.subService
+            tp.subscriptionService
               .current[SubscriptionPlan.AnyPlan](sfUser)
               .map(subs => subscriptionSelector(Some(memsub.Subscription.Name(subscriptionName)), s"the sfUser $sfUser")(subs)),
           )
@@ -134,7 +134,7 @@ class PaymentUpdateController(commonActions: CommonActions, override val control
           (bankAccountName, bankAccountNumber, bankSortCode) = directDebitDetails
           sfUser <- EitherT.fromEither(tp.contactRepository.get(user).map(_.toEither.flatMap(_.toRight(s"no SF user $user"))))
           subscription <- EitherT.fromEither(
-            tp.subService
+            tp.subscriptionService
               .current[SubscriptionPlan.AnyPlan](sfUser)
               .map(subs => subscriptionSelector(Some(memsub.Subscription.Name(subscriptionName)), s"the sfUser $sfUser")(subs)),
           )

--- a/membership-attribute-service/app/services/AccountDetailsFromZuora.scala
+++ b/membership-attribute-service/app/services/AccountDetailsFromZuora.scala
@@ -3,7 +3,6 @@ package services
 import com.gu.memsub.Product
 import com.gu.memsub.Subscription.Name
 import com.gu.memsub.subsv2.SubscriptionPlan.AnyPlan
-import com.gu.memsub.subsv2.services.SubscriptionService
 import com.gu.memsub.subsv2.{Subscription, SubscriptionPlan}
 import com.gu.salesforce.Contact
 import com.gu.services.model.PaymentDetails
@@ -18,6 +17,7 @@ import scalaz.std.scalaFuture._
 import services.DifferentiateSubscription.differentiateSubscription
 import services.PaymentFailureAlerter.{accountHasMissedPayments, alertText, safeToAllowPaymentUpdate}
 import services.salesforce.ContactRepository
+import services.subscription.SubscriptionService
 import utils.ListTEither.ListTEither
 import utils.SimpleEitherT.SimpleEitherT
 import utils.{ListTEither, SimpleEitherT}
@@ -28,7 +28,7 @@ class AccountDetailsFromZuora(
     createMetrics: CreateMetrics,
     zuoraRestService: ZuoraRestService[Future],
     contactRepository: ContactRepository,
-    subscriptionService: SubscriptionService[Future],
+    subscriptionService: SubscriptionService,
     chooseStripeService: ChooseStripeService,
     paymentDetailsForSubscription: PaymentDetailsForSubscription,
 )(implicit executionContext: ExecutionContext) {

--- a/membership-attribute-service/app/services/subscription/Sequence.scala
+++ b/membership-attribute-service/app/services/subscription/Sequence.scala
@@ -1,0 +1,27 @@
+package services.subscription
+
+import scalaz.{-\/, NonEmptyList, \/, \/-}
+
+/*
+Sequence turns a list of either into an either of list.  In this case, it does it by putting all the rights into a list and returning
+that as a right.  However if there are no rights, it will return a left of any lefts.
+This is mostly useful if we want to try a load of things and hopefully one will succeed.  It's not too good in case things
+go wrong, we don't know which ones should have failed and which shouldn't have.  But at least it keeps most of the errors.
+ */
+object Sequence {
+
+  def apply[A](eitherList: List[String \/ A]): String \/ NonEmptyList[A] = {
+    val zero = (List[String](), List[A]())
+    val product = eitherList.foldRight(zero)({
+      case (-\/(left), (accuLeft, accuRight)) => (left :: accuLeft, accuRight)
+      case (\/-(right), (accuLeft, accuRight)) => (accuLeft, right :: accuRight)
+    })
+    // if any are right, return them all, otherwise return all the left
+    product match {
+      case (Nil, Nil) => -\/("no subscriptions found at all, even invalid ones") // no failures or successes
+      case (errors, Nil) => -\/(errors.mkString("\n")) // no successes
+      case (_, result :: results) => \/-(NonEmptyList.fromSeq(result, results)) // discard some errors as long as some worked (log it?)
+    }
+  }
+
+}

--- a/membership-attribute-service/app/services/subscription/SubscriptionService.scala
+++ b/membership-attribute-service/app/services/subscription/SubscriptionService.scala
@@ -1,0 +1,87 @@
+package services.subscription
+
+import com.gu.memsub
+import com.gu.memsub.Subscription.{AccountId, ProductRatePlanId, RatePlanId}
+import com.gu.memsub.subsv2.SubscriptionPlan._
+import com.gu.memsub.subsv2._
+import com.gu.memsub.subsv2.reads.SubPlanReads
+import com.gu.salesforce.ContactId
+import org.joda.time.{LocalDate, LocalTime}
+import play.api.libs.json._
+import scalaz._
+
+import scala.concurrent.Future
+import scala.language.higherKinds
+
+case class SubIds(ratePlanId: RatePlanId, productRatePlanId: ProductRatePlanId)
+
+object SubscriptionService {
+  type SoapClient = ContactId => Future[List[memsub.Subscription.AccountId]]
+  type CatalogMap = Map[ProductRatePlanId, CatalogZuoraPlan]
+}
+
+trait SubscriptionService {
+  def get[P <: AnyPlan: SubPlanReads](
+      name: memsub.Subscription.Name,
+      isActiveToday: Boolean = false,
+  ): Future[Option[Subscription[P]]]
+
+  def current[P <: AnyPlan: SubPlanReads](contact: ContactId): Future[List[Subscription[P]]]
+
+  def since[P <: AnyPlan: SubPlanReads](onOrAfter: LocalDate)(contact: ContactId): Future[List[Subscription[P]]]
+
+  def recentlyCancelled(
+      contact: ContactId,
+      today: LocalDate = LocalDate.now(),
+      lastNMonths: Int = 3, // cancelled in the last N months
+  )(implicit ev: SubPlanReads[AnyPlan]): Future[String \/ List[Subscription[AnyPlan]]]
+
+  def subscriptionsForAccountId[P <: AnyPlan: SubPlanReads](accountId: AccountId): Future[Disjunction[String, List[Subscription[P]]]]
+
+  def jsonSubscriptionsFromContact(contact: ContactId): Future[Disjunction[String, List[JsValue]]]
+
+  def jsonSubscriptionsFromAccount(accountId: AccountId): Future[Disjunction[String, List[JsValue]]]
+
+  /** find the best current subscription for the salesforce contact TODO get rid of this and use pattern matching instead
+    */
+  def either[FALLBACK <: AnyPlan, PREFERRED <: AnyPlan](
+      contact: ContactId,
+  )(implicit a: SubPlanReads[FALLBACK], b: SubPlanReads[PREFERRED]): Future[\/[String, Option[Subscription[FALLBACK] \/ Subscription[PREFERRED]]]]
+
+  def getSubscription(contact: ContactId)(implicit a: SubPlanReads[Contributor]): Future[Option[Subscription[Contributor]]]
+
+  /** find the current subscription for the given subscription number TODO get rid of this and use pattern matching instead
+    */
+  def either[FALLBACK <: AnyPlan, PREFERRED <: AnyPlan](
+      name: memsub.Subscription.Name,
+  )(implicit a: SubPlanReads[FALLBACK], b: SubPlanReads[PREFERRED]): Future[\/[String, Subscription[FALLBACK] \/ Subscription[PREFERRED]]]
+
+  // this is a back door to find the subscription discount ids so we can delete when people upgrade
+  // just need the id and prp id
+  def backdoorRatePlanIds(name: com.gu.memsub.Subscription.Name): Future[String \/ List[SubIds]]
+
+  /** fetched with /v1/subscription/{key}?charge-detail=current-segment which zeroes out all the non-active charges
+    *
+    * There are multiple scenarios
+    *   - period between acquisition date and fulfilment date => None which indicates cancel now
+    *     - usually contractEffectiveDate to customerAcceptanceDate, except in the case of Guardian Weekly+6for6 where customerAcceptanceDate
+    *       indicates start of GW proper invoiced period instead of start of 6for6 invoiced period despite GW+6for6 being just a regular Subscription
+    *       with multiple products.
+    *     - free trial, or user choose start date of first issue in the future (lead time)
+    *   - Subscription within invoiced period proper => Some(endOfLastInvoicePeriod)
+    *   - free product => None which indicates cancel now
+    *   - edge case of being on the first day of invoice period however bill run has not yet happened => ERROR
+    *   - Today is after end of last invoice date and bill run has already completed => ERROR
+    *
+    * @return
+    *   Right(None) indicates cancel now, Right(Some("yyyy-mm-dd")) indicates cancel at end of last invoiced period Left indicates error and MMA
+    *   should not proceed with automatic cancelation
+    */
+  def decideCancellationEffectiveDate[P <: SubscriptionPlan.AnyPlan: SubPlanReads](
+      subscriptionName: memsub.Subscription.Name,
+      wallClockTimeNow: LocalTime = LocalTime.now(),
+      today: LocalDate = LocalDate.now(),
+  ): EitherT[String, Future, Option[LocalDate]]
+}
+
+

--- a/membership-attribute-service/app/services/subscription/SubscriptionServiceWithMetrics.scala
+++ b/membership-attribute-service/app/services/subscription/SubscriptionServiceWithMetrics.scala
@@ -1,0 +1,87 @@
+package services.subscription
+
+import com.gu.memsub
+import com.gu.memsub.Subscription.AccountId
+import com.gu.memsub.subsv2.Subscription
+import com.gu.memsub.subsv2.SubscriptionPlan.{AnyPlan, Contributor}
+import com.gu.memsub.subsv2.reads.SubPlanReads
+import com.gu.salesforce.ContactId
+import monitoring.CreateMetrics
+import org.joda.time.{LocalDate, LocalTime}
+import play.api.libs.json.JsValue
+import scalaz.{Disjunction, DisjunctionT, \/}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.language.higherKinds
+
+class SubscriptionServiceWithMetrics(wrapped: SubscriptionService, createMetrics: CreateMetrics)(implicit val ec: ExecutionContext)
+    extends SubscriptionService {
+  private val metrics = createMetrics.forService(wrapped.getClass)
+
+  override def get[P <: AnyPlan: SubPlanReads](name: memsub.Subscription.Name, isActiveToday: Boolean): Future[Option[Subscription[P]]] =
+    metrics.measureDuration("get")(wrapped.get(name, isActiveToday))
+
+  override def current[P <: AnyPlan: SubPlanReads](contact: ContactId): Future[List[Subscription[P]]] =
+    metrics.measureDuration("current")(wrapped.current(contact))
+
+  override def since[P <: AnyPlan: SubPlanReads](onOrAfter: LocalDate)(contact: ContactId): Future[List[Subscription[P]]] =
+    metrics.measureDuration("since")(wrapped.since(onOrAfter)(contact))
+
+  override def recentlyCancelled(contact: ContactId, today: LocalDate, lastNMonths: Int)(implicit
+      ev: SubPlanReads[AnyPlan],
+  ): Future[String \/ List[Subscription[AnyPlan]]] =
+    metrics.measureDuration("recentlyCancelled")(wrapped.recentlyCancelled(contact, today, lastNMonths))
+
+  override def subscriptionsForAccountId[P <: AnyPlan: SubPlanReads](accountId: AccountId): Future[Disjunction[String, List[Subscription[P]]]] =
+    metrics.measureDuration("subscriptionsForAccountId")(wrapped.subscriptionsForAccountId(accountId))
+
+  override def jsonSubscriptionsFromContact(contact: ContactId): Future[Disjunction[String, List[JsValue]]] =
+    metrics.measureDuration("jsonSubscriptionsFromContact")(wrapped.jsonSubscriptionsFromContact(contact))
+
+  override def jsonSubscriptionsFromAccount(accountId: AccountId): Future[Disjunction[String, List[JsValue]]] =
+    metrics.measureDuration("jsonSubscriptionsFromAccount")(wrapped.jsonSubscriptionsFromAccount(accountId))
+
+  /** find the best current subscription for the salesforce contact TODO get rid of this and use pattern matching instead
+    */
+  override def either[FALLBACK <: AnyPlan, PREFERRED <: AnyPlan](
+      contact: ContactId,
+  )(implicit a: SubPlanReads[FALLBACK], b: SubPlanReads[PREFERRED]): Future[String \/ Option[Subscription[FALLBACK] \/ Subscription[PREFERRED]]] =
+    metrics.measureDuration("eitherByContact")(wrapped.either(contact))
+
+  override def getSubscription(contact: ContactId)(implicit a: SubPlanReads[Contributor]): Future[Option[Subscription[Contributor]]] =
+    metrics.measureDuration("getSubscription")(wrapped.getSubscription(contact))
+
+  /** find the current subscription for the given subscription number TODO get rid of this and use pattern matching instead
+    */
+  override def either[FALLBACK <: AnyPlan, PREFERRED <: AnyPlan](
+      name: memsub.Subscription.Name,
+  )(implicit a: SubPlanReads[FALLBACK], b: SubPlanReads[PREFERRED]): Future[String \/ (Subscription[FALLBACK] \/ Subscription[PREFERRED])] =
+    metrics.measureDuration("eitherByName")(wrapped.either(name))
+
+  override def backdoorRatePlanIds(name: memsub.Subscription.Name): Future[String \/ List[SubIds]] =
+    metrics.measureDuration("backdoorRatePlanIds")(wrapped.backdoorRatePlanIds(name))
+
+  /** fetched with /v1/subscription/{key}?charge-detail=current-segment which zeroes out all the non-active charges
+    *
+    * There are multiple scenarios
+    *   - period between acquisition date and fulfilment date => None which indicates cancel now
+    *     - usually contractEffectiveDate to customerAcceptanceDate, except in the case of Guardian Weekly+6for6 where customerAcceptanceDate
+    *       indicates start of GW proper invoiced period instead of start of 6for6 invoiced period despite GW+6for6 being just a regular Subscription
+    *       with multiple products.
+    *     - free trial, or user choose start date of first issue in the future (lead time)
+    *   - Subscription within invoiced period proper => Some(endOfLastInvoicePeriod)
+    *   - free product => None which indicates cancel now
+    *   - edge case of being on the first day of invoice period however bill run has not yet happened => ERROR
+    *   - Today is after end of last invoice date and bill run has already completed => ERROR
+    *
+    * @return
+    *   Right(None) indicates cancel now, Right(Some("yyyy-mm-dd")) indicates cancel at end of last invoiced period Left indicates error and MMA
+    *   should not proceed with automatic cancelation
+    */
+  override def decideCancellationEffectiveDate[P <: AnyPlan: SubPlanReads](
+      subscriptionName: memsub.Subscription.Name,
+      wallClockTimeNow: LocalTime,
+      today: LocalDate,
+  ): DisjunctionT[String, Future, Option[LocalDate]] =
+    wrapped.decideCancellationEffectiveDate(subscriptionName, wallClockTimeNow, today)
+}

--- a/membership-attribute-service/app/services/subscription/SubscriptionTransform.scala
+++ b/membership-attribute-service/app/services/subscription/SubscriptionTransform.scala
@@ -1,0 +1,167 @@
+package services.subscription
+
+import com.gu.memsub.Subscription.{ProductRatePlanId, RatePlanId}
+import com.gu.memsub.subsv2.SubscriptionPlan.AnyPlan
+import com.gu.memsub.subsv2._
+import com.gu.memsub.subsv2.reads.ChargeListReads.ProductIds
+import com.gu.memsub.subsv2.reads.CommonReads._
+import com.gu.memsub.subsv2.reads.SubJsonReads._
+import com.gu.memsub.subsv2.reads.SubPlanReads
+import com.gu.memsub.subsv2.services.SubscriptionService.CatalogMap
+import com.gu.monitoring.SafeLogger
+import org.joda.time.LocalDate
+import play.api.libs.json.{Reads => JsReads, _}
+import scalaz._
+import scalaz.syntax.all._
+import scalaz.syntax.std.either._
+import scalaz.syntax.std.option._
+
+import scala.language.higherKinds
+import scala.util.Try
+
+
+
+// this is (all?) the testable stuff without mocking needed
+// we should make the subscription service just getting the json, and then we can have testable pure functions here
+object SubscriptionTransform {
+
+  val subIdsReads: JsReads[SubIds] = new JsReads[SubIds] {
+    override def reads(json: JsValue): JsResult[SubIds] = {
+
+      (
+        (json \ "id").validate[String].map(RatePlanId) |@|
+          (json \ "productRatePlanId").validate[String].map(ProductRatePlanId)
+      )(SubIds)
+    }
+  }
+
+  def backdoorRatePlanIdsFromJson(subJson: JsValue): Disjunction[String, List[SubIds]] = {
+    val ids = (subJson \ "ratePlans").validate[List[SubIds]](niceListReads(subIdsReads)).asEither.disjunction.leftMap(_.toString)
+    // didn't actually check if they're current
+
+    ids.leftMap { error =>
+      SafeLogger.warn(s"Error from sub service for json: $error")
+    }
+
+    ids
+  }
+
+  def tryTwoReadersForSubscriptionJson[PREFERRED <: AnyPlan: SubPlanReads, FALLBACK <: AnyPlan: SubPlanReads](catalog: CatalogMap, pids: ProductIds)(
+      subJsons: List[JsValue],
+  ): \/[String, Disjunction[Subscription[FALLBACK], Subscription[PREFERRED]]] = {
+    val maybePreferred =
+      getCurrentSubscriptions[PREFERRED](catalog, pids)(subJsons).map(_.head /*if more than one current, just pick one (for now!)*/ )
+    lazy val maybeFallback =
+      getCurrentSubscriptions[FALLBACK](catalog, pids)(subJsons).map(_.head /*if more than one current, just pick one (for now!)*/ )
+    maybePreferred match {
+      case \/-(preferredSub) => \/.right(\/-(preferredSub))
+      case -\/(err1) =>
+        maybeFallback match {
+          case \/-(fallbackSub) => \/.right(-\/(fallbackSub))
+          case -\/(err2) => \/.left(s"Error from sub service: $err1\n\n$err2")
+        }
+    }
+  }
+
+  type TimeRelativeSubTransformer[P <: AnyPlan] = (CatalogMap, ProductIds) => List[JsValue] => Disjunction[String, NonEmptyList[Subscription[P]]]
+
+  def getCurrentSubscriptions[P <: AnyPlan: SubPlanReads](catalog: CatalogMap, pids: ProductIds)(
+      subJsons: List[JsValue],
+  ): Disjunction[String, NonEmptyList[Subscription[P]]] = {
+
+    def getFirstCurrentSub[P <: AnyPlan](
+        subs: NonEmptyList[Subscription[P]],
+    ): String \/ NonEmptyList[Subscription[P]] = // just quickly check to find one with a current plan
+      Sequence(
+        subs
+          .map { sub =>
+            Try {
+              sub.plan // just to force a throw if it doesn't have one
+            } match {
+              case scala.util.Success(_) => \/-(sub): \/[String, Subscription[P]]
+              case scala.util.Failure(ex) => -\/(ex.toString): \/[String, Subscription[P]]
+            }
+          }
+          .list
+          .toList,
+      )
+
+    Sequence(subJsons.map { subJson =>
+      getSubscription(catalog, pids)(subJson)
+    }).flatMap(getFirstCurrentSub[P])
+  }
+
+  def getSubscriptionsActiveOnOrAfter[P <: AnyPlan: SubPlanReads](
+      onOrAfter: LocalDate,
+  )(catalog: CatalogMap, pids: ProductIds)(subJsons: List[JsValue]): Disjunction[String, NonEmptyList[Subscription[P]]] =
+    Sequence(subJsons.map(getSubscription[P](catalog, pids)).filter {
+      case \/-(sub) => !sub.termEndDate.isBefore(onOrAfter)
+      case _ => false
+    })
+
+  def getRecentlyCancelledSubscriptions[P <: AnyPlan: SubPlanReads](
+      today: LocalDate,
+      lastNMonths: Int, // cancelled in the last n months
+      catalog: CatalogMap,
+      pids: ProductIds,
+      subJsons: List[JsValue],
+  ): Disjunction[String, List[Subscription[P]]] = {
+    import Scalaz._
+    subJsons
+      .map(getSubscription[P](catalog, pids))
+      .sequence
+      .map {
+        _.filter { sub =>
+          sub.isCancelled &&
+          (sub.termEndDate isAfter today.minusMonths(lastNMonths)) &&
+          (sub.termEndDate isBefore today)
+        }
+      }
+  }
+
+  def getSubscription[P <: AnyPlan: SubPlanReads](
+      catalog: CatalogMap,
+      pids: ProductIds,
+      now: () => LocalDate = LocalDate.now, /*now only needed for pending friend downgrade*/
+  )(subJson: JsValue): Disjunction[String, Subscription[P]] = {
+    import Trace.Traceable
+    val planToSubscriptionFunction =
+      subscriptionReads[P](now()).reads(subJson).asEither.disjunction.leftMap(_.mkString(" ")).withTrace("planToSubscriptionFunction")
+
+    val lowLevelPlans = subJson
+      .validate[List[SubscriptionZuoraPlan]](subZuoraPlanListReads)
+      .asEither
+      .disjunction
+      .leftMap(_.toString)
+      .withTrace("validate-lowLevelPlans")
+    lowLevelPlans.flatMap { lowLevelPlans =>
+      val validHighLevelPlans: String \/ NonEmptyList[P] =
+        Sequence(
+          lowLevelPlans
+            .map { lowLevelPlan =>
+              // get the equivalent plan from the catalog so we can merge them into a standard high level object
+              catalog
+                .get(lowLevelPlan.productRatePlanId)
+                .toRightDisjunction(s"No catalog plan - prpId = ${lowLevelPlan.productRatePlanId}")
+                .flatMap { catalogPlan =>
+                  val maybePlans = implicitly[SubPlanReads[P]].read(pids, lowLevelPlan, catalogPlan)
+                  maybePlans.toDisjunction
+                    .leftMap(
+                      _.list.zipWithIndex
+                        .map { case (err, index) =>
+                          s"  ${index + 1}: $err"
+                        }
+                        .toList
+                        .mkString("\n", "\n", "\n"),
+                    )
+                    .withTrace(s"high-level-plan-read: ${lowLevelPlan.id}")
+                }
+            },
+        )
+
+      // now wrap them in a subscription
+      validHighLevelPlans.flatMap(highLevelPlans => planToSubscriptionFunction.map(_.apply(highLevelPlans)))
+    }
+  }
+
+}

--- a/membership-attribute-service/app/services/subscription/Trace.scala
+++ b/membership-attribute-service/app/services/subscription/Trace.scala
@@ -1,0 +1,14 @@
+package services.subscription
+
+import scalaz.{-\/, \/}
+
+object Trace {
+
+  implicit class Traceable[T](t: String \/ T) {
+    def withTrace(message: String): String \/ T = t match {
+      case -\/(e) => -\/(s"$message: {$e}")
+      case right => right
+    }
+  }
+
+}

--- a/membership-attribute-service/app/services/subscription/ZuoraSubscriptionService.scala
+++ b/membership-attribute-service/app/services/subscription/ZuoraSubscriptionService.scala
@@ -1,0 +1,297 @@
+package services.subscription
+
+import com.gu.memsub
+import com.gu.memsub.Subscription.AccountId
+import com.gu.memsub.subsv2.SubscriptionPlan._
+import com.gu.memsub.subsv2._
+import com.gu.memsub.subsv2.reads.ChargeListReads.ProductIds
+import com.gu.memsub.subsv2.reads.SubJsonReads._
+import com.gu.memsub.subsv2.reads.SubPlanReads
+import com.gu.memsub.subsv2.services.SubscriptionService.{CatalogMap, SoapClient}
+import com.gu.memsub.subsv2.services.SubscriptionTransform.getRecentlyCancelledSubscriptions
+import com.gu.memsub.subsv2.services.Trace.Traceable
+import com.gu.monitoring.SafeLogger
+import com.gu.salesforce.ContactId
+import com.gu.zuora.rest.SimpleClient
+import org.joda.time.{LocalDate, LocalTime}
+import play.api.libs.json.{Reads => JsReads, _}
+import scalaz._
+import scalaz.syntax.all._
+import utils.SimpleEitherT.SimpleEitherT
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.language.higherKinds
+import scala.util.Try
+
+class ZuoraSubscriptionService(pids: ProductIds, futureCatalog: => Future[CatalogMap], rest: SimpleClient[Future], soap: SoapClient[Future])(implicit
+    t: Monad[Future],
+    ec: ExecutionContext,
+) extends SubscriptionService {
+  private implicit val idReads = new JsReads[JsValue] {
+    override def reads(json: JsValue): JsResult[JsValue] = JsSuccess(json)
+  }
+
+  /** Time by which Bill Run should have run and completed. Usually starts around 5AM and takes 1 hour.
+    */
+  final val BillRunCompletedByTime = LocalTime.parse("12:00")
+
+  /** Fetch a subscription by its subscription name
+    *
+    * @param isActiveToday
+    *   If true return subscription with currently (today) active charge (effectiveStartDate <= today’s date < effectiveEndDate). Other rate plan
+    *   charges are effectively zeroed out, that is, returned as empty list.
+    *
+    * By default it is set to false which is supposed to, as per docs, return the last rate plan charge on the subscription. The last rate plan charge
+    * is the last one in the order of time on the subscription rather than the most recent changed charge on the subscription. However in practice
+    * this is not always the case. It also returns all the historical charges that have been removed that is charges with '"lastChangeType":
+    * "Remove"'.
+    *
+    * FIXME: We should change to true as default as we are usually interested in only what the user has right now. We could simplify much filtering
+    * logic then, and possibly it would resolve automatically few bugs. (All clients would have to be tested!)
+    *
+    * @see
+    *   Query Parameters section of https://www.zuora.com/developer/api-reference/#operation/GET_SubscriptionsByKey
+    * @see
+    *   https://community.zuora.com/t5/Admin-Settings-Ideas/Get-current-active-subscription-rate-plans/idi-p/19049
+    */
+  def get[P <: AnyPlan: SubPlanReads](
+      name: memsub.Subscription.Name,
+      isActiveToday: Boolean = false,
+  ): Future[Option[Subscription[P]]] = {
+
+    val url =
+      if (isActiveToday)
+        s"subscriptions/${name.get}?charge-detail=current-segment" // (effectiveStartDate <= today’s date < effectiveEndDate).
+      else
+        s"subscriptions/${name.get}" // FIXME: equivalent to ?charge-detail=last-segment which returns even removed historical charges. We should not have this as default.
+
+    val futureSubJson = rest.get[JsValue](url)(idReads)
+
+    futureSubJson.flatMap { subJson =>
+      futureCatalog.map { catalog =>
+        // FIXME: Why naming indicates multiple subscriptions? There should be only one sub per provided name.
+        val allSubscriptionsForSubscriberName = subJson.flatMap { jsValue =>
+          SubscriptionTransform.getSubscription[P](catalog, pids)(jsValue).withTrace("getAllValidSubscriptionsFromJson")
+        }
+        warnOnMissingChargedThroughDate(allSubscriptionsForSubscriberName)
+        allSubscriptionsForSubscriberName.leftMap(error => SafeLogger.warn(s"Error from sub service for $name: $error")).toOption
+
+      }
+    }
+  }
+
+  /** A paid subscription that is active today should have been invoiced, which means Bill Run should have happened, and so chargedThroughDate should
+    * be populated. If a paid subscription is missing chargeThroughDate also known as End of Last Invoice Period, or day after service period end
+    * date, then the likelihood of bugs increases. For example, holiday credit or cancellation effective date should be applied on End of Last Invoice
+    * Period date, and we have had bugs around both of these functionalities.
+    *
+    * Free trials are an exception, however we might be able to execute real-time Bill Run at point of acquisition with future target date in which
+    * case chargedThroughDate date should again be populated even though payment run has not happened yet. Currently there is assumption in the
+    * codebase if chargedThroughDate does not exist on paid product then it is free trial, however this is not a safe assumption. We should explicitly
+    * be determining free free trial state by perhaps if(sub.startDate <= today && sub.acceptanceDate > today) then free trial.
+    *
+    * This logging side-effect should make more visible in which scenarios we are missing chargedThroughDate.
+    */
+  private def warnOnMissingChargedThroughDate[P <: AnyPlan: SubPlanReads](subscription: String \/ Subscription[P]): Unit =
+    Try { // just to make sure it is not interfering with main business logic
+      subscription.foreach { sub =>
+        sub.plan match {
+          case p: PaidSubscriptionPlan[_, _] if p.chargedThrough.isEmpty =>
+            SafeLogger.warn(s"chargedThroughDate (end of last invoice date) does not exist for ${sub.name}")
+          case _ => // do nothing
+        }
+      }
+    }
+
+  /** Using fromContact above fetch all the subscriptions for a given contact
+    */
+  private def subscriptionsForContact[P <: AnyPlan: SubPlanReads](
+      transform: SubscriptionTransform.TimeRelativeSubTransformer[P],
+  )(contact: ContactId): Future[List[Subscription[P]]] = {
+    val subJsonsFuture = jsonSubscriptionsFromContact(contact)
+
+    subJsonsFuture.flatMap { subJsonsEither =>
+      futureCatalog.map { catalog =>
+        val highLevelSubscriptions = subJsonsEither.map { subJsons =>
+          transform(catalog, pids)(subJsons)
+            .leftMap(e => SafeLogger.warn(s"Error from sub service for contact $contact: $e"))
+            .toList
+            .flatMap(_.list.toList) // returns an empty list if there's an error
+        }
+        highLevelSubscriptions
+          .leftMap(e => SafeLogger.warn(s"Error from sub service for contact $contact: $e"))
+          .toList
+          .flatten // returns an empty list if there's an error
+      }
+    }
+  }
+
+  def current[P <: AnyPlan: SubPlanReads](contact: ContactId): Future[List[Subscription[P]]] =
+    subscriptionsForContact(SubscriptionTransform.getCurrentSubscriptions[P])(contact)
+
+  def since[P <: AnyPlan: SubPlanReads](onOrAfter: LocalDate)(contact: ContactId): Future[List[Subscription[P]]] =
+    subscriptionsForContact(SubscriptionTransform.getSubscriptionsActiveOnOrAfter[P](onOrAfter))(contact)
+
+  def recentlyCancelled(
+      contact: ContactId,
+      today: LocalDate = LocalDate.now(),
+      lastNMonths: Int = 3, // cancelled in the last N months
+  )(implicit ev: SubPlanReads[AnyPlan]): Future[String \/ List[Subscription[AnyPlan]]] = {
+    (for {
+      catalog <- EitherT(futureCatalog.map(\/.right[String, CatalogMap]))
+      jsonSubs <- EitherT(jsonSubscriptionsFromContact(contact))
+      subs <- EitherT(Monad[Future].pure(getRecentlyCancelledSubscriptions[AnyPlan](today, lastNMonths, catalog, pids, jsonSubs)))
+    } yield subs).run
+  }
+
+  private def jsToSubscription[P <: AnyPlan: SubPlanReads](
+      subJsonsFuture: Future[Disjunction[String, List[JsValue]]],
+      errorMsg: String,
+  ): Future[List[Subscription[P]]] =
+    subJsonsFuture.flatMap { subJsonsEither =>
+      futureCatalog.map { catalog =>
+        val highLevelSubscriptions = subJsonsEither.map { subJsons =>
+          SubscriptionTransform
+            .getCurrentSubscriptions[P](catalog, pids)(subJsons)
+            .leftMap(e => SafeLogger.warn(s"${errorMsg}: $e"))
+            .toList
+            .flatMap(_.list.toList) // returns an empty list if there's an error
+        }
+        highLevelSubscriptions.leftMap(e => SafeLogger.warn(s"${errorMsg}: $e")).toList.flatten // returns an empty list if there's an error
+      }
+    }
+
+  def subscriptionsForAccountId[P <: AnyPlan: SubPlanReads](accountId: AccountId): Future[Disjunction[String, List[Subscription[P]]]] = {
+    val subsAsJson = jsonSubscriptionsFromAccount(accountId)
+
+    subsAsJson.flatMap { subJsonsEither =>
+      futureCatalog.map { catalog =>
+        subJsonsEither.rightMap { subJsons =>
+          SubscriptionTransform.getCurrentSubscriptions[P](catalog, pids)(subJsons).toList.flatMap(_.list.toList)
+        }
+      }
+    }
+  }
+
+  def jsonSubscriptionsFromContact(contact: ContactId): Future[Disjunction[String, List[JsValue]]] = {
+    (for {
+      account <- ListT[SimpleEitherT, AccountId](
+        EitherT[String, Future, IList[AccountId]](soap.apply(contact).map(l => \/.r[String](IList.fromSeq(l)))),
+      )
+      subJson <- ListT[SimpleEitherT, JsValue](EitherT(jsonSubscriptionsFromAccount(account)).map(IList.fromSeq))
+    } yield subJson).toList.run
+  }
+
+  def jsonSubscriptionsFromAccount(accountId: AccountId): Future[Disjunction[String, List[JsValue]]] =
+    rest.get[List[JsValue]](s"subscriptions/accounts/${accountId.get}")(multiSubJsonReads)
+
+  /** find the best current subscription for the salesforce contact TODO get rid of this and use pattern matching instead
+    */
+  def either[FALLBACK <: AnyPlan, PREFERRED <: AnyPlan](
+      contact: ContactId,
+  )(implicit a: SubPlanReads[FALLBACK], b: SubPlanReads[PREFERRED]): Future[\/[String, Option[Subscription[FALLBACK] \/ Subscription[PREFERRED]]]] = {
+    val futureSubJson = jsonSubscriptionsFromContact(contact)
+    futureSubJson.flatMap { subJsonsEither =>
+      futureCatalog.map { catalog =>
+        subJsonsEither.leftMap(e => s"Error from sub service for sf contact $contact: $e").map { subJson =>
+          SubscriptionTransform
+            .tryTwoReadersForSubscriptionJson[PREFERRED, FALLBACK](catalog, pids)(subJson)
+            .leftMap(e => SafeLogger.debug(s"Error from tryTwoReadersForSubscriptionJson for sf contact $contact: $e"))
+            .fold(_ => None, Some.apply)
+        }
+      }
+    }
+  }
+
+  def getSubscription(contact: ContactId)(implicit a: SubPlanReads[Contributor]): Future[Option[Subscription[Contributor]]] = {
+    val futureSubJson = jsonSubscriptionsFromContact(contact)
+    val onError = s"Error from sub service for sf contact $contact"
+
+    jsToSubscription(futureSubJson, onError).map(_.headOption)
+  }
+
+  /** find the current subscription for the given subscription number TODO get rid of this and use pattern matching instead
+    */
+  def either[FALLBACK <: AnyPlan, PREFERRED <: AnyPlan](
+      name: memsub.Subscription.Name,
+  )(implicit a: SubPlanReads[FALLBACK], b: SubPlanReads[PREFERRED]): Future[\/[String, Subscription[FALLBACK] \/ Subscription[PREFERRED]]] = {
+    val futureSubJson = rest.get[JsValue](s"subscriptions/${name.get}")(idReads)
+
+    futureSubJson.flatMap { subJsonsEither =>
+      futureCatalog.map { catalog =>
+        subJsonsEither.leftMap(e => s"Error from sub service for subname $name: $e").flatMap { subJson =>
+          SubscriptionTransform.tryTwoReadersForSubscriptionJson[PREFERRED, FALLBACK](catalog, pids)(List(subJson))
+        }
+      }
+    }
+  }
+
+  // this is a back door to find the subscription discount ids so we can delete when people upgrade
+  // just need the id and prp id
+  def backdoorRatePlanIds(name: com.gu.memsub.Subscription.Name): Future[String \/ List[SubIds]] = {
+    val futureSubJson = rest.get[JsValue](s"subscriptions/${name.get}")(idReads)
+
+    futureSubJson.map(_.flatMap { subJson =>
+      SubscriptionTransform.backdoorRatePlanIdsFromJson(subJson)
+    })
+
+  }
+
+  /** fetched with /v1/subscription/{key}?charge-detail=current-segment which zeroes out all the non-active charges
+    *
+    * There are multiple scenarios
+    *   - period between acquisition date and fulfilment date => None which indicates cancel now
+    *     - usually contractEffectiveDate to customerAcceptanceDate, except in the case of Guardian Weekly+6for6 where customerAcceptanceDate
+    *       indicates start of GW proper invoiced period instead of start of 6for6 invoiced period despite GW+6for6 being just a regular Subscription
+    *       with multiple products.
+    *     - free trial, or user choose start date of first issue in the future (lead time)
+    *   - Subscription within invoiced period proper => Some(endOfLastInvoicePeriod)
+    *   - free product => None which indicates cancel now
+    *   - edge case of being on the first day of invoice period however bill run has not yet happened => ERROR
+    *   - Today is after end of last invoice date and bill run has already completed => ERROR
+    *
+    * @return
+    *   Right(None) indicates cancel now, Right(Some("yyyy-mm-dd")) indicates cancel at end of last invoiced period Left indicates error and MMA
+    *   should not proceed with automatic cancelation
+    */
+  def decideCancellationEffectiveDate[P <: SubscriptionPlan.AnyPlan: SubPlanReads](
+      subscriptionName: memsub.Subscription.Name,
+      wallClockTimeNow: LocalTime = LocalTime.now(),
+      today: LocalDate = LocalDate.now(),
+  ): EitherT[String, Future, Option[LocalDate]] = {
+    EitherT(
+      OptionT(get[P](subscriptionName, isActiveToday = true)).fold(
+        zuoraSubscriptionWithCurrentSegment => {
+          val paidPlans =
+            zuoraSubscriptionWithCurrentSegment.plans.list.collect { case paidPlan: PaidSubscriptionPlan[_, _] => paidPlan }
+          val billRunHasAlreadyHappened = wallClockTimeNow.isAfter(BillRunCompletedByTime)
+
+          paidPlans match {
+            case paidPlan1 :: paidPlan2 :: _ => \/.l[Option[LocalDate]]("Failed to determine specific single active paid rate plan charge")
+
+            case paidPlan :: Nil => // single rate plan charge identified
+              paidPlan.chargedThrough match {
+                case Some(endOfLastInvoicePeriod) =>
+                  val endOfLastInvoiceDateIsBeforeOrOnToday = endOfLastInvoicePeriod.isBefore(today) || endOfLastInvoicePeriod.isEqual(today)
+                  if (endOfLastInvoiceDateIsBeforeOrOnToday && billRunHasAlreadyHappened)
+                    \/.left(
+                      "chargedThroughDate exists but seems out-of-date because bill run should have moved chargedThroughDate to next invoice period. Investigate ASAP!",
+                    )
+                  else
+                    \/.r[String](Some(endOfLastInvoicePeriod))
+                case None =>
+                  if (paidPlan.start.equals(today) && !billRunHasAlreadyHappened) // effectiveStartDate exists but not chargedThroughDate
+                    \/.l[Option[LocalDate]](s"Invoiced period has started today, however Bill Run has not yet completed (it usually runs around 6am)")
+                  else
+                    \/.l[Option[LocalDate]](s"Unknown reason for missing chargedThroughDate. Investigate ASAP!")
+              }
+
+            case Nil => \/.r[String](Option.empty[LocalDate]) // free product so cancel now
+          }
+        },
+        none = \/.right(Option.empty[LocalDate]),
+      ), // we are within period between acquisition date and fulfilment date so cancel now (lead time / free trial)
+    )
+  }
+
+}

--- a/membership-attribute-service/app/wiring/AppLoader.scala
+++ b/membership-attribute-service/app/wiring/AppLoader.scala
@@ -2,7 +2,7 @@ package wiring
 
 import actions.CommonActions
 import akka.actor.ActorSystem
-import com.gu.memsub.subsv2.services.{CatalogService, SubscriptionService}
+import com.gu.memsub.subsv2.services.CatalogService
 import com.gu.zuora.ZuoraSoapService
 import com.gu.zuora.rest.ZuoraRestService
 import components.TouchpointBackends
@@ -20,14 +20,8 @@ import play.filters.cors.{CORSConfig, CORSFilter}
 import play.filters.csrf.CSRFComponents
 import router.Routes
 import services.salesforce.ContactRepository
-import services.{
-  BasicStripeService,
-  ContributionsStoreDatabaseService,
-  HealthCheckableService,
-  MobileSubscriptionServiceImpl,
-  PostgresDatabaseService,
-  SupporterProductDataService,
-}
+import services.subscription.SubscriptionService
+import services.{BasicStripeService, ContributionsStoreDatabaseService, HealthCheckableService, MobileSubscriptionServiceImpl, PostgresDatabaseService, SupporterProductDataService}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -59,7 +53,7 @@ class MyComponents(context: Context)
 
   lazy val supporterProductDataServiceOverride: Option[SupporterProductDataService] = None
   lazy val contactRepositoryOverride: Option[ContactRepository] = None
-  lazy val subscriptionServiceOverride: Option[SubscriptionService[Future]] = None
+  lazy val subscriptionServiceOverride: Option[SubscriptionService] = None
   lazy val zuoraRestServiceOverride: Option[ZuoraRestService[Future]] = None
   lazy val catalogServiceOverride: Option[CatalogService[Future]] = None
   lazy val zuoraSoapServiceOverride: Option[ZuoraSoapService with HealthCheckableService] = None

--- a/membership-attribute-service/test/acceptance/AccountControllerAcceptanceTest.scala
+++ b/membership-attribute-service/test/acceptance/AccountControllerAcceptanceTest.scala
@@ -1,18 +1,9 @@
 package acceptance
 
 import acceptance.data.stripe.{TestCustomersPaymentMethods, TestDynamoSupporterRatePlanItem, TestStripeSubscription}
-import acceptance.data.{
-  IdentityResponse,
-  TestAccountSummary,
-  TestCatalog,
-  TestContact,
-  TestPaidSubscriptionPlan,
-  TestPaymentSummary,
-  TestQueriesAccount,
-  TestSubscription,
-}
+import acceptance.data.{IdentityResponse, TestAccountSummary, TestCatalog, TestContact, TestPaidSubscriptionPlan, TestPaymentSummary, TestQueriesAccount, TestSubscription}
 import com.gu.i18n.Currency
-import com.gu.memsub.subsv2.services.{CatalogService, SubscriptionService}
+import com.gu.memsub.subsv2.services.CatalogService
 import com.gu.memsub.subsv2.{CovariantNonEmptyList, SubscriptionPlan}
 import com.gu.memsub.{Product, Subscription}
 import com.gu.zuora.ZuoraSoapService
@@ -35,6 +26,8 @@ import services.{
   SupporterProductDataService,
   SupporterRatePlanToAttributesMapper,
 }
+import services.subscription.SubscriptionService
+import services.{BasicStripeService, ContributionsStoreDatabaseService, HealthCheckableService, SupporterProductDataService, SupporterRatePlanToAttributesMapper}
 import utils.SimpleEitherT
 import wiring.MyComponents
 
@@ -43,7 +36,7 @@ import scala.concurrent.Future
 
 class AccountControllerAcceptanceTest extends AcceptanceTest {
   var contactRepositoryMock: ContactRepository = _
-  var subscriptionServiceMock: SubscriptionService[Future] = _
+  var subscriptionServiceMock: SubscriptionService = _
   var zuoraRestServiceMock: ZuoraRestService[Future] = _
   var catalogServiceMock: CatalogService[Future] = _
   var zuoraSoapServiceMock: ZuoraSoapService with HealthCheckableService = _
@@ -53,7 +46,7 @@ class AccountControllerAcceptanceTest extends AcceptanceTest {
 
   override protected def before: Unit = {
     contactRepositoryMock = mock[ContactRepository]
-    subscriptionServiceMock = mock[SubscriptionService[Future]]
+    subscriptionServiceMock = mock[SubscriptionService]
     zuoraRestServiceMock = mock[ZuoraRestService[Future]]
     catalogServiceMock = mock[CatalogService[Future]]
     zuoraSoapServiceMock = mock[ZuoraSoapService with HealthCheckableService]


### PR DESCRIPTION
Adding call duration metrics for SubscriptionService.

Bringing in SubscriptionService from membership-common.
Creating SubscriptionServiceWithMetrics wrapper that adds call duration metrics to the wrapped SubscriptionService calls.

Cleanup and some simplifications.