### PR TITLE
Remove recency tests when handling Okta tokens

### DIFF
--- a/membership-attribute-service/test/actions/AuthAndBackendViaIdapiActionTest.scala
+++ b/membership-attribute-service/test/actions/AuthAndBackendViaIdapiActionTest.scala
@@ -12,7 +12,7 @@ import play.api.mvc.{AnyContent, Result, Results}
 import play.api.test.FakeRequest
 import services.{IdentityAuthService, UserAndCredentials}
 
-import java.time.{Clock, ZoneId, ZonedDateTime}
+import java.time.{ZoneId, ZonedDateTime}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
@@ -26,7 +26,6 @@ class AuthAndBackendViaIdapiActionTest extends Specification with IdiomaticMocki
 
     def oktaTest(
         authenticatedTime: ZonedDateTime,
-        currentTime: ZonedDateTime,
         howToHandleRecencyOfSignedIn: HowToHandleRecencyOfSignedIn,
     ): Future[Result] = {
       val request = FakeRequest()
@@ -47,37 +46,42 @@ class AuthAndBackendViaIdapiActionTest extends Specification with IdiomaticMocki
       val backends = mock[TouchpointBackends]
       when(backends.normal).thenReturn(components)
 
-      val clock = Clock.fixed(currentTime.toInstant, zoneId)
-      val action = new AuthAndBackendViaIdapiAction(backends, howToHandleRecencyOfSignedIn, isTestUser, requiredScopes, clock)
+      val action = new AuthAndBackendViaIdapiAction(backends, howToHandleRecencyOfSignedIn, isTestUser, requiredScopes)
       action.invokeBlock(request, { _: AuthAndBackendRequest[AnyContent] => Future.successful(Results.Ok) })
     }
 
     "use Okta token to build a refined request when a recently authenticated Okta token is present" in {
       val authenticatedTime = ZonedDateTime.of(2023, 1, 18, 9, 20, 0, 1, zoneId)
-      val currentTime = ZonedDateTime.of(2023, 1, 18, 9, 50, 0, 0, zoneId)
-      val result = oktaTest(authenticatedTime, currentTime, Return401IfNotSignedInRecently)
+      val result = oktaTest(authenticatedTime, Return401IfNotSignedInRecently)
       Await.result(result, Duration.Inf) shouldEqual Results.Ok
-    }
-
-    "fail with a 401 when a stale Okta token is present and howToHandleRecencyOfSignedIn is Return401IfNotSignedInRecently" in {
-      val authenticatedTime = ZonedDateTime.of(2023, 1, 18, 7, 42, 0, 0, zoneId)
-      val currentTime = ZonedDateTime.of(2023, 1, 18, 9, 50, 0, 0, zoneId)
-      val result = oktaTest(authenticatedTime, currentTime, Return401IfNotSignedInRecently)
-      Await.result(result, Duration.Inf) shouldEqual Results.Unauthorized
     }
 
     "use Okta token to build a refined request when a stale Okta token is present and howToHandleRecencyOfSignedIn is ContinueRegardlessOfSignInRecency" in {
       val authenticatedTime = ZonedDateTime.of(2023, 1, 18, 7, 42, 0, 0, zoneId)
-      val currentTime = ZonedDateTime.of(2023, 1, 18, 9, 50, 0, 0, zoneId)
-      val result = oktaTest(authenticatedTime, currentTime, ContinueRegardlessOfSignInRecency)
+      val result = oktaTest(authenticatedTime, ContinueRegardlessOfSignInRecency)
       Await.result(result, Duration.Inf) shouldEqual Results.Ok
     }
 
-    "fail with a 401 when a recently stale Okta token is present and howToHandleRecencyOfSignedIn is Return401IfNotSignedInRecently" in {
-      val authenticatedTime = ZonedDateTime.of(2023, 1, 18, 9, 20, 0, 0, zoneId)
-      val currentTime = ZonedDateTime.of(2023, 1, 18, 9, 50, 0, 0, zoneId)
-      val result = oktaTest(authenticatedTime, currentTime, Return401IfNotSignedInRecently)
-      Await.result(result, Duration.Inf) shouldEqual Results.Unauthorized
+    "fail with a 401 when call to identityAuthService fails with a 401" in {
+      val request = FakeRequest()
+
+      val isTestUser = mock[IsTestUser]
+
+      val authService = mock[IdentityAuthService]
+      when(authService.userAndCredentials(request, requiredScopes))
+        .thenReturn(Future.successful(Left(ApiErrors.unauthorized)))
+
+      val components = mock[TouchpointComponents]
+      when(components.identityAuthService).thenReturn(authService)
+
+      val backends = mock[TouchpointBackends]
+      when(backends.normal).thenReturn(components)
+
+      val action = new AuthAndBackendViaIdapiAction(backends, Return401IfNotSignedInRecently, isTestUser, requiredScopes)
+      val result = action.invokeBlock(request, { _: AuthAndBackendRequest[AnyContent] => Future.successful(Results.Ok) })
+      Await.result(result, Duration.Inf).toString shouldEqual Results.Unauthorized
+        .withHeaders("Pragma" -> "no-cache", "Cache-Control" -> "no-cache, private")
+        .toString
     }
 
     "fail with a 403 when call to identityAuthService fails with a 403" in {


### PR DESCRIPTION
# Problem
At the moment, the API is inspecting access tokens for their age and rejecting them if they are above a certain age, even when the token is valid.  APIs shouldn't know anything more about an access token than whether it is valid or not.
This recency test is also causing a potential race condition with similar checks taking place in the MMA client app.  So it's both redundant and harmful.
(We do need to continue to check the age of Identity cookies though, when they are presented, as they have no similar checking process in client apps.)

# Solution implemented
I've removed the recency check for Okta tokens.  It does a validity check, which includes an expiry check, in the `IdentityAuthService`.
