### PR TITLE
Fix productIsInstanceOfProductType for SupporterPlus

### DIFF
--- a/membership-attribute-service/app/services/AccountDetailsFromZuora.scala
+++ b/membership-attribute-service/app/services/AccountDetailsFromZuora.scala
@@ -204,6 +204,7 @@ class AccountDetailsFromZuora(
       case _: Product.Contribution => requestedProductType == "Contribution"
       case _: Product.Membership => requestedProductType == "Membership"
       case _: Product.ZDigipack => requestedProductType == "Digipack" || requestedProductTypeIsContentSubscription
+      case _: Product.SupporterPlus => requestedProductType == "SupporterPlus" || requestedProductTypeIsContentSubscription
       case _ => requestedProductType == product.name // fallback
     }
   }


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
This PR fixes the product filtering on the /me/mma endpoint for the supporter plus  product `/me/mma?productType=SupporterPlus`
