### PR TITLE
Handle all relevant `ZBillingPeriod`

### DIFF
--- a/membership-common/src/main/scala/com/gu/memsub/subsv2/Plan.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/subsv2/Plan.scala
@@ -61,12 +61,15 @@ object EndDateCondition {
 
 sealed trait ZBillingPeriod extends ZuoraEnum {
   def toBillingPeriod: BillingPeriod = this match {
+    case ZMonth => Month
+    case ZQuarter => Quarter
+    case ZSemiAnnual => SixMonths
     case ZYear => Year
     case ZTwoYears => TwoYears
     case ZThreeYears => ThreeYears
-    case ZMonth => Month
-    case ZQuarter => Quarter
-    case _ => throw new IllegalArgumentException("Zuora billing period not supported")
+    case ZSpecificWeeks => OneTimeChargeBillingPeriod
+    case ZSpecificMonths => OneTimeChargeBillingPeriod
+    case _ => throw new IllegalArgumentException(s"Zuora billing period not supported: ${this.id}")
   }
 }
 

--- a/membership-common/src/main/scala/com/gu/memsub/subsv2/Plan.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/subsv2/Plan.scala
@@ -69,7 +69,7 @@ sealed trait ZBillingPeriod extends ZuoraEnum {
     case ZThreeYears => ThreeYears
     case ZSpecificWeeks => OneTimeChargeBillingPeriod
     case ZSpecificMonths => OneTimeChargeBillingPeriod
-    case _ => throw new IllegalArgumentException(s"Zuora billing period not supported: ${this.id}")
+    case ZWeek => throw new IllegalArgumentException("ZWeek billing period is not supported")
   }
 }
 

--- a/membership-common/src/test/scala/com/gu/memsub/subsv2/reads/CatReadsTest.scala
+++ b/membership-common/src/test/scala/com/gu/memsub/subsv2/reads/CatReadsTest.scala
@@ -68,8 +68,8 @@ class CatReadsTest extends AnyFlatSpec {
             productRatePlanChargeId = ProductRatePlanChargeId("2c92c0f96df75b5a016df81ba1e9260b"),
             pricing = PricingSummary(
               Map(
-                GBP -> Price(60f, GBP),
-                USD -> Price(81.3f, USD),
+                GBP -> Price(74.4f, GBP),
+                USD -> Price(90f, USD),
                 CAD -> Price(86.25f, CAD),
                 AUD -> Price(106.0f, AUD),
                 NZD -> Price(132.5f, NZD),


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
#1030 added a method to map between the `ZBillingPeriod` type and the `BillingPeriod` type but threw an error for unexpected values. 

It turns out that there are a number of these unexpected types in use in production subscriptions which has been causing errors for users. This PR fixes that.

I have tested this by running the tests in the membership-common sub project which are not being run by the main build, these failed in the same was as production before these changes but now pass

### [Trello card](https://trello.com/c/CLI53Yaf/4273-csr-bug-report-case-03658920-03658747-03658868-03658775-sub-a-s01207291-a-s01910890-a-s01281913-a-s01297330-a-s00919651-severity)
