### PR TITLE
Add Digipack product to self-service-cancellation

### DIFF
--- a/membership-attribute-service/app/models/SelfServiceCancellation.scala
+++ b/membership-attribute-service/app/models/SelfServiceCancellation.scala
@@ -23,7 +23,7 @@ object SelfServiceCancellation {
 
   def apply(product: Product, billingCountry: Option[Country]): SelfServiceCancellation = {
 
-    if (isOneOf(product, Membership, Contribution, SupporterPlus)) {
+    if (isOneOf(product, Membership, Contribution, SupporterPlus, Digipack)) {
       SelfServiceCancellation(
         isAllowed = true,
         shouldDisplayEmail = true,


### PR DESCRIPTION
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
We need to update MDAPI to support a self-service cancellation journey for Digipack products.

This work supports some related work in the member-frontend repo, as detailed in this PR: https://github.com/guardian/manage-frontend/pull/1291 

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
One word added to one file
