### PR TITLE
Add features to plan JSON object so MMA can show Membership benefits based off it

### DIFF
--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -115,6 +115,7 @@ object AccountDetails {
             "currency" -> paidPlan.charges.price.prices.head.currency.glyph,
             "currencyISO" -> paidPlan.charges.price.prices.head.currency.iso,
             "billingPeriod" -> paidPlan.charges.billingPeriod.noun,
+            "features" -> paidPlan.features.map(_.code.get).mkString(",")
           )
         case _ => Json.obj()
       }) ++ (plan.charges match {

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -115,7 +115,7 @@ object AccountDetails {
             "currency" -> paidPlan.charges.price.prices.head.currency.glyph,
             "currencyISO" -> paidPlan.charges.price.prices.head.currency.iso,
             "billingPeriod" -> paidPlan.charges.billingPeriod.noun,
-            "features" -> paidPlan.features.map(_.code.get).mkString(",")
+            "features" -> paidPlan.features.map(_.code.get).mkString(","),
           )
         case _ => Json.obj()
       }) ++ (plan.charges match {


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
Add Zuora rate plan feature codes (basically only ever `"Events"`, `"Books"` or `"Events,Books"`) to the JSON paylod so that MMA can show Partner and Patron benefits if the features say `Events`. See https://github.com/guardian/manage-frontend/pull/1258

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
Added an additional non-nullable (empty or comma-separated string) JSON field to return what features are chosen (if any) in each subscription's Zuora product rate plan.

### trello card/screenshot/json/related PRs etc
https://trello.com/c/ElqzQZLR

### Testing

- [x] Tested in CODE (required to test local box)