### PR TITLE
Remove deprecated routes

### DIFF
--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -307,7 +307,7 @@ class AccountController(
         val services = request.touchpoint
         val userId = request.user.identityId
         val email = request.user.primaryEmailAddress
-        logger.info(s"Attempting to update contribution amount for ${userId}")
+        logger.info(s"Attempting to update contribution amount for $userId")
         (for {
           newPrice <- SimpleEitherT.fromEither(validateContributionAmountUpdateForm(request))
           user <- SimpleEitherT.right(userId)
@@ -413,24 +413,6 @@ class AccountController(
   def updateAmountForSpecificContribution(subscriptionName: String): Action[AnyContent] = updateContributionAmount(
     Some(memsub.Subscription.Name(subscriptionName)),
   )
-
-  @Deprecated def membershipDetails: Action[AnyContent] =
-    paymentDetails[SubscriptionPlan.PaidMember, SubscriptionPlan.FreeMember]("GET /user-attributes/me/mma-membership")
-
-  @Deprecated def monthlyContributionDetails: Action[AnyContent] = {
-    implicit val nothingReads = SubPlanReads.nothingReads
-    paymentDetails[SubscriptionPlan.Contributor, Nothing]("GET /user-attributes/me/mma-monthlycontribution")
-  }
-
-  @Deprecated def digitalPackDetails: Action[AnyContent] = {
-    implicit val nothingReads = SubPlanReads.nothingReads
-    paymentDetails[SubscriptionPlan.Digipack, Nothing]("GET /user-attributes/me/mma-digitalpack")
-  }
-
-  @Deprecated def paperDetails: Action[AnyContent] = {
-    implicit val nothingReads = SubPlanReads.nothingReads
-    paymentDetails[SubscriptionPlan.PaperPlan, Nothing]("GET /user-attributes/me/mma-paper")
-  }
 
   def allPaymentDetails(productType: Option[String]): Action[AnyContent] =
     anyPaymentDetails(

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -27,10 +27,4 @@ PUT         /user-attributes/me/delivery-address/:contactId                     
 # OLD ENDPOINTS below will be phased out as traffic moves over to the new endpoints above
 GET         /user-attributes/me/membership                              controllers.AttributeController.membership
 GET         /user-attributes/me/features                                controllers.AttributeController.features
-
-GET         /user-attributes/me/mma-digitalpack                         controllers.AccountController.digitalPackDetails
-GET         /user-attributes/me/mma-membership                          controllers.AccountController.membershipDetails
-GET         /user-attributes/me/mma-monthlycontribution                 controllers.AccountController.monthlyContributionDetails
-GET         /user-attributes/me/mma-paper                               controllers.AccountController.paperDetails
-
 POST        /user-attributes/me/contribution-update-amount              controllers.AccountController.contributionUpdateAmount


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
These routes in AccountController have been deprecated for ages (years?). I've checked the cloudwatch metrics and they are never called any more so I'm deleting them