### PR TITLE
Add support for National Delivery product - Part 1

### DIFF
--- a/membership-attribute-service/app/services/SupporterRatePlanToAttributesMapper.scala
+++ b/membership-attribute-service/app/services/SupporterRatePlanToAttributesMapper.scala
@@ -235,9 +235,9 @@ object SupporterRatePlanToAttributesMapper {
       "2c92c0f955c3cf0f0155c5d9ddf13bc5",
       "2c92c0f955c3cf0f0155c5d9e2493c43",
       // National Delivery
-      "8ad096ca8992481d018992a363bd17ad",
-      "8ad096ca8992481d018992a36256175e",
-      "8ad096ca8992481d018992a35f60171b",
+      "8ad096ca8992481d018992a363bd17ad", // Everyday
+      "8ad096ca8992481d018992a36256175e", // Weekend
+      "8ad096ca8992481d018992a35f60171b", // Sixday
     ) -> paperTransformer,
     List(
       "2c92c0f86fa49142016fa49eb1732a39",

--- a/membership-attribute-service/app/services/SupporterRatePlanToAttributesMapper.scala
+++ b/membership-attribute-service/app/services/SupporterRatePlanToAttributesMapper.scala
@@ -113,6 +113,10 @@ object SupporterRatePlanToAttributesMapper {
       "2c92a0fd560d13880156136b72e50f0c",
       "2c92a0ff56fe33f001572334561765c1",
       "2c92a0fd596d321a0159735a7b150e43",
+      // National Delivery
+      "8a12999f8a268c57018a27ebfd721883",
+      "8a12999f8a268c57018a27ebe868150c",
+      "8a12999f8a268c57018a27ebe31414a4",
     ) -> paperTransformer,
     List(
       "2c92a00870ec598001710740ce702ff0",
@@ -230,6 +234,10 @@ object SupporterRatePlanToAttributesMapper {
       "2c92c0f955c3cf0f0155c5d9df433bf7",
       "2c92c0f955c3cf0f0155c5d9ddf13bc5",
       "2c92c0f955c3cf0f0155c5d9e2493c43",
+      // National Delivery
+      "8ad096ca8992481d018992a363bd17ad",
+      "8ad096ca8992481d018992a36256175e",
+      "8ad096ca8992481d018992a35f60171b",
     ) -> paperTransformer,
     List(
       "2c92c0f86fa49142016fa49eb1732a39",

--- a/membership-attribute-service/app/services/SupporterRatePlanToAttributesMapper.scala
+++ b/membership-attribute-service/app/services/SupporterRatePlanToAttributesMapper.scala
@@ -114,9 +114,9 @@ object SupporterRatePlanToAttributesMapper {
       "2c92a0ff56fe33f001572334561765c1",
       "2c92a0fd596d321a0159735a7b150e43",
       // National Delivery
-      "8a12999f8a268c57018a27ebfd721883",
-      "8a12999f8a268c57018a27ebe868150c",
-      "8a12999f8a268c57018a27ebe31414a4",
+      "8a12999f8a268c57018a27ebfd721883", // Sixday
+      "8a12999f8a268c57018a27ebe868150c", // Weekend
+      "8a12999f8a268c57018a27ebe31414a4", // Everyday
     ) -> paperTransformer,
     List(
       "2c92a00870ec598001710740ce702ff0",

--- a/membership-attribute-service/test/services/SupporterRatePlanToAttributesMapperTest.scala
+++ b/membership-attribute-service/test/services/SupporterRatePlanToAttributesMapperTest.scala
@@ -211,6 +211,11 @@ class SupporterRatePlanToAttributesMapperTest extends Specification {
         "2c92a0fd560d13880156136b72e50f0c", // Everyday"
         "2c92a0ff56fe33f001572334561765c1", // Echo-Legacy
         "2c92a0fd596d321a0159735a7b150e43", // Fiveday
+        // National delivery
+        "8a12999f8a268c57018a27ebfd721883", // Sixday
+        "8a12999f8a268c57018a27ebe868150c", // Weekend
+        "8a12999f8a268c57018a27ebe31414a4", // Everyday
+
       )
       possibleProductRatePlanIds.map(productRatePlanId =>
         mapper


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
To support National paper delivery (Paperround) we need to make sure that the `/user-attributes/me` endpoint can recognise customers of this product.

This PR adds mappings for the product rate plans of the new National Delivery product to the SupporterRatePlanToAttributesMapper class so that we can correctly identify subscriptions stored in the SupporterProductData Dynamo store

## [Trello card](https://trello.com/c/MmL9heDE/49-product-build-supporter-product-data-mdapi)