### PR TITLE
Use unified cloudwatch agent for logging

### DIFF
--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -234,7 +234,7 @@ Resources:
               chown membership-attribute-service /etc/gu/members-data-api.private.conf
               chmod 0600 /etc/gu/members-data-api.private.conf
               
-              /opt/cloudwatch-logs/configure-logs application ${Stack} ${Stage} members-data-api /var/log/membership-attribute-service/membership-attribute-service.log`;
+              /opt/cloudwatch-logs/configure-logs application membership ${Stage} members-data-api /var/log/membership-attribute-service/membership-attribute-service.log`;
             - {}
   LoadBalancerSecurityGroup:
     Type: AWS::EC2::SecurityGroup

--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -233,12 +233,8 @@ Resources:
               aws --region ${AWS::Region} s3 cp s3://gu-reader-revenue-private/membership/members-data-api/${Stage}/members-data-api.private.conf /etc/gu
               chown membership-attribute-service /etc/gu/members-data-api.private.conf
               chmod 0600 /etc/gu/members-data-api.private.conf
-
-              wget https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py
-              sed -i -e "s/__DATE/$(date +%F)/" -e 's/__STAGE/${Stage}/' $CONF_DIR/logger.conf
-              python awslogs-agent-setup.py -nr ${AWS::Region} -c $CONF_DIR/logger.conf
-              systemctl enable awslogs
-              systemctl start awslogs
+              
+              /opt/cloudwatch-logs/configure-logs application ${Stack} ${Stage} members-data-api /var/log/membership-attribute-service/membership-attribute-service.log`;
             - {}
   LoadBalancerSecurityGroup:
     Type: AWS::EC2::SecurityGroup

--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -234,7 +234,7 @@ Resources:
               chown membership-attribute-service /etc/gu/members-data-api.private.conf
               chmod 0600 /etc/gu/members-data-api.private.conf
               
-              /opt/cloudwatch-logs/configure-logs application membership ${Stage} members-data-api /var/log/membership-attribute-service/membership-attribute-service.log`;
+              /opt/cloudwatch-logs/configure-logs application membership ${Stage} members-data-api /var/log/membership-attribute-service/membership-attribute-service.log;
             - {}
   LoadBalancerSecurityGroup:
     Type: AWS::EC2::SecurityGroup

--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -234,7 +234,7 @@ Resources:
               chown membership-attribute-service /etc/gu/members-data-api.private.conf
               chmod 0600 /etc/gu/members-data-api.private.conf
               
-              /opt/cloudwatch-logs/configure-logs application membership ${Stage} members-data-api /var/log/membership-attribute-service/membership-attribute-service.log;
+              /opt/cloudwatch-logs/configure-logs application members ${Stage} data-api /var/log/membership-attribute-service/membership-attribute-service.log;
             - {}
   LoadBalancerSecurityGroup:
     Type: AWS::EC2::SecurityGroup

--- a/membership-attribute-service/conf/logger.conf
+++ b/membership-attribute-service/conf/logger.conf
@@ -1,8 +1,0 @@
-[general]
-state_file = /var/awslogs/agent-state
-
-[membership-attribute-service]
-file = /var/log/membership-attribute-service/membership-attribute-service.log
-log_group_name = members-data-api-__STAGE
-log_stream_name = __DATE/{instance_id}/membership-attribute-service.log
-datetime_format = %Y-%m-%d %H:%M-%S


### PR DESCRIPTION
The [previous PR](https://github.com/guardian/members-data-api/pull/935) changed the ami.
This broke cloudwatch logs, as we now need to use the 'unified cloudwatch agent'.
See https://github.com/guardian/amigo/blob/85ffa1e080368ef56ecb55f0a7825127db1b571e/roles/cloud-watch-agent-logs/README.md