### PR TITLE
Improved validation for readSupporterPlusV2ChargeList

### DIFF
--- a/membership-common/src/main/scala/com/gu/memsub/subsv2/Plan.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/subsv2/Plan.scala
@@ -59,19 +59,7 @@ object EndDateCondition {
   implicit val reads: Reads[EndDateCondition] = ZuoraEnum.getReads(values, "invalid end date condition value")
 }
 
-sealed trait ZBillingPeriod extends ZuoraEnum {
-  def toBillingPeriod: BillingPeriod = this match {
-    case ZMonth => Month
-    case ZQuarter => Quarter
-    case ZSemiAnnual => SixMonths
-    case ZYear => Year
-    case ZTwoYears => TwoYears
-    case ZThreeYears => ThreeYears
-    case ZSpecificWeeks => OneTimeChargeBillingPeriod
-    case ZSpecificMonths => OneTimeChargeBillingPeriod
-    case ZWeek => throw new IllegalArgumentException("ZWeek billing period is not supported")
-  }
-}
+sealed trait ZBillingPeriod extends ZuoraEnum
 
 case object ZYear extends ZBillingPeriod {
   override val id = "Annual"

--- a/membership-common/src/main/scala/com/gu/memsub/subsv2/reads/ChargeListReads.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/subsv2/reads/ChargeListReads.scala
@@ -15,8 +15,6 @@ import scalaz.syntax.std.boolean._
 import scalaz.syntax.std.option._
 import scalaz.Validation.FlatMap._
 
-import scala.util.Try
-
 /** Try to convert a single ZuoraCharge into some type A
   */
 trait ChargeReads[A] {

--- a/membership-common/src/main/scala/com/gu/memsub/subsv2/reads/ChargeListReads.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/subsv2/reads/ChargeListReads.scala
@@ -190,16 +190,17 @@ object ChargeListReads {
 
   implicit def readSupporterPlusV2ChargeList: ChargeListReads[SupporterPlusCharges] = new ChargeListReads[SupporterPlusCharges] {
 
+    def validateBillingPeriod(zBillingPeriod: ZBillingPeriod): ValidationNel[String, BillingPeriod] = zBillingPeriod match {
+      case ZMonth => Validation.success[NonEmptyList[String], BillingPeriod](Month)
+      case ZYear => Validation.success[NonEmptyList[String], BillingPeriod](Year)
+      case _ => Validation.failureNel(s"Supporter plus V2 must have a Monthly or Annual billing period, not $zBillingPeriod")
+    }
+
     def getBillingPeriod(charges: List[ZuoraCharge]): ValidationNel[String, BillingPeriod] = {
       val billingPeriods = charges.flatMap(_.billingPeriod).distinct
       billingPeriods match {
         case Nil => Validation.failureNel("No billing period found")
-        case b :: Nil => Validation
-          .success[NonEmptyList[String], BillingPeriod](b.toBillingPeriod)
-          .ensure(s"Supporter plus V2 must have a Monthly or Annual billing period, not $b".wrapNel) {
-            case Month | Year => true
-            case _ => false
-          }
+        case b :: Nil => validateBillingPeriod(b)
         case _ => Validation.failureNel("Too many billing periods found")
       }
     }


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
The `readSupporterPlusV2ChargeList` ChargeListReads object was quite loose in the type of charges it would match, this PR tightens it up so that it only matches charges with billing periods which are valid for supporter plus subscriptions.