### PR TITLE
Add new feast boolean to contentAccess as well as advice on which iOS subscription group to offer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The members' data API is a Play app that manages and retrieves supporter attribu
 It runs on https://members-data-api.theguardian.com/.
 
 ### Dotcom
-theguardian.com website is the biggest single consumer of `members-data-api`, specifically the `/user-attributes/me` endpoint, which it uses to determine both ad-free (becuase user has digital subscription) and if we should hide 'support messaging/asks' (banner, epic, header/footer support buttons etc).
+theguardian.com website is the biggest single consumer of `members-data-api`, specifically the `/user-attributes/me` endpoint, which it uses to determine both ad-free (when user has a digital subscription or supporter plus or a newspaper product) and if we should hide 'support messaging/asks' (banner, epic, header/footer support buttons etc).
 
 It would be unnecessary to hit `members-data-api` on every single page view, so instead it uses cookies to regulate how often calls are made. **The `gu_user_features_expiry` contains a timestamp for the 'earliest' point it would be allowed to call `members-data-api` again, and is updated whenever it does call `members-data-api` to _'now + 24hours'_.**
 
@@ -18,9 +18,9 @@ Various things from the `/user-attributes/me` response are stored in cookies, to
 - `gu_one_off_contribution_date` = `oneOffContributionDate` in the response
 
 ##### Useful Links 
-- DCR [dotcom-rendering/src/web/lib/contributions.ts](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/web/lib/contributions.ts)
+- DCR [dotcom-rendering/src/web/lib/contributions.ts](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/lib/contributions.ts#L10)
 - Dotcom
-  - [frontend/static/src/javascripts/projects/common/modules/commercial/user-features.ts](https://github.com/guardian/frontend/blob/main/static/src/javascripts/projects/common/modules/commercial/user-features.ts)
+  - [frontend/static/src/javascripts/projects/common/modules/commercial/user-features.ts](https://github.com/guardian/frontend/blob/main/static/src/javascripts/projects/common/modules/commercial/user-features.ts#L17)
   - [frontend/blob/master/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js](https://github.com/guardian/frontend/blob/master/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js)
 
 ### User attributes data sources
@@ -29,25 +29,6 @@ User attributes (which products a user currently holds) are served from three so
 from Stripe (Guardian Patrons only) and Zuora (digital and print subscriptions & recurring contributions)
 2. The `contributions-store-[STAGE]` Postgres database (one off contributions only)
 3. The [mobile purchases api](https://github.com/guardian/mobile-purchases) (in-app purchases only)
-
-### Limiting concurrent requests
-
-There is a simple if-else logic applied per instance
-
-```
-if (current concurrent requests < calculate limit per instance)
-  hit zuora
-else
-  hit cache
-```
-
-Effect of different values for `ConcurrentZuoraCallThreshold`
-- 6 total across 6 instances (i.e. limit of 1 per instance) results in about 50/50 split between Zuora and cache
-- 12 total across 6 instances (i.e. limit of 2 per instance) results in about 80/20
-- 0 results in 100% cache
-
-**WARNING: Remember to reduce `ConcurrentZuoraCallThreshold` if instances need to scale, say in expectation of 
-drastic increase of load due to breaking news.** 
 
 ## Setting it up locally
 

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -133,7 +133,7 @@ class AttributeController(
           )
 
           val result = allProductAttributes match {
-            case Some(attrs @ Attributes(_, Some(tier), _, _, _, _, _, _, _, _, _, _, _, _)) =>
+            case Some(attrs @ Attributes(_, Some(tier), _, _, _, _, _, _, _, _, _, _, _)) =>
               logInfoWithCustomFields(
                 s"${user.identityId} is a $tier member - $endpointDescription - $attrs found via $fromWhere",
                 customFields("member"),

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -133,7 +133,7 @@ class AttributeController(
           )
 
           val result = allProductAttributes match {
-            case Some(attrs @ Attributes(_, Some(tier), _, _, _, _, _, _, _, _, _, _)) =>
+            case Some(attrs @ Attributes(_, Some(tier), _, _, _, _, _, _, _, _, _, _, _, _)) =>
               logInfoWithCustomFields(
                 s"${user.identityId} is a $tier member - $endpointDescription - $attrs found via $fromWhere",
                 customFields("member"),

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -74,7 +74,7 @@ case class Attributes(
     paperSubscriber = isPaperSubscriber,
     guardianWeeklySubscriber = isGuardianWeeklySubscriber,
     guardianPatron = isGuardianPatron,
-    feast = isGuardianPatron || isPartnerTier || isPatronTier || isGuardianPatron ||
+    feast = isStaffTier || isPatronTier || isPartnerTier || isPatronTier || isGuardianPatron ||
       (isSupporterPlus && SupporterPlusAcquisitionDate.exists(isBeforeFeastLaunch))
   )
 

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -74,7 +74,7 @@ case class Attributes(
     paperSubscriber = isPaperSubscriber,
     guardianWeeklySubscriber = isGuardianWeeklySubscriber,
     guardianPatron = isGuardianPatron,
-    feast = isStaffTier || isPatronTier || isPartnerTier || isPatronTier || isGuardianPatron ||
+    feast = isStaffTier || isPartnerTier || isPatronTier || isGuardianPatron ||
       (isSupporterPlus && SupporterPlusAcquisitionDate.exists(isBeforeFeastLaunch)),
   )
 

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -75,7 +75,7 @@ case class Attributes(
     guardianWeeklySubscriber = isGuardianWeeklySubscriber,
     guardianPatron = isGuardianPatron,
     feast = isStaffTier || isPatronTier || isPartnerTier || isPatronTier || isGuardianPatron ||
-      (isSupporterPlus && SupporterPlusAcquisitionDate.exists(isBeforeFeastLaunch))
+      (isSupporterPlus && SupporterPlusAcquisitionDate.exists(isBeforeFeastLaunch)),
   )
 
   // show support messaging (in app & on dotcom) if they do NOT have any active products

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -61,7 +61,6 @@ case class Attributes(
   lazy val isPremiumLiveAppSubscriber = LiveAppSubscriptionExpiryDate.exists(_.isAfter(now))
   lazy val isGuardianPatron = GuardianPatronExpiryDate.exists(_.isAfter(now))
 
-
   lazy val contentAccess = ContentAccess(
     member = isPaidTier || isFriendTier,
     paidMember = isPaidTier,

--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -92,7 +92,7 @@ case class Attributes(
       || isGuardianPatron
   )
 
-  lazy val feastSubscriptionGroup =
+  lazy val feastIosSubscriptionGroup =
     if (isSupporterPlus && RecurringContributonAcquisitionDate.exists(isBeforeFeastLaunch))
       "21445388" // extended trial subscription
     else
@@ -119,7 +119,7 @@ object Attributes {
   )(unlift(Attributes.unapply))
     .addNullableField("digitalSubscriptionExpiryDate", _.latestDigitalSubscriptionExpiryDate)
     .addField("showSupportMessaging", _.showSupportMessaging)
-    .addField("feastSubscriptionGroup", _.feastSubscriptionGroup)
+    .addField("feastIosSubscriptionGroup", _.feastIosSubscriptionGroup)
     .addField("contentAccess", _.contentAccess)
 }
 

--- a/membership-attribute-service/app/models/FeastApp.scala
+++ b/membership-attribute-service/app/models/FeastApp.scala
@@ -19,6 +19,7 @@ object FeastApp {
       attributes.isPartnerTier ||
       attributes.isPatronTier ||
       attributes.isGuardianPatron ||
+      attributes.digitalSubscriberHasActivePlan ||
       attributes.isSupporterPlus
 
   private def isRecurringContributorWhoSubscribedBeforeFeastLaunch(attributes: Attributes) =

--- a/membership-attribute-service/app/models/FeastApp.scala
+++ b/membership-attribute-service/app/models/FeastApp.scala
@@ -1,0 +1,36 @@
+package models
+
+import models.FeastApp.IosSubscriptionGroupIds.{ExtendedTrial, RegularSubscription}
+import org.joda.time.LocalDate
+import scalaz.Scalaz.ToBooleanOpsFromBoolean
+
+object FeastApp {
+  val FeastLaunchDate = LocalDate.parse("2024-04-01")
+  object IosSubscriptionGroupIds {
+    // Subscription group ids are used by the app to tell the app store which subscription option to show to the user
+    val ExtendedTrial = "21445388"
+    val RegularSubscription = "21396030"
+  }
+
+  private def isBeforeFeastLaunch(dt: LocalDate): Boolean = dt.isBefore(FeastLaunchDate)
+
+  def shouldGetFeastAccess(attributes: Attributes) =
+    attributes.isStaffTier ||
+      attributes.isPartnerTier ||
+      attributes.isPatronTier ||
+      attributes.isGuardianPatron ||
+      attributes.isSupporterPlus
+
+  private def isRecurringContributorWhoSubscribedBeforeFeastLaunch(attributes: Attributes) =
+    attributes.isRecurringContributor && attributes.RecurringContributionAcquisitionDate.exists(isBeforeFeastLaunch)
+
+  private def shouldShowSubscriptionOptions(attributes: Attributes) = !shouldGetFeastAccess(attributes)
+
+  def getFeastIosSubscriptionGroup(attributes: Attributes) =
+    shouldShowSubscriptionOptions(attributes).option(
+      if (isRecurringContributorWhoSubscribedBeforeFeastLaunch(attributes))
+        ExtendedTrial
+      else
+        RegularSubscription,
+    )
+}

--- a/membership-attribute-service/app/models/FeastApp.scala
+++ b/membership-attribute-service/app/models/FeastApp.scala
@@ -5,14 +5,14 @@ import org.joda.time.LocalDate
 import scalaz.Scalaz.ToBooleanOpsFromBoolean
 
 object FeastApp {
-  val FeastLaunchDate = LocalDate.parse("2024-04-01")
+  val FeastIosLaunchDate = LocalDate.parse("2024-04-01")
   object IosSubscriptionGroupIds {
     // Subscription group ids are used by the app to tell the app store which subscription option to show to the user
     val ExtendedTrial = "21445388"
     val RegularSubscription = "21396030"
   }
 
-  private def isBeforeFeastLaunch(dt: LocalDate): Boolean = dt.isBefore(FeastLaunchDate)
+  private def isBeforeFeastLaunch(dt: LocalDate): Boolean = dt.isBefore(FeastIosLaunchDate)
 
   def shouldGetFeastAccess(attributes: Attributes) =
     attributes.isStaffTier ||

--- a/membership-attribute-service/app/models/FeastApp.scala
+++ b/membership-attribute-service/app/models/FeastApp.scala
@@ -25,11 +25,15 @@ object FeastApp {
   private def isRecurringContributorWhoSubscribedBeforeFeastLaunch(attributes: Attributes) =
     attributes.isRecurringContributor && attributes.RecurringContributionAcquisitionDate.exists(isBeforeFeastLaunch)
 
+  private def shouldGetFreeTrial(attributes: Attributes) =
+    isRecurringContributorWhoSubscribedBeforeFeastLaunch(attributes) ||
+      attributes.isPremiumLiveAppSubscriber
+
   private def shouldShowSubscriptionOptions(attributes: Attributes) = !shouldGetFeastAccess(attributes)
 
   def getFeastIosSubscriptionGroup(attributes: Attributes) =
     shouldShowSubscriptionOptions(attributes).option(
-      if (isRecurringContributorWhoSubscribedBeforeFeastLaunch(attributes))
+      if (shouldGetFreeTrial(attributes))
         ExtendedTrial
       else
         RegularSubscription,

--- a/membership-attribute-service/app/services/SupporterRatePlanToAttributesMapper.scala
+++ b/membership-attribute-service/app/services/SupporterRatePlanToAttributesMapper.scala
@@ -48,18 +48,18 @@ object SupporterRatePlanToAttributesMapper {
   val supporterPlusTransformer: AttributeTransformer = (attributes: Attributes, supporterRatePlanItem: DynamoSupporterRatePlanItem) =>
     attributes.copy(
       SupporterPlusExpiryDate = Some(supporterRatePlanItem.termEndDate),
-      SupporterPlusAcquisitionDate = Some(supporterRatePlanItem.contractEffectiveDate)
+      SupporterPlusAcquisitionDate = Some(supporterRatePlanItem.contractEffectiveDate),
     )
   val supporterPlusV2Transformer: AttributeTransformer = supporterPlusTransformer
   val monthlyContributionTransformer: AttributeTransformer = (attributes: Attributes, item: DynamoSupporterRatePlanItem) =>
     attributes.copy(
       RecurringContributionPaymentPlan = Some("Monthly Contribution"),
-      RecurringContributonAcquisitionDate = Some(item.contractEffectiveDate)
+      RecurringContributonAcquisitionDate = Some(item.contractEffectiveDate),
     )
   val annualContributionTransformer: AttributeTransformer = (attributes: Attributes, item: DynamoSupporterRatePlanItem) =>
     attributes.copy(
       RecurringContributionPaymentPlan = Some("Annual Contribution"),
-      RecurringContributonAcquisitionDate = Some(item.contractEffectiveDate)
+      RecurringContributonAcquisitionDate = Some(item.contractEffectiveDate),
     )
   val paperTransformer: AttributeTransformer = (attributes: Attributes, supporterRatePlanItem: DynamoSupporterRatePlanItem) =>
     attributes.copy(

--- a/membership-attribute-service/app/services/SupporterRatePlanToAttributesMapper.scala
+++ b/membership-attribute-service/app/services/SupporterRatePlanToAttributesMapper.scala
@@ -48,12 +48,19 @@ object SupporterRatePlanToAttributesMapper {
   val supporterPlusTransformer: AttributeTransformer = (attributes: Attributes, supporterRatePlanItem: DynamoSupporterRatePlanItem) =>
     attributes.copy(
       SupporterPlusExpiryDate = Some(supporterRatePlanItem.termEndDate),
+      SupporterPlusAcquisitionDate = Some(supporterRatePlanItem.contractEffectiveDate)
     )
   val supporterPlusV2Transformer: AttributeTransformer = supporterPlusTransformer
-  val monthlyContributionTransformer: AttributeTransformer = (attributes: Attributes, _: DynamoSupporterRatePlanItem) =>
-    attributes.copy(RecurringContributionPaymentPlan = Some("Monthly Contribution"))
-  val annualContributionTransformer: AttributeTransformer = (attributes: Attributes, _: DynamoSupporterRatePlanItem) =>
-    attributes.copy(RecurringContributionPaymentPlan = Some("Annual Contribution"))
+  val monthlyContributionTransformer: AttributeTransformer = (attributes: Attributes, item: DynamoSupporterRatePlanItem) =>
+    attributes.copy(
+      RecurringContributionPaymentPlan = Some("Monthly Contribution"),
+      RecurringContributonAcquisitionDate = Some(item.contractEffectiveDate)
+    )
+  val annualContributionTransformer: AttributeTransformer = (attributes: Attributes, item: DynamoSupporterRatePlanItem) =>
+    attributes.copy(
+      RecurringContributionPaymentPlan = Some("Annual Contribution"),
+      RecurringContributonAcquisitionDate = Some(item.contractEffectiveDate)
+    )
   val paperTransformer: AttributeTransformer = (attributes: Attributes, supporterRatePlanItem: DynamoSupporterRatePlanItem) =>
     attributes.copy(
       PaperSubscriptionExpiryDate = Some(supporterRatePlanItem.termEndDate),

--- a/membership-attribute-service/app/services/SupporterRatePlanToAttributesMapper.scala
+++ b/membership-attribute-service/app/services/SupporterRatePlanToAttributesMapper.scala
@@ -48,18 +48,17 @@ object SupporterRatePlanToAttributesMapper {
   val supporterPlusTransformer: AttributeTransformer = (attributes: Attributes, supporterRatePlanItem: DynamoSupporterRatePlanItem) =>
     attributes.copy(
       SupporterPlusExpiryDate = Some(supporterRatePlanItem.termEndDate),
-      SupporterPlusAcquisitionDate = Some(supporterRatePlanItem.contractEffectiveDate),
     )
   val supporterPlusV2Transformer: AttributeTransformer = supporterPlusTransformer
   val monthlyContributionTransformer: AttributeTransformer = (attributes: Attributes, item: DynamoSupporterRatePlanItem) =>
     attributes.copy(
       RecurringContributionPaymentPlan = Some("Monthly Contribution"),
-      RecurringContributonAcquisitionDate = Some(item.contractEffectiveDate),
+      RecurringContributionAcquisitionDate = Some(item.contractEffectiveDate),
     )
   val annualContributionTransformer: AttributeTransformer = (attributes: Attributes, item: DynamoSupporterRatePlanItem) =>
     attributes.copy(
       RecurringContributionPaymentPlan = Some("Annual Contribution"),
-      RecurringContributonAcquisitionDate = Some(item.contractEffectiveDate),
+      RecurringContributionAcquisitionDate = Some(item.contractEffectiveDate),
     )
   val paperTransformer: AttributeTransformer = (attributes: Attributes, supporterRatePlanItem: DynamoSupporterRatePlanItem) =>
     attributes.copy(

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -3,7 +3,6 @@ package controllers
 import actions.{AuthAndBackendRequest, AuthenticatedUserAndBackendRequest, CommonActions, HowToHandleRecencyOfSignedIn}
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.stream.Materializer
-import org.apache.pekko.stream.ActorMaterializer
 import com.gu.identity.auth.AccessScope
 import com.gu.identity.{RedirectAdviceResponse, SignedInRecently}
 import com.typesafe.config.ConfigFactory
@@ -265,7 +264,7 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
                  """.stripMargin)
   }
 
-  private def verifySuccessfulOneOfContributionsResult(result: Future[Result]) = {
+  private def verifySuccessfulOneOffContributionsResult(result: Future[Result]) = {
     status(result) shouldEqual OK
     val jsonBody = contentAsJson(result)
     jsonBody shouldEqual
@@ -407,7 +406,7 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
       val req = FakeRequest().withCookies(validUserCookie)
       val result: Future[Result] = controller.oneOffContributions(req)
 
-      verifySuccessfulOneOfContributionsResult(result)
+      verifySuccessfulOneOffContributionsResult(result)
       verifyIdentityHeadersSet(result, validUser.identityId)
     }
 
@@ -415,7 +414,7 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
       val req = FakeRequest().withCookies(validUserCookie)
       val result: Future[Result] = controller.oneOffContributions(req)
 
-      verifySuccessfulOneOfContributionsResult(result)
+      verifySuccessfulOneOffContributionsResult(result)
       verifyIdentityHeadersSet(result, validUser.identityId)
     }
 

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -29,7 +29,7 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
 
   implicit val as: ActorSystem = ActorSystem("test")
 
-  private val dateBeforeFeastLaunch = FeastApp.FeastLaunchDate.minusDays(1)
+  private val dateBeforeFeastLaunch = FeastApp.FeastIosLaunchDate.minusDays(1)
   private val validUserId = "123"
   private val userWithoutAttributesUserId = "456"
   private val userWithRecurringContributionUserId = "101"

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -9,7 +9,7 @@ import com.typesafe.config.ConfigFactory
 import components.{TouchpointBackends, TouchpointComponents}
 import configuration.{CreateTestUsernames, Stage}
 import filters.{AddGuIdentityHeaders, IsTestUser}
-import models.{Attributes, MobileSubscriptionStatus, UserFromToken}
+import models.{Attributes, FeastApp, MobileSubscriptionStatus, UserFromToken}
 import monitoring.CreateNoopMetrics
 import org.joda.time.LocalDate
 import org.mockito.IdiomaticMockito
@@ -29,8 +29,10 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
 
   implicit val as: ActorSystem = ActorSystem("test")
 
+  private val dateBeforeFeastLaunch = FeastApp.FeastLaunchDate.minusWeeks(1)
   private val validUserId = "123"
   private val userWithoutAttributesUserId = "456"
+  private val userWithRecurringContributionUserId = "101"
   private val unvalidatedEmailUserId = "789"
 
   private val testAttributes = Attributes(
@@ -41,11 +43,19 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
     DigitalSubscriptionExpiryDate = Some(new LocalDate(2100, 1, 1)),
     PaperSubscriptionExpiryDate = Some(new LocalDate(2099, 1, 1)),
     GuardianWeeklySubscriptionExpiryDate = Some(new LocalDate(2099, 1, 1)),
+    SupporterPlusExpiryDate = Some(new LocalDate(2024, 1, 1)),
+    RecurringContributionAcquisitionDate = Some(FeastApp.FeastLaunchDate.minusDays(1)),
+  )
+  private val recurringContributionOnlyAttributes = Attributes(
+    UserId = userWithRecurringContributionUserId,
+    RecurringContributionPaymentPlan = Some("Monthly Contribution"),
+    RecurringContributionAcquisitionDate = Some(dateBeforeFeastLaunch),
   )
 
   private val validUserCookie = Cookie("validUser", "true")
   private val validUnvalidatedEmailCookie = Cookie("unvalidatedEmailUser", "true")
   private val userWithoutAttributesCookie = Cookie("invalidUser", "true")
+  private val recurringContributorCookie = Cookie("recurringContributor", "true")
   private val validUser = UserFromToken(
     primaryEmailAddress = "test@gu.com",
     identityId = validUserId,
@@ -61,6 +71,11 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
   private val userWithoutAttributes = UserFromToken(
     primaryEmailAddress = "notcached@gu.com",
     identityId = userWithoutAttributesUserId,
+    authTime = None,
+  )
+  private val userWithRecurringContribution = UserFromToken(
+    primaryEmailAddress = "recurringContribution@gu.com",
+    identityId = userWithRecurringContributionUserId,
     authTime = None,
   )
 
@@ -94,6 +109,7 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
         case Some(c) if c == validUserCookie => Future.successful(Right(validUser))
         case Some(c) if c == validUnvalidatedEmailCookie => Future.successful(Right(unvalidatedEmailUser))
         case Some(c) if c == userWithoutAttributesCookie => Future.successful(Right(userWithoutAttributes))
+        case Some(c) if c == recurringContributorCookie => Future.successful(Right(userWithRecurringContribution))
         case Some(c) if c == guardianEmployeeCookie => Future.successful(Right(guardianEmployeeUser))
         case Some(c) if c == guardianEmployeeCookieTheguardian => Future.successful(Right(guardianEmployeeUserTheguardian))
         case Some(c) if c == validEmployeeUserCookie => Future.successful(Right(validEmployeeUser))
@@ -162,7 +178,9 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
       )(implicit request: AuthenticatedUserAndBackendRequest[AnyContent]): Future[(String, Option[Attributes])] = Future {
         if (identityId == validUserId || identityId == validEmployeeUser.identityId)
           ("Zuora", Some(testAttributes))
-        else
+        else if (identityId == userWithRecurringContributionUserId) {
+          ("Zuora", Some(recurringContributionOnlyAttributes))
+        } else
           ("Zuora", None)
       }
     }
@@ -214,11 +232,11 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
 
   }
 
-  private def verifySuccessfullAttributesResult(result: Future[Result]) = {
+  private def verifySuccessfulAttributesResult(result: Future[Result]) = {
     status(result) shouldEqual OK
     val jsonBody = contentAsJson(result)
     jsonBody shouldEqual
-      Json.parse("""
+      Json.parse(s"""
                    | {
                    |   "tier": "patron",
                    |   "userId": "123",
@@ -227,12 +245,14 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
                    |   "digitalSubscriptionExpiryDate":"2100-01-01",
                    |   "paperSubscriptionExpiryDate":"2099-01-01",
                    |   "guardianWeeklyExpiryDate":"2099-01-01",
+                   |   "recurringContributionAcquisitionDate":"${FeastApp.FeastLaunchDate.minusDays(1)}",
                    |   "showSupportMessaging": false,
                    |   "contentAccess": {
                    |     "member": true,
                    |     "paidMember": true,
                    |     "recurringContributor": true,
                    |     "supporterPlus":false,
+                   |     "feast":true,
                    |     "digitalPack": true,
                    |     "paperSubscriber": true,
                    |     "guardianWeeklySubscriber": true,
@@ -242,7 +262,7 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
                  """.stripMargin)
   }
 
-  private def verifySuccessfullOneOfContributionsResult(result: Future[Result]) = {
+  private def verifySuccessfulOneOfContributionsResult(result: Future[Result]) = {
     status(result) shouldEqual OK
     val jsonBody = contentAsJson(result)
     jsonBody shouldEqual
@@ -256,6 +276,7 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
                    | ]
                  """.stripMargin)
   }
+
   "getMyMembershipAttributesFeatures" should {
     "return unauthorised when cookies not provided" in {
       val req = FakeRequest()
@@ -285,15 +306,17 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
       status(result) shouldEqual OK
       val jsonBody = contentAsJson(result)
       jsonBody shouldEqual
-        Json.parse("""
+        Json.parse(s"""
                      |{
                      |  "userId": "456",
                      |  "showSupportMessaging": true,
+                     |  "feastIosSubscriptionGroup": "${FeastApp.IosSubscriptionGroupIds.RegularSubscription}",
                      |  "contentAccess": {
                      |    "member": false,
                      |    "paidMember": false,
                      |    "recurringContributor": false,
                      |    "supporterPlus" : false,
+                     |    "feast": false,
                      |    "digitalPack": false,
                      |    "paperSubscriber": false,
                      |    "guardianWeeklySubscriber": false,
@@ -301,6 +324,36 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
                      |  }
                      |}""".stripMargin)
       verifyIdentityHeadersSet(result, userWithoutAttributesUserId)
+
+    }
+
+    "return the correct feast attributes for recurring contributors who signed up before feast launch" in {
+      val req = FakeRequest().withCookies(recurringContributorCookie)
+      val result = controller.attributes(req)
+
+      status(result) shouldEqual OK
+      val jsonBody = contentAsJson(result)
+      jsonBody shouldEqual
+        Json.parse(s"""
+             |{
+             |  "userId": "101",
+             |  "showSupportMessaging": false,
+             |  "feastIosSubscriptionGroup": "${FeastApp.IosSubscriptionGroupIds.ExtendedTrial}",
+             |  "recurringContributionPaymentPlan":"Monthly Contribution",
+             |  "recurringContributionAcquisitionDate":"$dateBeforeFeastLaunch",
+             |  "contentAccess": {
+             |    "member": false,
+             |    "paidMember": false,
+             |    "recurringContributor": true,
+             |    "supporterPlus" : false,
+             |    "feast": false,
+             |    "digitalPack": false,
+             |    "paperSubscriber": false,
+             |    "guardianWeeklySubscriber": false,
+             |    "guardianPatron": false
+             |  }
+             |}""".stripMargin)
+      verifyIdentityHeadersSet(result, userWithRecurringContributionUserId)
 
     }
 
@@ -335,7 +388,7 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
       val req = FakeRequest().withCookies(validUserCookie)
       val result: Future[Result] = controller.attributes(req)
 
-      verifySuccessfullAttributesResult(result)
+      verifySuccessfulAttributesResult(result)
       verifyIdentityHeadersSet(result, validUser.identityId)
 
     }
@@ -351,7 +404,7 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
       val req = FakeRequest().withCookies(validUserCookie)
       val result: Future[Result] = controller.oneOffContributions(req)
 
-      verifySuccessfullOneOfContributionsResult(result)
+      verifySuccessfulOneOfContributionsResult(result)
       verifyIdentityHeadersSet(result, validUser.identityId)
     }
 
@@ -359,7 +412,7 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
       val req = FakeRequest().withCookies(validUserCookie)
       val result: Future[Result] = controller.oneOffContributions(req)
 
-      verifySuccessfullOneOfContributionsResult(result)
+      verifySuccessfulOneOfContributionsResult(result)
       verifyIdentityHeadersSet(result, validUser.identityId)
     }
 

--- a/membership-attribute-service/test/services/SupporterRatePlanToAttributesMapperTest.scala
+++ b/membership-attribute-service/test/services/SupporterRatePlanToAttributesMapperTest.scala
@@ -343,12 +343,13 @@ class SupporterRatePlanToAttributesMapperTest extends Specification {
     }
 
     "handle supporter with multiple products correctly" in {
+      val recurringContributionAcquisitionDate = LocalDate.parse("2024-02-29")
       mapper
         .attributesFromSupporterRatePlans(
           identityId,
           List(
             ratePlanItem("2c92a0f94c547592014c69f5b0ff4f7e"),
-            ratePlanItem("2c92a0fc5aacfadd015ad24db4ff5e97"),
+            ratePlanItem("2c92a0fc5aacfadd015ad24db4ff5e97", termEndDate, recurringContributionAcquisitionDate),
             ratePlanItem("2c92a0fb4edd70c8014edeaa4eae220a"),
             ratePlanItem("2c92a00870ec598001710740d0d83017"),
             ratePlanItem("2c92a0fe6619b4b601661ab300222651"),
@@ -366,7 +367,7 @@ class SupporterRatePlanToAttributesMapperTest extends Specification {
           GuardianWeeklySubscriptionExpiryDate = Some(termEndDate),
           LiveAppSubscriptionExpiryDate = None,
           GuardianPatronExpiryDate = None,
-          RecurringContributionAcquisitionDate = Some(LocalDate.parse("2024-02-29")),
+          RecurringContributionAcquisitionDate = Some(recurringContributionAcquisitionDate),
         ),
       )
     }

--- a/membership-attribute-service/test/services/SupporterRatePlanToAttributesMapperTest.scala
+++ b/membership-attribute-service/test/services/SupporterRatePlanToAttributesMapperTest.scala
@@ -366,7 +366,7 @@ class SupporterRatePlanToAttributesMapperTest extends Specification {
           GuardianWeeklySubscriptionExpiryDate = Some(termEndDate),
           LiveAppSubscriptionExpiryDate = None,
           GuardianPatronExpiryDate = None,
-          RecurringContributionAcquisitionDate = Some(LocalDate.parse("2024-02-29"))
+          RecurringContributionAcquisitionDate = Some(LocalDate.parse("2024-02-29")),
         ),
       )
     }

--- a/membership-attribute-service/test/services/SupporterRatePlanToAttributesMapperTest.scala
+++ b/membership-attribute-service/test/services/SupporterRatePlanToAttributesMapperTest.scala
@@ -355,17 +355,18 @@ class SupporterRatePlanToAttributesMapperTest extends Specification {
           ),
         ) should beSome(
         Attributes(
-          identityId,
-          Some("Supporter"),
-          Some("Monthly Contribution"),
-          None,
-          None,
-          None,
-          Some(termEndDate),
-          Some(termEndDate),
-          Some(termEndDate),
-          None,
-          None,
+          UserId = identityId,
+          Tier = Some("Supporter"),
+          RecurringContributionPaymentPlan = Some("Monthly Contribution"),
+          OneOffContributionDate = None,
+          MembershipJoinDate = None,
+          SupporterPlusExpiryDate = None,
+          DigitalSubscriptionExpiryDate = Some(termEndDate),
+          PaperSubscriptionExpiryDate = Some(termEndDate),
+          GuardianWeeklySubscriptionExpiryDate = Some(termEndDate),
+          LiveAppSubscriptionExpiryDate = None,
+          GuardianPatronExpiryDate = None,
+          RecurringContributionAcquisitionDate = Some(LocalDate.parse("2024-02-29"))
         ),
       )
     }


### PR DESCRIPTION
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->

There is a request by the Feast team to allow access to the app or to a free trial IAP by various cohorts of the existing Supporter base (see https://docs.google.com/presentation/d/1y6Sxe5pLiq8bUSreLiPy-CsWZHf-0DmWlFSRh3Qycks/edit).

I created this PR (1) to collaborate with Ben Briggs on what the new fields will look like so that work across both teams can run in parallel and (2) to roughly demonstrate that the code changes were not extensive, and possible without requiring access to more [SupporterProduct] data within MDAPI.

<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
- Added new `feast` boolean within the `contentAccess` object
- Added a new `feastIosSubscriptionGroup` field at the top level to provide advice to the app on which subscription group (SKU) to offer (this moves logic to the backend saving logic in the app having to make the decision).

### trello card/screenshot/json/related PRs etc
https://trello.com/c/qZy2vvXn and https://trello.com/c/rPUKspl9