### PR TITLE
Serving first and last name from SalesForce rather than Identity in /me/mma

### DIFF
--- a/membership-attribute-service/app/models/ProductsResponse.scala
+++ b/membership-attribute-service/app/models/ProductsResponse.scala
@@ -1,5 +1,6 @@
 package models
 
+import com.gu.salesforce.Contact
 import play.api.libs.json._
 
 case class UserDetails(firstName: Option[String], lastName: Option[String], email: String)
@@ -11,11 +12,11 @@ object ProductsResponse {
   implicit val accountDetailsWrites = Writes[AccountDetails](_.toJson)
   implicit val writes = Json.writes[ProductsResponse]
 
-  def from(user: UserFromToken, products: List[AccountDetails]) =
+  def from(user: UserFromToken, contact: Contact, products: List[AccountDetails]) =
     ProductsResponse(
       user = UserDetails(
-        firstName = user.firstName,
-        lastName = user.lastName,
+        firstName = contact.firstName,
+        lastName = Some(contact.lastName).filterNot(_.isEmpty),
         email = user.primaryEmailAddress,
       ),
       products = products,

--- a/membership-attribute-service/test/acceptance/AccountControllerAcceptanceTest.scala
+++ b/membership-attribute-service/test/acceptance/AccountControllerAcceptanceTest.scala
@@ -124,7 +124,11 @@ class AccountControllerAcceptanceTest extends AcceptanceTest {
             ),
         )
 
-      val contact = TestContact(identityId = "200067388")
+      val contact = TestContact(
+        identityId = "200067388",
+        firstName = Some("James"),
+        lastName = "Cromwell",
+      )
 
       contactRepositoryMock.get("200067388") returns Future(\/.right(Some(contact)))
 
@@ -224,8 +228,8 @@ class AccountControllerAcceptanceTest extends AcceptanceTest {
       identityMockClientAndServer.verify(redirectAdviceRequest)
       identityMockClientAndServer.verify(identityRequest)
 
-      (json \ "user" \ "firstName").as[String] shouldEqual "Frank"
-      (json \ "user" \ "lastName").as[String] shouldEqual "Poole"
+      (json \ "user" \ "firstName").as[String] shouldEqual "James"
+      (json \ "user" \ "lastName").as[String] shouldEqual "Cromwell"
       (json \ "user" \ "email").as[String] shouldEqual "frank.poole@amail.com"
 
       val productsArray = (json \ "products").as[JsArray].value


### PR DESCRIPTION
Serving first and last name from SalesForce rather than Identity in /me/mma, since first and last name are not yet available in identity response.