### PR TITLE
Give Feast access to supporter members

### DIFF
--- a/membership-attribute-service/app/models/FeastApp.scala
+++ b/membership-attribute-service/app/models/FeastApp.scala
@@ -16,6 +16,7 @@ object FeastApp {
 
   def shouldGetFeastAccess(attributes: Attributes) =
     attributes.isStaffTier ||
+      attributes.isSupporterTier ||
       attributes.isPartnerTier ||
       attributes.isPatronTier ||
       attributes.isGuardianPatron ||


### PR DESCRIPTION
Supporter Members should also get 6 months free of feast as per [this doc (private)](https://docs.google.com/presentation/d/1y6Sxe5pLiq8bUSreLiPy-CsWZHf-0DmWlFSRh3Qycks/edit#slide=id.g1f0f1f87f11_0_0).

> Recurring Contributors / Supporter Members / IAP / Guardian Weekly subs

This enables that.
