### PR TITLE
Log path + user-agent for OktaValidationErrors

### DIFF
--- a/membership-attribute-service/app/services/IdentityAuthService.scala
+++ b/membership-attribute-service/app/services/IdentityAuthService.scala
@@ -30,7 +30,10 @@ class IdentityAuthService(identityPlayAuthService: IdentityPlayAuthService[UserF
               SafeLogger.warn(s"could not validate okta token - $validationError")
               Left(Forbidden)
             case OktaValidationError(originalException) =>
-              SafeLogger.warn(s"could not validate okta token - $validationError. Path: ${requestHeader.path}. User-Agent: ${requestHeader.headers.get("User-Agent")}", originalException)
+              SafeLogger.warn(
+                s"could not validate okta token - $validationError. Path: ${requestHeader.path}. User-Agent: ${requestHeader.headers.get("User-Agent")}",
+                originalException,
+              )
               Left(Unauthorised)
             case _ =>
               SafeLogger.warn(s"could not validate okta token - $validationError")

--- a/membership-attribute-service/app/services/IdentityAuthService.scala
+++ b/membership-attribute-service/app/services/IdentityAuthService.scala
@@ -30,7 +30,7 @@ class IdentityAuthService(identityPlayAuthService: IdentityPlayAuthService[UserF
               SafeLogger.warn(s"could not validate okta token - $validationError")
               Left(Forbidden)
             case OktaValidationError(originalException) =>
-              SafeLogger.warn(s"could not validate okta token - $validationError", originalException)
+              SafeLogger.warn(s"could not validate okta token - $validationError. Path: ${requestHeader.path}. User-Agent: ${requestHeader.headers.get("User-Agent")}", originalException)
               Left(Unauthorised)
             case _ =>
               SafeLogger.warn(s"could not validate okta token - $validationError")


### PR DESCRIPTION
We've seen a big increase in 4XX responses caused by this error. Each has the cause:
`Caused by: io.jsonwebtoken.ExpiredJwtException: JWT expired at 2023-03-19T22:37:33Z`