### PR TITLE
Remove public IP address for Members Data API EC2 instances

### DIFF
--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -226,7 +226,7 @@ Resources:
       - Ref: SecurityGroupForPostgres
       InstanceType:
         Ref: InstanceType
-      AssociatePublicIpAddress: 'True'
+      AssociatePublicIpAddress: 'False'
       IamInstanceProfile:
         Ref: InstanceProfile
       UserData:


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
Public IP addresses will cost $3.65 per hour, and having the apps reachable from the internet increases the security risk profile. This change brings this app in line with all our others.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
This app had a public IP address configured. This PR removes the public IP address assignment to bring the app in line with all our others. It requires a CFN parameter change to move it into the private subnet.

I didn't have time to upgrade it to CDK.

### trello card/screenshot/json/related PRs etc
https://trello.com/b/KiMIxAsm/supporter-revenue-engine
