### PR TITLE
WIP: Remove redundant zuora call

### DIFF
--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -152,7 +152,8 @@ class TouchpointComponents(
     }
 
   lazy val subscriptionService: SubscriptionService = {
-    lazy val zuoraSubscriptionService = new ZuoraSubscriptionService(productIds, futureCatalog, zuoraRestClient, zuoraSoapService.getAccountIds)
+    lazy val zuoraSubscriptionService =
+      new ZuoraSubscriptionService(productIds, futureCatalog, zuoraRestClient, zuoraSoapService.getAccounts(_).map(_.toList))
 
     subscriptionServiceOverride.getOrElse(
       new SubscriptionServiceWithMetrics(zuoraSubscriptionService, createFineMetrics),

--- a/membership-attribute-service/app/controllers/PaymentUpdateController.scala
+++ b/membership-attribute-service/app/controllers/PaymentUpdateController.scala
@@ -52,7 +52,9 @@ class PaymentUpdateController(commonActions: CommonActions, override val control
           subscription <- EitherT.fromEither(
             tp.subscriptionService
               .current[SubscriptionPlan.AnyPlan](sfUser)
-              .map(subs => subscriptionSelector(Some(memsub.Subscription.Name(subscriptionName)), s"the sfUser $sfUser")(subs)),
+              .map(subs =>
+                subscriptionSelector(Some(memsub.Subscription.Name(subscriptionName)), s"the sfUser $sfUser")(subs.map { case (account, sub) => sub }),
+              ),
           )
           stripeService <- EitherT.fromEither(
             Future
@@ -137,7 +139,9 @@ class PaymentUpdateController(commonActions: CommonActions, override val control
           subscription <- EitherT.fromEither(
             tp.subscriptionService
               .current[SubscriptionPlan.AnyPlan](sfUser)
-              .map(subs => subscriptionSelector(Some(memsub.Subscription.Name(subscriptionName)), s"the sfUser $sfUser")(subs)),
+              .map(subs =>
+                subscriptionSelector(Some(memsub.Subscription.Name(subscriptionName)), s"the sfUser $sfUser")(subs.map { case (account, sub) => sub }),
+              ),
           )
           account <- EitherT.fromEither(
             annotateFailableFuture(tp.zuoraSoapService.getAccount(subscription.accountId), s"get account with id ${subscription.accountId}"),

--- a/membership-attribute-service/app/services/AccountDetailsFromZuora.scala
+++ b/membership-attribute-service/app/services/AccountDetailsFromZuora.scala
@@ -78,7 +78,7 @@ class AccountDetailsFromZuora(
   private def nonGiftContactAndSubscriptionsFor(contact: Contact): Future[List[ContactAndSubscription]] = {
     subscriptionService
       .current[SubscriptionPlan.AnyPlan](contact)
-      .map(_.map(ContactAndSubscription(contact, _, isGiftRedemption = false)))
+      .map(_.map { case (account, sub) => ContactAndSubscription(contact, sub, isGiftRedemption = false) })
   }
 
   private def applyFilter(

--- a/membership-attribute-service/app/services/PaymentService.scala
+++ b/membership-attribute-service/app/services/PaymentService.scala
@@ -145,6 +145,9 @@ class PaymentService(zuoraService: ZuoraSoapService, planMap: Map[ProductRatePla
   override def getPaymentMethod(accountId: AccountId, defaultMandateIdIfApplicable: Option[String] = None): Future[Option[PaymentMethod]] =
     getPaymentMethodByAccountId(accountId).map(_.flatMap(buildPaymentMethod(defaultMandateIdIfApplicable)))
 
+  override def getPaymentMethod(account: Account, defaultMandateIdIfApplicable: Option[String]): Future[Option[PaymentMethod]] =
+    getPaymentMethodByAccount(account).map(_.flatMap(buildPaymentMethod(defaultMandateIdIfApplicable)))
+
   override def getPaymentCard(accountId: AccountId): Future[Option[PaymentCard]] =
     getPaymentMethod(accountId).map(_.collect { case c: PaymentCard => c })
 

--- a/membership-attribute-service/app/services/api/PaymentService.scala
+++ b/membership-attribute-service/app/services/api/PaymentService.scala
@@ -12,6 +12,7 @@ import scala.concurrent.Future
 
 trait PaymentService {
   def getPaymentMethod(accountId: AccountId, defaultMandateIdIfApplicable: Option[String] = None): Future[Option[PaymentMethod]]
+  def getPaymentMethod(account: Account, defaultMandateIdIfApplicable: Option[String]): Future[Option[PaymentMethod]]
   def getPaymentCard(accountId: AccountId): Future[Option[PaymentCard]]
   @Deprecated def setPaymentCardWithStripeToken(
       accountId: AccountId,

--- a/membership-attribute-service/app/services/subscription/SubscriptionServiceWithMetrics.scala
+++ b/membership-attribute-service/app/services/subscription/SubscriptionServiceWithMetrics.scala
@@ -6,6 +6,7 @@ import com.gu.memsub.subsv2.Subscription
 import com.gu.memsub.subsv2.SubscriptionPlan.{AnyPlan, Contributor}
 import com.gu.memsub.subsv2.reads.SubPlanReads
 import com.gu.salesforce.ContactId
+import com.gu.zuora.soap.models.Queries.Account
 import monitoring.CreateMetrics
 import org.joda.time.{LocalDate, LocalTime}
 import play.api.libs.json.JsValue
@@ -21,21 +22,21 @@ class SubscriptionServiceWithMetrics(wrapped: SubscriptionService, createMetrics
   override def get[P <: AnyPlan: SubPlanReads](name: memsub.Subscription.Name, isActiveToday: Boolean): Future[Option[Subscription[P]]] =
     metrics.measureDuration("get")(wrapped.get(name, isActiveToday))
 
-  override def current[P <: AnyPlan: SubPlanReads](contact: ContactId): Future[List[Subscription[P]]] =
+  override def current[P <: AnyPlan: SubPlanReads](contact: ContactId): Future[List[(Account, Subscription[P])]] =
     metrics.measureDuration("current")(wrapped.current(contact))
 
-  override def since[P <: AnyPlan: SubPlanReads](onOrAfter: LocalDate)(contact: ContactId): Future[List[Subscription[P]]] =
+  override def since[P <: AnyPlan: SubPlanReads](onOrAfter: LocalDate)(contact: ContactId): Future[List[(Account, Subscription[P])]] =
     metrics.measureDuration("since")(wrapped.since(onOrAfter)(contact))
 
   override def recentlyCancelled(contact: ContactId, today: LocalDate, lastNMonths: Int)(implicit
       ev: SubPlanReads[AnyPlan],
-  ): Future[String \/ List[Subscription[AnyPlan]]] =
+  ): Future[String \/ List[(Account, Subscription[AnyPlan])]] =
     metrics.measureDuration("recentlyCancelled")(wrapped.recentlyCancelled(contact, today, lastNMonths))
 
   override def subscriptionsForAccountId[P <: AnyPlan: SubPlanReads](accountId: AccountId): Future[Disjunction[String, List[Subscription[P]]]] =
     metrics.measureDuration("subscriptionsForAccountId")(wrapped.subscriptionsForAccountId(accountId))
 
-  override def jsonSubscriptionsFromContact(contact: ContactId): Future[Disjunction[String, List[JsValue]]] =
+  override def jsonSubscriptionsFromContact(contact: ContactId): Future[Disjunction[String, List[(Account, JsValue)]]] =
     metrics.measureDuration("jsonSubscriptionsFromContact")(wrapped.jsonSubscriptionsFromContact(contact))
 
   override def jsonSubscriptionsFromAccount(accountId: AccountId): Future[Disjunction[String, List[JsValue]]] =
@@ -45,10 +46,13 @@ class SubscriptionServiceWithMetrics(wrapped: SubscriptionService, createMetrics
     */
   override def either[FALLBACK <: AnyPlan, PREFERRED <: AnyPlan](
       contact: ContactId,
-  )(implicit a: SubPlanReads[FALLBACK], b: SubPlanReads[PREFERRED]): Future[String \/ Option[Subscription[FALLBACK] \/ Subscription[PREFERRED]]] =
+  )(implicit
+      a: SubPlanReads[FALLBACK],
+      b: SubPlanReads[PREFERRED],
+  ): Future[String \/ Option[(Account, Subscription[FALLBACK] \/ Subscription[PREFERRED])]] =
     metrics.measureDuration("eitherByContact")(wrapped.either(contact))
 
-  override def getSubscription(contact: ContactId)(implicit a: SubPlanReads[Contributor]): Future[Option[Subscription[Contributor]]] =
+  override def getSubscription(contact: ContactId)(implicit a: SubPlanReads[Contributor]): Future[Option[(Account, Subscription[Contributor])]] =
     metrics.measureDuration("getSubscription")(wrapped.getSubscription(contact))
 
   /** find the current subscription for the given subscription number TODO get rid of this and use pattern matching instead

--- a/membership-attribute-service/test/acceptance/AccountControllerAcceptanceTest.scala
+++ b/membership-attribute-service/test/acceptance/AccountControllerAcceptanceTest.scala
@@ -142,9 +142,10 @@ class AccountControllerAcceptanceTest extends AcceptanceTest {
 
       val nonGiftSubscription = TestSubscription()
       val nonGiftSubscriptionAccountId = nonGiftSubscription.accountId
+      val nonGiftQueriesAccount = TestQueriesAccount(id = nonGiftSubscriptionAccountId.get)
 
       subscriptionServiceMock.current[SubscriptionPlan.AnyPlan](contact)(any) returns
-        Future(List(nonGiftSubscription))
+        Future(List((nonGiftQueriesAccount, nonGiftSubscription)))
 
       val giftSubscriptionFromSubscriptionService = TestSubscription(
         id = Subscription.Id(giftSubscription.Id),
@@ -166,7 +167,7 @@ class AccountControllerAcceptanceTest extends AcceptanceTest {
       zuoraRestServiceMock.getCancellationEffectiveDate(nonGiftSubscription.name) returns Future(\/.right(None))
 
       zuoraSoapServiceMock.getPaymentSummary(nonGiftSubscription.name, Currency.GBP) returns Future(TestPaymentSummary())
-      zuoraSoapServiceMock.getAccount(nonGiftSubscriptionAccountId) returns Future(TestQueriesAccount())
+      zuoraSoapServiceMock.getAccount(nonGiftSubscriptionAccountId) returns Future(nonGiftQueriesAccount)
 
       val patronSubscription = TestDynamoSupporterRatePlanItem(
         identityId = "200067388",


### PR DESCRIPTION
When finding existing payment methods, the code currently calls zuora twice for account details: the first time to turn a contact ID into an account ID (throwing away the rest of the account details in the process), and the second time to get the account details again.

This change surfaces the account details from the first call within ExistingPaymentOptionsController, and then removes the second call: the hope is that removing an unnecessary call to zuora will speed up the endpoint.

A couple of other places in the code also turn a contact ID into an account ID in the same way: I haven’t yet checked whether they can avoid a later call. For at least one of them, the later call is to zuora’s rest API, which seems to return slightly more info – if any of that info is used this would mean the call can’t be avoided, though perhaps the soap call could be replaced by an up-front rest call.