### PR TITLE
Add support for National Delivery product - Part 2

### DIFF
--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -168,67 +168,6 @@ class AccountController(
       }
     }
 
-  @Deprecated
-  private def paymentDetails[P <: SubscriptionPlan.Paid: SubPlanReads, F <: SubscriptionPlan.Free: SubPlanReads](metricName: String) =
-    AuthorizeForScopes(requiredScopes = List(completeReadSelf)).async { implicit request =>
-      metrics.measureDuration(metricName) {
-        DeprecatedRequestLogger.logDeprecatedRequest(request)
-
-        implicit val tp: TouchpointComponents = request.touchpoint
-
-        def getPaymentMethod(id: PaymentMethodId) = tp.zuoraRestService.getPaymentMethod(id.get).map(_.toEither)
-
-        val userId = request.user.identityId
-
-        logger.info(s"Deprecated function called: Attempting to retrieve payment details for identity user: ${userId.mkString}")
-        (for {
-          user <- OptionTEither.some(userId)
-          contact <- OptionTEither(tp.contactRepository.get(user))
-          freeOrPaidSub <- OptionTEither(
-            tp.subscriptionService
-              .either[F, P](contact)
-              .map(_.leftMap(message => s"couldn't read sub from zuora for crmId ${contact.salesforceAccountId} due to $message")),
-          ).map(_.toEither)
-          sub: Subscription[AnyPlan] = freeOrPaidSub.fold(identity, identity)
-          paymentDetails <- OptionTEither.liftOption(tp.paymentService.paymentDetails(\/.fromEither(freeOrPaidSub)).map(Right(_)).recover { case x =>
-            Left(s"error retrieving payment details for subscription: ${sub.name}. Reason: $x")
-          })
-          accountSummary <- OptionTEither.liftOption(tp.zuoraRestService.getAccount(sub.accountId).map(_.toEither).recover { case x =>
-            Left(s"error receiving account summary for subscription: ${sub.name} with account id ${sub.accountId}. Reason: $x")
-          })
-          stripePublicKey = tp.chooseStripe.publicKeyForCountry(accountSummary.billToContact.country)
-          alertText <- OptionTEither.fromFuture(alertText(accountSummary, sub, getPaymentMethod))
-          cancellationEffectiveDate <- OptionTEither.liftOption(tp.zuoraRestService.getCancellationEffectiveDate(sub.name).map(_.toEither))
-          isAutoRenew = sub.autoRenew
-        } yield AccountDetails(
-          contactId = contact.salesforceContactId,
-          regNumber = contact.regNumber,
-          email = accountSummary.billToContact.email,
-          deliveryAddress = None,
-          subscription = sub,
-          paymentDetails = paymentDetails,
-          billingCountry = accountSummary.billToContact.country,
-          stripePublicKey = stripePublicKey.key,
-          accountHasMissedRecentPayments = false,
-          safeToUpdatePaymentMethod = true,
-          isAutoRenew = isAutoRenew,
-          alertText = alertText,
-          accountId = accountSummary.id.get,
-          cancellationEffectiveDate,
-        ).toJson).run.run.map(_.toEither).map {
-          case Right(Some(result)) =>
-            logger.info(s"Successfully retrieved payment details result for identity user: ${userId.mkString}")
-            Ok(result)
-          case Right(None) =>
-            logger.info(s"identity user doesn't exist in SF: ${userId.mkString}")
-            Ok(Json.obj())
-          case Left(message) =>
-            logger.warn(s"Unable to retrieve payment details result for identity user ${userId.mkString} due to $message")
-            InternalServerError("Failed to retrieve payment details due to an internal error")
-        }
-      }
-    }
-
   def reminders: Action[AnyContent] =
     AuthorizeForRecentLogin(Return401IfNotSignedInRecently, requiredScopes = List(completeReadSelf)).async { implicit request =>
       metrics.measureDuration("GET /user-attributes/me/reminders") {

--- a/membership-attribute-service/app/services/AccountDetailsFromZuora.scala
+++ b/membership-attribute-service/app/services/AccountDetailsFromZuora.scala
@@ -201,6 +201,8 @@ class AccountDetailsFromZuora(
         requestedProductType == "DigitalVoucher" || requestedProductType == "Paper" || requestedProductTypeIsContentSubscription
       case _: Product.Delivery =>
         requestedProductType == "HomeDelivery" || requestedProductType == "Paper" || requestedProductTypeIsContentSubscription
+      case _: Product.NationalDelivery =>
+        requestedProductType == "HomeDelivery" || requestedProductType == "Paper" || requestedProductTypeIsContentSubscription
       case _: Product.Contribution => requestedProductType == "Contribution"
       case _: Product.Membership => requestedProductType == "Membership"
       case _: Product.ZDigipack => requestedProductType == "Digipack" || requestedProductTypeIsContentSubscription

--- a/membership-attribute-service/test/integration/AccountDetailsFromZuoraIntegrationTest.scala
+++ b/membership-attribute-service/test/integration/AccountDetailsFromZuoraIntegrationTest.scala
@@ -1,0 +1,46 @@
+package integration
+
+import akka.actor.ActorSystem
+import com.typesafe.config.ConfigFactory
+import components.TouchpointComponents
+import configuration.Stage
+import controllers.AccountHelpers
+import monitoring.CreateNoopMetrics
+import org.specs2.mutable.Specification
+
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.Duration
+
+class AccountDetailsFromZuoraIntegrationTest extends Specification {
+
+  // This is an integration test to run code locally, we don't want it running in CI
+  args(skipAll = true)
+
+  "AccountDetailsFromZuora" should {
+    "fetch a list of subs" in {
+      val result = Await
+        .result(
+          createTouchpointComponents.accountDetailsFromZuora
+            .fetch("200152344", AccountHelpers.NoFilter)
+            .run
+            .map { list =>
+              println(s"Fetched this list: $list")
+              list
+            },
+          Duration.Inf,
+        )
+      result.isRight must_== true
+    }
+  }
+
+  def createTouchpointComponents = {
+    implicit val system = ActorSystem.create()
+    lazy val conf = ConfigFactory.load()
+    new TouchpointComponents(
+      Stage("CODE"),
+      CreateNoopMetrics,
+      conf,
+    )
+  }
+}

--- a/membership-common/conf/touchpoint.CODE.conf
+++ b/membership-common/conf/touchpoint.CODE.conf
@@ -78,6 +78,7 @@ touchpoint.backend.environments {
                     voucher="2c92c0f8555ce5cf01556e7f01281b7e"
                     digitalVoucher="2c92c0f86fa49142016fa49e9b36286d"
                     delivery="2c92c0f955c3cf0f0155c5d9ddc53bc3"
+                    nationalDelivery="8ad096ca8992481d018992a35483159d"
                     digipack="2c92c0f84b786da2014b91d3629b4298"
                     supporterPlus="8ad09fc281de1ce70181de3b23b2363d"
                 }

--- a/membership-common/conf/touchpoint.PROD.conf
+++ b/membership-common/conf/touchpoint.PROD.conf
@@ -63,6 +63,7 @@ touchpoint.backend.environments {
                     voucher="2c92a0fc55a0dc530155dfa5b8dd56c0"
                     digitalVoucher="2c92a00870ec598001710740c3d92eab"
                     delivery="2c92a0ff55a0e4940155dfa589da2591"
+                    nationalDelivery="8a12999f8a268c57018a27ebddab1460"
                     digipack="2c92a0fb4edd70c8014edeaa4ddb21e7"
                     supporterPlus="8a12865b8219d9b4018221061563643f"
                 }

--- a/membership-common/src/main/scala/com/gu/config/SubsV2ProductIds.scala
+++ b/membership-common/src/main/scala/com/gu/config/SubsV2ProductIds.scala
@@ -10,6 +10,7 @@ object SubsV2ProductIds {
     weeklyDomestic = ProductId(config.getString("subscriptions.weeklyDomestic")),
     weeklyRestOfWorld = ProductId(config.getString("subscriptions.weeklyRestOfWorld")),
     delivery = ProductId(config.getString("subscriptions.delivery")),
+    nationalDelivery = ProductId(config.getString("subscriptions.nationalDelivery")),
     voucher = ProductId(config.getString("subscriptions.voucher")),
     digitalVoucher = ProductId(config.getString("subscriptions.digitalVoucher")),
     digipack = ProductId(config.getString("subscriptions.digipack")),

--- a/membership-common/src/main/scala/com/gu/memsub/ProductFamily.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/ProductFamily.scala
@@ -60,6 +60,9 @@ object Product {
   case object Delivery extends Paper {
     val name = "delivery"
   }
+  case object NationalDelivery extends Paper {
+    val name = "nationalDelivery"
+  }
   case object Voucher extends Paper {
     val name = "voucher"
   }
@@ -90,6 +93,7 @@ object Product {
     case SupporterPlus.name => Some(SupporterPlus)
     case Membership.name => Some(Membership)
     case Delivery.name => Some(Delivery)
+    case NationalDelivery.name => Some(NationalDelivery)
     case Voucher.name => Some(Voucher)
     case DigitalVoucher.name => Some(DigitalVoucher)
     case WeeklyZoneA.name => Some(WeeklyZoneA)
@@ -105,6 +109,7 @@ object Product {
   type ZDigipack = Digipack.type
   type SupporterPlus = SupporterPlus.type
   type Delivery = Delivery.type
+  type NationalDelivery = NationalDelivery.type
   type Voucher = Voucher.type
   type DigitalVoucher = DigitalVoucher.type
   type WeeklyZoneA = WeeklyZoneA.type

--- a/membership-common/src/main/scala/com/gu/memsub/subsv2/reads/ChargeListReads.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/subsv2/reads/ChargeListReads.scala
@@ -64,6 +64,7 @@ object ChargeListReads {
       voucher: ProductId,
       digitalVoucher: ProductId,
       delivery: ProductId,
+      nationalDelivery: ProductId,
       contributor: ProductId,
   )
 

--- a/membership-common/src/main/scala/com/gu/memsub/subsv2/reads/SubPlanReads.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/subsv2/reads/SubPlanReads.scala
@@ -38,6 +38,7 @@ object SubPlanReads {
   implicit val voucherReads: SubPlanReads[Voucher] = findProduct(_.voucher.point[List], Voucher)
   implicit val digitalVoucherReads: SubPlanReads[DigitalVoucher] = findProduct(_.digitalVoucher.point[List], DigitalVoucher)
   implicit val deliveryReads: SubPlanReads[Delivery] = findProduct(_.delivery.point[List], Delivery)
+  implicit val nationalDeliveryReads: SubPlanReads[NationalDelivery] = findProduct(_.nationalDelivery.point[List], NationalDelivery)
   implicit val zDigipackReads: SubPlanReads[ZDigipack] = findProduct(_.digipack.point[List], Digipack)
   implicit val supporterPlusReads: SubPlanReads[SupporterPlus] = findProduct(_.supporterPlus.point[List], SupporterPlus)
   implicit val membershipReads: SubPlanReads[Membership] =
@@ -68,6 +69,7 @@ object SubPlanReads {
       (voucherReads.read(p, z, c).map(identity[Paper]) orElse2
         digitalVoucherReads.read(p, z, c) orElse2
         deliveryReads.read(p, z, c) orElse2
+        nationalDeliveryReads.read(p, z, c) orElse2
         weeklyZoneAReads.read(p, z, c) orElse2
         weeklyZoneBReads.read(p, z, c) orElse2
         weeklyZoneCReads.read(p, z, c)) orElse2


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
Following on from #1034 this PR enables the endpoints used by MMA to load National Delivery subscriptions