### PR TITLE
fix: change SupporterTier to have free feast trial

### DIFF
--- a/membership-attribute-service/app/models/FeastApp.scala
+++ b/membership-attribute-service/app/models/FeastApp.scala
@@ -16,7 +16,6 @@ object FeastApp {
 
   def shouldGetFeastAccess(attributes: Attributes) =
     attributes.isStaffTier ||
-      attributes.isSupporterTier ||
       attributes.isPartnerTier ||
       attributes.isPatronTier ||
       attributes.isGuardianPatron ||
@@ -30,7 +29,8 @@ object FeastApp {
   private def shouldGetFreeTrial(attributes: Attributes) =
     isRecurringContributorWhoSubscribedBeforeFeastLaunch(attributes) ||
       attributes.isPremiumLiveAppSubscriber ||
-      attributes.isGuardianWeeklySubscriber
+      attributes.isGuardianWeeklySubscriber ||
+      attributes.isSupporterTier
 
   private def shouldShowSubscriptionOptions(attributes: Attributes) = !shouldGetFeastAccess(attributes)
 


### PR DESCRIPTION
The `SupporterTier` should have a 6 month free trial for feast rather than full access forever. 

(Unit tests to follow)