### PR TITLE
Include scalafmt checks as part of CI

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,4 @@
 # Scala Steward: Reformat with scalafmt 3.7.0
 94b4ac056a1531dddaefc27f3c6ac9377b786a1b
+# Include scalafmt checks as part of CI #902
+719ff459615e2b7d44026d91e4f7602c8efb592e

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,4 +32,4 @@ jobs:
         run: |
           LAST_TEAMCITY_BUILD=11657
           export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
-          sbt "project membership-attribute-service" clean test riffRaffUpload
+          sbt "project membership-attribute-service" clean scalafmtCheckAll scalafmtSbtCheck test riffRaffUpload

--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -31,7 +31,12 @@ import software.amazon.awssdk.auth.credentials.{
   ProfileCredentialsProvider,
 }
 import services.subscription.{SubscriptionService, SubscriptionServiceWithMetrics, ZuoraSubscriptionService}
-import software.amazon.awssdk.auth.credentials.{AwsCredentialsProviderChain, EnvironmentVariableCredentialsProvider, InstanceProfileCredentialsProvider, ProfileCredentialsProvider}
+import software.amazon.awssdk.auth.credentials.{
+  AwsCredentialsProviderChain,
+  EnvironmentVariableCredentialsProvider,
+  InstanceProfileCredentialsProvider,
+  ProfileCredentialsProvider,
+}
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.dynamodb.{DynamoDbAsyncClient, DynamoDbAsyncClientBuilder}
 

--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -138,7 +138,9 @@ class AccountController(
             .leftMap(CancelError(_, 404))
           sfSub <- EitherT
             .fromEither(
-              tp.subscriptionService.current[P](sfContact).map(subs => subscriptionSelector(Some(subscriptionName), s"Salesforce user $sfContact")(subs)),
+              tp.subscriptionService
+                .current[P](sfContact)
+                .map(subs => subscriptionSelector(Some(subscriptionName), s"Salesforce user $sfContact")(subs)),
             )
             .leftMap(CancelError(_, 404))
           accountId <- EitherT.fromEither(

--- a/membership-attribute-service/app/services/subscription/SubscriptionService.scala
+++ b/membership-attribute-service/app/services/subscription/SubscriptionService.scala
@@ -83,5 +83,3 @@ trait SubscriptionService {
       today: LocalDate = LocalDate.now(),
   ): EitherT[String, Future, Option[LocalDate]]
 }
-
-

--- a/membership-attribute-service/app/services/subscription/SubscriptionTransform.scala
+++ b/membership-attribute-service/app/services/subscription/SubscriptionTransform.scala
@@ -19,8 +19,6 @@ import scalaz.syntax.std.option._
 import scala.language.higherKinds
 import scala.util.Try
 
-
-
 // this is (all?) the testable stuff without mocking needed
 // we should make the subscription service just getting the json, and then we can have testable pure functions here
 object SubscriptionTransform {

--- a/membership-attribute-service/app/wiring/AppLoader.scala
+++ b/membership-attribute-service/app/wiring/AppLoader.scala
@@ -21,7 +21,14 @@ import play.filters.csrf.CSRFComponents
 import router.Routes
 import services.salesforce.ContactRepository
 import services.subscription.SubscriptionService
-import services.{BasicStripeService, ContributionsStoreDatabaseService, HealthCheckableService, MobileSubscriptionServiceImpl, PostgresDatabaseService, SupporterProductDataService}
+import services.{
+  BasicStripeService,
+  ContributionsStoreDatabaseService,
+  HealthCheckableService,
+  MobileSubscriptionServiceImpl,
+  PostgresDatabaseService,
+  SupporterProductDataService,
+}
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/membership-attribute-service/test/acceptance/AccountControllerAcceptanceTest.scala
+++ b/membership-attribute-service/test/acceptance/AccountControllerAcceptanceTest.scala
@@ -1,7 +1,16 @@
 package acceptance
 
 import acceptance.data.stripe.{TestCustomersPaymentMethods, TestDynamoSupporterRatePlanItem, TestStripeSubscription}
-import acceptance.data.{IdentityResponse, TestAccountSummary, TestCatalog, TestContact, TestPaidSubscriptionPlan, TestPaymentSummary, TestQueriesAccount, TestSubscription}
+import acceptance.data.{
+  IdentityResponse,
+  TestAccountSummary,
+  TestCatalog,
+  TestContact,
+  TestPaidSubscriptionPlan,
+  TestPaymentSummary,
+  TestQueriesAccount,
+  TestSubscription,
+}
 import com.gu.i18n.Currency
 import com.gu.memsub.subsv2.services.CatalogService
 import com.gu.memsub.subsv2.{CovariantNonEmptyList, SubscriptionPlan}
@@ -27,7 +36,13 @@ import services.{
   SupporterRatePlanToAttributesMapper,
 }
 import services.subscription.SubscriptionService
-import services.{BasicStripeService, ContributionsStoreDatabaseService, HealthCheckableService, SupporterProductDataService, SupporterRatePlanToAttributesMapper}
+import services.{
+  BasicStripeService,
+  ContributionsStoreDatabaseService,
+  HealthCheckableService,
+  SupporterProductDataService,
+  SupporterRatePlanToAttributesMapper,
+}
 import utils.SimpleEitherT
 import wiring.MyComponents
 


### PR DESCRIPTION
This was part of the Teamcity build but seems to have been overlooked in the move to GHA.

See https://scalameta.org/scalafmt/docs/installation.html#task-keys for details.