### PR TITLE
jd-paper-feast

### DIFF
--- a/membership-attribute-service/app/models/FeastApp.scala
+++ b/membership-attribute-service/app/models/FeastApp.scala
@@ -5,7 +5,9 @@ import org.joda.time.LocalDate
 import scalaz.Scalaz.ToBooleanOpsFromBoolean
 
 object FeastApp {
+
   val FeastIosLaunchDate = LocalDate.parse("2024-04-01")
+
   object IosSubscriptionGroupIds {
     // Subscription group ids are used by the app to tell the app store which subscription option to show to the user
     val ExtendedTrial = "21445388"
@@ -14,13 +16,12 @@ object FeastApp {
 
   private def isBeforeFeastLaunch(dt: LocalDate): Boolean = dt.isBefore(FeastIosLaunchDate)
 
-  def shouldGetFeastAccess(attributes: Attributes) =
+  def shouldGetFeastAccess(attributes: Attributes): Boolean =
     attributes.isStaffTier ||
       attributes.isPartnerTier ||
       attributes.isPatronTier ||
       attributes.isGuardianPatron ||
       attributes.digitalSubscriberHasActivePlan ||
-      attributes.isPaperSubscriber ||
       attributes.isSupporterPlus
 
   private def isRecurringContributorWhoSubscribedBeforeFeastLaunch(attributes: Attributes) =
@@ -30,11 +31,12 @@ object FeastApp {
     isRecurringContributorWhoSubscribedBeforeFeastLaunch(attributes) ||
       attributes.isPremiumLiveAppSubscriber ||
       attributes.isGuardianWeeklySubscriber ||
-      attributes.isSupporterTier
+      attributes.isSupporterTier ||
+      attributes.isPaperSubscriber
 
   private def shouldShowSubscriptionOptions(attributes: Attributes) = !shouldGetFeastAccess(attributes)
 
-  def getFeastIosSubscriptionGroup(attributes: Attributes) =
+  def getFeastIosSubscriptionGroup(attributes: Attributes): Option[String] =
     shouldShowSubscriptionOptions(attributes).option(
       if (shouldGetFreeTrial(attributes))
         ExtendedTrial


### PR DESCRIPTION
At the moment Paper only subscribers will get full feast access in the app.

MRR want paper only to get the extended trial, and only Print+digital subscribers to get the full access.

This PR moves the print only to be in the free trial group.