### PR TITLE
Adding support for single_contribution rate plan id to SupporterRatePlanToAttributesMapper

### DIFF
--- a/membership-attribute-service/app/services/SupporterRatePlanToAttributesMapper.scala
+++ b/membership-attribute-service/app/services/SupporterRatePlanToAttributesMapper.scala
@@ -186,6 +186,7 @@ object SupporterRatePlanToAttributesMapper {
       "2c92a0f9479fb46d0147d0155bf9557a",
       "2c92a0f9479fb46d0147d0155c245581",
     ) -> memberTransformer(Patron),
+    List("single_contribution") -> singleContributionTransformer(),
   )
 
   private val uatMappings: Map[List[ProductRatePlanId], AttributeTransformer] = Map(
@@ -276,6 +277,7 @@ object SupporterRatePlanToAttributesMapper {
       "2c92c0f848f362750148f4c2726079d5",
       "2c92c0f848f362750148f4c2724679d3",
     ) -> memberTransformer(Patron),
+    List("single_contribution") -> singleContributionTransformer(),
   )
 
   private val devMappings: Map[List[ProductRatePlanId], AttributeTransformer] = Map(
@@ -366,6 +368,7 @@ object SupporterRatePlanToAttributesMapper {
       "2c92c0f845fed48301460578277167c3",
       "2c92c0f9471e145d01471ffd7c304df9",
     ) -> memberTransformer(Patron),
+    List("single_contribution") -> singleContributionTransformer(),
   )
 
   val productRatePlanMappings: Map[Stage, Map[ProductRatePlanId, AttributeTransformer]] =
@@ -379,6 +382,9 @@ object SupporterRatePlanToAttributesMapper {
     map.flatMap { case (list, value) =>
       list.map(_ -> value)
     }
+
+  def singleContributionTransformer(): AttributeTransformer = (attributes: Attributes, item: DynamoSupporterRatePlanItem) =>
+    attributes.copy(OneOffContributionDate = Some(item.contractEffectiveDate))
 
   def memberTransformer(tier: MembershipTier): AttributeTransformer = (attributes: Attributes, _: DynamoSupporterRatePlanItem) =>
     attributes.copy(Tier = getMostValuableTier(tier, attributes.Tier))

--- a/membership-attribute-service/test/services/SupporterRatePlanToAttributesMapperTest.scala
+++ b/membership-attribute-service/test/services/SupporterRatePlanToAttributesMapperTest.scala
@@ -13,16 +13,17 @@ class SupporterRatePlanToAttributesMapperTest extends Specification {
   val identityId = "999"
   val termEndDate = LocalDate.now().plusDays(5)
 
-  def ratePlanItem(ratePlanId: String, termEndDate: LocalDate = termEndDate) = DynamoSupporterRatePlanItem(
-    identityId,
-    "some-rate-plan-id",
-    ratePlanId,
-    termEndDate,
-    LocalDate.now(),
-    cancellationDate = None,
-    contributionCurrency = None,
-    contributionAmount = None,
-  )
+  def ratePlanItem(ratePlanId: String, termEndDate: LocalDate = termEndDate, contractEffectiveDate: LocalDate = LocalDate.now()) =
+    DynamoSupporterRatePlanItem(
+      identityId,
+      "some-rate-plan-id",
+      ratePlanId,
+      termEndDate,
+      contractEffectiveDate,
+      cancellationDate = None,
+      contributionCurrency = None,
+      contributionAmount = None,
+    )
 
   "SupporterRatePlanToAttributesMapper" should {
     "identify a Guardian Patron" in {
@@ -73,6 +74,19 @@ class SupporterRatePlanToAttributesMapperTest extends Specification {
           ),
         ),
         _ should beSome.which(_.RecurringContributionPaymentPlan should beSome("Annual Contribution")),
+      )
+    }
+
+    "identify an single contribution" in {
+      val contributionDate = new LocalDate(2023, 1, 1)
+      val item = ratePlanItem("single_contribution", contractEffectiveDate = contributionDate)
+      testMapper(
+        Map(
+          "PROD" -> List(item),
+          "UAT" -> List(item),
+          "DEV" -> List(item),
+        ),
+        _ should beSome.which(_.OneOffContributionDate should beSome(new LocalDate(2023, 1, 1))),
       )
     }
 


### PR DESCRIPTION
OneOffContributionDate attribute is now set using DynamoDb data.
The plan is to remove the call to postgres fetching that data in the future (when we're sure dynamo has the same data as Postgres).
Stops the "Unsupported rate plan id" alarm from going off.