### PR TITLE
Fix bug where all charges have monthly billing period

### DIFF
--- a/membership-common/src/main/scala/com/gu/memsub/subsv2/Plan.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/subsv2/Plan.scala
@@ -60,7 +60,16 @@ object EndDateCondition {
   implicit val reads: Reads[EndDateCondition] = ZuoraEnum.getReads(values, "invalid end date condition value")
 }
 
-sealed trait ZBillingPeriod extends ZuoraEnum
+sealed trait ZBillingPeriod extends ZuoraEnum {
+  def toBillingPeriod: BillingPeriod = this match {
+    case ZYear => Year
+    case ZTwoYears => TwoYears
+    case ZThreeYears => ThreeYears
+    case ZMonth => Month
+    case ZQuarter => Quarter
+    case  _ => throw new IllegalArgumentException("Zuora billing period not supported")
+  }
+}
 
 case object ZYear extends ZBillingPeriod {
   override val id = "Annual"

--- a/membership-common/src/main/scala/com/gu/memsub/subsv2/reads/ChargeListReads.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/subsv2/reads/ChargeListReads.scala
@@ -140,8 +140,8 @@ object ChargeListReads {
   implicit def readPaidChargeList: ChargeListReads[PaidChargeList] = new ChargeListReads[PaidChargeList] {
     def read(cat: PlanChargeMap, charges: List[ZuoraCharge]): ValidationNel[String, PaidChargeList] = {
       readPaperChargeList.read(cat, charges).map(identity[PaidChargeList]) orElse2
-        readPaidCharge[Benefit, BillingPeriod](readAnyProduct, anyBpReads).read(cat, charges) orElse2
-        readSupporterPlusV2ChargeList.read(cat, charges).map(identity[PaidChargeList])
+      readPaidCharge[Benefit, BillingPeriod](readAnyProduct, anyBpReads).read(cat, charges) orElse2
+      readSupporterPlusV2ChargeList.read(cat, charges)
     }.withTrace("readPaidChargeList")
   }
 

--- a/membership-common/src/main/scala/com/gu/memsub/subsv2/reads/ChargeListReads.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/subsv2/reads/ChargeListReads.scala
@@ -140,8 +140,8 @@ object ChargeListReads {
   implicit def readPaidChargeList: ChargeListReads[PaidChargeList] = new ChargeListReads[PaidChargeList] {
     def read(cat: PlanChargeMap, charges: List[ZuoraCharge]): ValidationNel[String, PaidChargeList] = {
       readPaperChargeList.read(cat, charges).map(identity[PaidChargeList]) orElse2
-        readSupporterPlusV2ChargeList.read(cat, charges).map(identity[PaidChargeList]) orElse2
-        readPaidCharge[Benefit, BillingPeriod](readAnyProduct, anyBpReads).read(cat, charges)
+        readPaidCharge[Benefit, BillingPeriod](readAnyProduct, anyBpReads).read(cat, charges) orElse2
+        readSupporterPlusV2ChargeList.read(cat, charges).map(identity[PaidChargeList])
     }.withTrace("readPaidChargeList")
   }
 

--- a/membership-common/src/test/scala/com/gu/memsub/subsv2/services/CatalogServiceTest.scala
+++ b/membership-common/src/test/scala/com/gu/memsub/subsv2/services/CatalogServiceTest.scala
@@ -1,5 +1,6 @@
 package com.gu.memsub.subsv2.services
 import com.gu.config.SubsV2ProductIds
+import com.gu.memsub.BillingPeriod.Year
 import com.gu.memsub.Subscription.ProductId
 import com.gu.zuora.ZuoraRestConfig
 import com.gu.zuora.rest.SimpleClient
@@ -9,7 +10,6 @@ import com.gu.memsub.subsv2.Fixtures._
 import io.lemonlabs.uri.dsl._
 import com.typesafe.config.ConfigFactory
 import utils.Resource
-
 import scalaz.Id._
 import scalaz.\/
 
@@ -21,7 +21,12 @@ class CatalogServiceTest extends Specification {
       val dev = ConfigFactory.parseResources("touchpoint.CODE.conf")
       val ids = SubsV2ProductIds(dev.getConfig("touchpoint.backend.environments.CODE.zuora.productIds"))
       val cats = new CatalogService[Id](ids, FetchCatalog.fromZuoraApi(CatalogServiceTest.client("rest/Catalog.json")), identity, "CODE")
-      cats.catalog.map(catalog => catalog.supporterPlus.plans.size) mustEqual \/.right(2)
+      cats.catalog.map {
+        catalog =>
+          catalog.supporterPlus.year.charges.billingPeriod mustEqual Year
+          catalog.supporterPlus.plans.size
+      } mustEqual \/.right(2)
+
     }
   }
 }


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
#1028 had a bug which hard coded the billing period of the charge lists attached to subscriptions to be monthly. 
This meant that the billing period displayed in MMA was incorrect for annual subscriptions as shown here:
![mma-bug](https://github.com/guardian/members-data-api/assets/181371/e806b8e3-b58f-4c01-b5f8-5b06f6dec22f)
Due to the incorrect mdapi response here:
![mdapi-bug](https://github.com/guardian/members-data-api/assets/181371/38172bc4-68fc-421f-a733-184bdc5f1785)

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
This PR changes the serialisation of charge lists to take the billing period from the catalog
