### PR TITLE
Upgrade to ubuntu jammy

### DIFF
--- a/membership-attribute-service/conf/riff-raff.yaml
+++ b/membership-attribute-service/conf/riff-raff.yaml
@@ -7,7 +7,7 @@ deployments:
     parameters:
       templatePath: membership-attribute-service.yaml
       amiTags:
-        Recipe: bionic-membership-ARM
+        Recipe: jammy-membership-java8
         AmigoStage: PROD
       amiEncrypted: true
       amiParameter: AmiId


### PR DESCRIPTION
Ubuntu Bionic is approaching end of life. This PR updates the metering api to use an AMI based on Jammy.

Tested in CODE