### PR TITLE
Removing name from LaunchConfiguration in CloudFormation so it can be updated

### DIFF
--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -216,7 +216,6 @@ Resources:
   LaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
-      LaunchConfigurationName: !Sub members-data-api-${Stage}
       ImageId:
         Ref: AmiId
       SecurityGroups:


### PR DESCRIPTION
Removing name from LaunchConfiguration in CloudFormation so it can be updated
Fix for previous PR that broke CloudFormation.