### PR TITLE
add new endpoint for updating subscription cancellation reason in Zuora

### DIFF
--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -379,6 +379,7 @@ class AccountController(
   def updateCancellationReason(subscriptionName: String): Action[AnyContent] =
     AuthorizeForScopes(requiredScopes = List(readSelf, updateSelf)).async { implicit request =>
       metrics.measureDuration("POST /user-attributes/me/update-cancellation-reason/:subscriptionName") {
+        val subName = memsub.Subscription.Name(subscriptionName)
         val services = request.touchpoint
         val cancelForm = Form {
           single("reason" -> nonEmptyText)
@@ -388,7 +389,7 @@ class AccountController(
 
         cancellationReasonEither match {
           case Right(cancellationReason) =>
-            services.zuoraRestService.updateCancellationReason(subscriptionName, cancellationReason).map {
+            services.zuoraRestService.updateCancellationReason(subName, cancellationReason).map {
               case -\/(error) =>
                 logError(scrub"Failed to update cancellation reason for user $identityId because $error")
                 InternalServerError(s"Failed to update cancellation reason with error: $error")

--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -376,6 +376,32 @@ class AccountController(
   def cancelSpecificSub(subscriptionName: String): Action[AnyContent] =
     cancelSubscription[SubscriptionPlan.AnyPlan](memsub.Subscription.Name(subscriptionName))
 
+  def updateCancellationReason(subscriptionName: String): Action[AnyContent] =
+    AuthorizeForScopes(requiredScopes = List(readSelf, updateSelf)).async { implicit request =>
+      metrics.measureDuration("POST /user-attributes/me/update-cancellation-reason/:subscriptionName") {
+        val services = request.touchpoint
+        val cancelForm = Form {
+          single("reason" -> nonEmptyText)
+        }
+        val identityId = request.user.identityId
+        val cancellationReasonEither = extractCancellationReason(cancelForm)
+
+        cancellationReasonEither match {
+          case Right(cancellationReason) =>
+            services.zuoraRestService.updateCancellationReason(subscriptionName, cancellationReason).map {
+              case -\/(error) =>
+                logError(scrub"Failed to update cancellation reason for user $identityId because $error")
+                InternalServerError(s"Failed to update cancellation reason with error: $error")
+              case \/-(_) =>
+                logger.info(s"Successfully updated cancellation reason for subscription $subscriptionName owned by $identityId")
+                NoContent
+            }
+          case Left(apiError) =>
+            Future.successful(BadRequest(Json.toJson(apiError)))
+        }
+      }
+    }
+
   def decideCancellationEffectiveDate(subscriptionName: String): Action[AnyContent] =
     getCancellationEffectiveDate[SubscriptionPlan.AnyPlan](memsub.Subscription.Name(subscriptionName))
 

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -10,6 +10,7 @@ GET         /user-attributes/me/mma/:subscriptionName                           
 POST        /user-attributes/me/cancel/:subscriptionName                        controllers.AccountController.cancelSpecificSub(subscriptionName: String)
 GET         /user-attributes/me/cancellation-date/:subscriptionName             controllers.AccountController.decideCancellationEffectiveDate(subscriptionName: String)
 GET         /user-attributes/me/cancelled-subscriptions                         controllers.AccountController.cancelledSubscriptions()
+POST        /user-attributes/me/update-cancellation-reason/:subscriptionName    controllers.AccountController.updateCancellationReason(subscriptionName: String)
 
 GET         /user-attributes/me/reminders                                       controllers.AccountController.reminders
 


### PR DESCRIPTION
This PR introduces a new endpoint in the AccountController that updates the cancellation reason in Zuora. This is part of the new cancellation saves work, which allows customers to optionally select the reason for cancelling at the end of the journey, after the cancellation is complete.

Previously, customers had to select the cancellation reason before cancelling. When confirming the cancellation, the reason would be sent to the API, which would perform both the reason update and cancellation. Now, these two actions must be done separately.

[frontend PR here](https://github.com/guardian/manage-frontend/pull/1123)

- [x] Tested in CODE