### PR TITLE
Testing `alertableProducts` functionality

### DIFF
--- a/membership-attribute-service/app/services/PaymentFailureAlerter.scala
+++ b/membership-attribute-service/app/services/PaymentFailureAlerter.scala
@@ -89,7 +89,7 @@ object PaymentFailureAlerter extends LoggingWithLogstashFields with StrictLoggin
       expectedAlertText.map { someText => shouldShowAlert.option(someText).flatten }
     }
   }
-  val alertableProducts = List(Product.Membership, Product.Digipack)
+  val alertableProducts = List(Product.Membership, Product.Contribution, Product.Digipack, Product.SupporterPlus)
 
   def alertAvailableFor(
       account: AccountObject,

--- a/membership-attribute-service/app/services/PaymentFailureAlerter.scala
+++ b/membership-attribute-service/app/services/PaymentFailureAlerter.scala
@@ -89,15 +89,16 @@ object PaymentFailureAlerter extends LoggingWithLogstashFields with StrictLoggin
       expectedAlertText.map { someText => shouldShowAlert.option(someText).flatten }
     }
   }
-  val alertableProducts = List(Product.Membership, Product.Contribution, Product.Digipack, Product.SupporterPlus)
+
+  val nonAlertableProducts: List[Product] = List()
 
   def alertAvailableFor(
       account: AccountObject,
       subscription: Subscription[AnyPlan],
       paymentMethodGetter: PaymentMethodId => Future[Either[String, PaymentMethodResponse]],
   )(implicit ec: ExecutionContext): Future[Boolean] = {
+    def isAlertableProduct = !nonAlertableProducts.contains(subscription.plan.product)
 
-    def isAlertableProduct = alertableProducts.contains(subscription.plan.product)
     def creditCard(paymentMethodResponse: PaymentMethodResponse) =
       paymentMethodResponse.paymentMethodType == "CreditCardReferenceTransaction" || paymentMethodResponse.paymentMethodType == "CreditCard"
 

--- a/membership-attribute-service/app/services/PaymentFailureAlerter.scala
+++ b/membership-attribute-service/app/services/PaymentFailureAlerter.scala
@@ -89,7 +89,7 @@ object PaymentFailureAlerter extends LoggingWithLogstashFields with StrictLoggin
       expectedAlertText.map { someText => shouldShowAlert.option(someText).flatten }
     }
   }
-  val alertableProducts = List(Product.Membership, Product.Contribution, Product.Digipack)
+  val alertableProducts = List(Product.Membership, Product.Digipack)
 
   def alertAvailableFor(
       account: AccountObject,

--- a/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
+++ b/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
@@ -72,11 +72,23 @@ class PaymentFailureAlerterTest(implicit ee: ExecutionEnv) extends Specification
       }
 
       "return a message for a supporter plus who is in payment failure" in {
-        val result: Future[Option[String]] = PaymentFailureAlerter.alertText(accountSummaryWithBalance, supporterPlus, paymentMethodResponseRecentFailure)
+        val result: Future[Option[String]] =
+          PaymentFailureAlerter.alertText(accountSummaryWithBalance, supporterPlus, paymentMethodResponseRecentFailure)
 
         val attemptDateTime = DateTime.now().minusDays(1)
         val formatter = DateTimeFormat.forPattern("d MMMM yyyy").withLocale(Locale.ENGLISH)
         val expectedActionText = s"Our attempt to take payment for your Supporter Plus failed on ${attemptDateTime.toString(formatter)}."
+
+        result must beSome(expectedActionText).await
+      }
+
+      "return a message for a Guardian weekly subscriber who is in payment failure" in {
+        val result: Future[Option[String]] =
+          PaymentFailureAlerter.alertText(accountSummaryWithBalance, guardianWeekly, paymentMethodResponseRecentFailure)
+
+        val attemptDateTime = DateTime.now().minusDays(1)
+        val formatter = DateTimeFormat.forPattern("d MMMM yyyy").withLocale(Locale.ENGLISH)
+        val expectedActionText = s"Our attempt to take payment for your Guardian Weekly failed on ${attemptDateTime.toString(formatter)}."
 
         result must beSome(expectedActionText).await
       }

--- a/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
+++ b/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
@@ -71,6 +71,16 @@ class PaymentFailureAlerterTest(implicit ee: ExecutionEnv) extends Specification
         result must beSome(expectedActionText).await
       }
 
+      "return a message for a supporter plus recurring contributor who is in payment failure" in {
+        val result: Future[Option[String]] = PaymentFailureAlerter.alertText(accountSummaryWithBalance, supporterPlus, paymentMethodResponseRecentFailure)
+
+        val attemptDateTime = DateTime.now().minusDays(1)
+        val formatter = DateTimeFormat.forPattern("d MMMM yyyy").withLocale(Locale.ENGLISH)
+        val expectedActionText = s"Our attempt to take payment for your Supporter Plus failed on ${attemptDateTime.toString(formatter)}."
+
+        result must beSome(expectedActionText).await
+      }
+
     }
 
     "alertAvailableFor" should {

--- a/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
+++ b/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
@@ -71,7 +71,7 @@ class PaymentFailureAlerterTest(implicit ee: ExecutionEnv) extends Specification
         result must beSome(expectedActionText).await
       }
 
-      "return a message for a supporter plus recurring contributor who is in payment failure" in {
+      "return a message for a supporter plus who is in payment failure" in {
         val result: Future[Option[String]] = PaymentFailureAlerter.alertText(accountSummaryWithBalance, supporterPlus, paymentMethodResponseRecentFailure)
 
         val attemptDateTime = DateTime.now().minusDays(1)

--- a/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
+++ b/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
@@ -82,7 +82,7 @@ class PaymentFailureAlerterTest(implicit ee: ExecutionEnv) extends Specification
         result must beSome(expectedActionText).await
       }
 
-      "return a message for a Guardian weekly subscriber who is in payment failure" in {
+      "return a message for a Guardian Weekly subscriber who is in payment failure" in {
         val result: Future[Option[String]] =
           PaymentFailureAlerter.alertText(accountSummaryWithBalance, guardianWeekly, paymentMethodResponseRecentFailure)
 

--- a/membership-attribute-service/test/testdata/SubscriptionTestData.scala
+++ b/membership-attribute-service/test/testdata/SubscriptionTestData.scala
@@ -193,5 +193,5 @@ trait SubscriptionTestData {
   val expiredMembership = toSubscription(false)(NonEmptyList(supporterPlan(referenceDate - 2.year, referenceDate - 1.year)))
   val friend = toSubscription(false)(NonEmptyList(friendPlan))
   val contributor = toSubscription(false)(NonEmptyList(contributorPlan(referenceDate, referenceDate + 1.month)))
-  val supporterPlus = toSubscription(isCancelled = false)(NonEmptyList(supporterPlusPlan(referenceDate, referenceDate + 1.month)))
+  val supporterPlus = toSubscription(false)(NonEmptyList(supporterPlusPlan(referenceDate, referenceDate + 1.month)))
 }

--- a/membership-attribute-service/test/testdata/SubscriptionTestData.scala
+++ b/membership-attribute-service/test/testdata/SubscriptionTestData.scala
@@ -140,6 +140,28 @@ trait SubscriptionTestData {
       endDate,
     )
 
+  def supporterPlusPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan.SupporterPlus =
+    PaidSubscriptionPlan[Product.SupporterPlus, PaidCharge[Benefit.SupporterPlus.type, BillingPeriod]](
+      RatePlanId("idSupporterPlusPlan"),
+      ProductRatePlanId("prpi"),
+      "Supporter Plus",
+      "desc",
+      "Supporter Plus",
+      "Supporter Plus",
+      Product.SupporterPlus,
+      List.empty,
+      PaidCharge(
+        Benefit.SupporterPlus,
+        BillingPeriod.Month,
+        PricingSummary(Map(GBP -> Price(10.0f, GBP))),
+        ProductRatePlanChargeId("bar"),
+        SubscriptionRatePlanChargeId("nar"),
+      ),
+      None,
+      startDate,
+      endDate,
+    )
+
   def toSubscription[P <: SubscriptionPlan.AnyPlan](isCancelled: Boolean)(plans: NonEmptyList[P]): Subscription[P] = {
     Subscription(
       id = Id(plans.head.id.get),
@@ -171,4 +193,5 @@ trait SubscriptionTestData {
   val expiredMembership = toSubscription(false)(NonEmptyList(supporterPlan(referenceDate - 2.year, referenceDate - 1.year)))
   val friend = toSubscription(false)(NonEmptyList(friendPlan))
   val contributor = toSubscription(false)(NonEmptyList(contributorPlan(referenceDate, referenceDate + 1.month)))
+  val supporterPlus = toSubscription(isCancelled = false)(NonEmptyList(supporterPlusPlan(referenceDate, referenceDate + 1.month)))
 }


### PR DESCRIPTION
This PR inverts the logic determining whether or not to produce an alert for products in payment failure. Instead of a hard-coded list of products which are opted _into_ alerting, payment failure alerts will be generated for all products unless they are explicitly opted _out_.