### PR TITLE
add identity id to all log statements

### DIFF
--- a/membership-attribute-service/app/actions/CommonActions.scala
+++ b/membership-attribute-service/app/actions/CommonActions.scala
@@ -54,9 +54,7 @@ class AuthenticatedUserAndBackendRequest[A](
     val touchpoint: TouchpointComponents,
     val request: Request[A],
 ) extends WrappedRequest[A](request) {
-  implicit val logPrefix: LogPrefix = new LogPrefix {
-    override def message: String = user.identityId
-  }
+  implicit val logPrefix: LogPrefix = user.logPrefix
 }
 
 class AuthAndBackendRequest[A](

--- a/membership-attribute-service/app/actions/CommonActions.scala
+++ b/membership-attribute-service/app/actions/CommonActions.scala
@@ -62,7 +62,5 @@ class AuthAndBackendRequest[A](
     val touchpoint: TouchpointComponents,
     request: Request[A],
 ) extends WrappedRequest[A](request) {
-  implicit val logPrefix: LogPrefix = new LogPrefix {
-    override def message: String = redirectAdvice.userId.getOrElse("no-identity-id")
-  }
+  implicit val logPrefix: LogPrefix = LogPrefix(redirectAdvice.userId.getOrElse("no-identity-id"))
 }

--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -6,6 +6,7 @@ import com.gu.identity.IdapiService
 import com.gu.identity.auth._
 import com.gu.identity.play.IdentityPlayAuthService
 import com.gu.memsub.subsv2.services.SubscriptionService.CatalogMap
+import com.gu.monitoring.SafeLogger.LogPrefix
 import com.gu.monitoring.{SafeLogging, ZuoraMetrics}
 import com.gu.okhttp.RequestRunners
 import com.gu.touchpoint.TouchpointBackendConfig
@@ -122,7 +123,12 @@ class TouchpointComponents(
 
   lazy val catalogRestClient = rest.SimpleClient[Future](backendConfig.zuoraRest, RequestRunners.configurableFutureRunner(60.seconds))
   lazy val catalogService = catalogServiceOverride.getOrElse(
-    new CatalogService(productIds, FetchCatalog.fromZuoraApi(catalogRestClient), Await.result(_, 60.seconds), stage.value),
+    new CatalogService(
+      productIds,
+      FetchCatalog.fromZuoraApi(catalogRestClient)(implicitly, LogPrefix.noLogPrefix),
+      Await.result(_, 60.seconds),
+      stage.value,
+    ),
   )
 
   lazy val futureCatalog: Future[CatalogMap] = catalogService.catalog

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -57,7 +57,7 @@ class AttributeController(
 
   private def getLatestMobileSubscription(
       identityId: String,
-  )(implicit executionContext: ExecutionContext): Future[Option[MobileSubscriptionStatus]] = {
+  )(implicit executionContext: ExecutionContext, logPrefix: LogPrefix): Future[Option[MobileSubscriptionStatus]] = {
     mobileSubscriptionService.getSubscriptionStatusForUser(identityId).transform {
       case Failure(error) =>
         metrics.incrementCount(s"mobile-subscription-fetch-exception")

--- a/membership-attribute-service/app/controllers/ContactController.scala
+++ b/membership-attribute-service/app/controllers/ContactController.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import actions.{AuthAndBackendRequest, CommonActions, Return401IfNotSignedInRecently}
+import com.gu.monitoring.SafeLogger.LogPrefix
 import com.gu.monitoring.SafeLogging
 import models.AccessScope.updateSelf
 import models.DeliveryAddress
@@ -25,6 +26,7 @@ class ContactController(
 
   def updateDeliveryAddress(contactId: String): Action[AnyContent] =
     AuthorizeForRecentLogin(Return401IfNotSignedInRecently, requiredScopes = List(updateSelf)).async { request =>
+      import request.logPrefix
       metrics.measureDuration("PUT /user-attributes/me/delivery-address/:contactId") {
         logger.info(s"Updating delivery address for contact $contactId")
 
@@ -58,7 +60,7 @@ class ContactController(
   private def isContactOwnedByRequester(
       request: AuthAndBackendRequest[AnyContent],
       contactId: String,
-  ): Future[Boolean] = {
+  )(implicit logPrefix: LogPrefix): Future[Boolean] = {
     val contactRepository = request.touchpoint.contactRepository
     request.redirectAdvice.userId match {
       case Some(userId) =>
@@ -74,7 +76,7 @@ class ContactController(
       contactRepository: ContactRepository,
       contactId: String,
       address: DeliveryAddress,
-  ): Future[Unit] = {
+  )(implicit logPrefix: LogPrefix): Future[Unit] = {
     val contactFields = {
       def contactField(name: String, optValue: Option[String]): Map[String, String] =
         optValue map { value =>

--- a/membership-attribute-service/app/controllers/HealthCheckController.scala
+++ b/membership-attribute-service/app/controllers/HealthCheckController.scala
@@ -36,7 +36,7 @@ class HealthCheckController(touchPointBackends: TouchpointBackends, override val
       if (failures.isEmpty) {
         Ok(Json.obj("status" -> "ok", "gitCommitId" -> app.BuildInfo.gitCommitId))
       } else {
-        failures.flatMap(_.messages).foreach(msg => logger.warn(msg))
+        failures.flatMap(_.messages).foreach(msg => logger.warnNoPrefix(msg))
         ServiceUnavailable("Service Unavailable")
       }
     }

--- a/membership-attribute-service/app/controllers/PaymentUpdateController.scala
+++ b/membership-attribute-service/app/controllers/PaymentUpdateController.scala
@@ -91,8 +91,8 @@ class PaymentUpdateController(
       contact: Contact,
       paymentMethod: PaymentType,
       plan: SubscriptionPlan.AnyPlan,
-  ): SimpleEitherT[Unit] =
-    SimpleEitherT.rightT(sendEmail(paymentMethodChangedEmail(emailAddress, contact, paymentMethod, plan)))
+  )(implicit logPrefix: LogPrefix): SimpleEitherT[Unit] =
+    SimpleEitherT.rightT(sendEmail.send(paymentMethodChangedEmail(emailAddress, contact, paymentMethod, plan)))
 
   private def checkDirectDebitUpdateResult(
       userId: String,

--- a/membership-attribute-service/app/loghandling/DeprecatedRequestLogger.scala
+++ b/membership-attribute-service/app/loghandling/DeprecatedRequestLogger.scala
@@ -1,5 +1,6 @@
 package loghandling
 
+import com.gu.monitoring.SafeLogger.LogPrefix
 import com.gu.monitoring.SafeLogging
 import play.api.mvc.{AnyContent, WrappedRequest}
 
@@ -7,7 +8,7 @@ object DeprecatedRequestLogger extends SafeLogging {
 
   val deprecatedSearchPhrase = "DeprecatedEndpointCalled"
 
-  def logDeprecatedRequest(request: WrappedRequest[AnyContent]): Unit = {
+  def logDeprecatedRequest(request: WrappedRequest[AnyContent])(implicit logPrefix: LogPrefix): Unit = {
     logger.info(s"$deprecatedSearchPhrase ${request.method} ${request.path} with headers ${request.headers.toMap} with body ${request.body}")
   }
 }

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -3,6 +3,7 @@ import com.gu.i18n.Country
 import com.gu.memsub.subsv2.SubscriptionPlan.AnyPlan
 import com.gu.memsub.subsv2._
 import com.gu.memsub.{Subscription, _}
+import com.gu.monitoring.SafeLogger.LogPrefix
 import com.gu.monitoring.SafeLogging
 import com.gu.services.model.PaymentDetails
 import json.localDateWrites
@@ -38,7 +39,7 @@ object AccountDetails {
 
     import accountDetails._
 
-    def toJson: JsObject = {
+    def toJson(implicit logPrefix: LogPrefix): JsObject = {
 
       val product = accountDetails.subscription.plan.product
 

--- a/membership-attribute-service/app/models/ProductsResponse.scala
+++ b/membership-attribute-service/app/models/ProductsResponse.scala
@@ -1,5 +1,6 @@
 package models
 
+import com.gu.monitoring.SafeLogger.LogPrefix
 import play.api.libs.json._
 
 case class UserDetails(firstName: Option[String], lastName: Option[String], email: String)
@@ -8,8 +9,8 @@ case class ProductsResponse(user: UserDetails, products: List[AccountDetails])
 
 object ProductsResponse {
   implicit val userDetailsWrites: OWrites[UserDetails] = Json.writes[UserDetails]
-  implicit val accountDetailsWrites: Writes[AccountDetails] = Writes[AccountDetails](_.toJson)
-  implicit val writes: OWrites[ProductsResponse] = Json.writes[ProductsResponse]
+  implicit def accountDetailsWrites(implicit logPrefix: LogPrefix): Writes[AccountDetails] = Writes[AccountDetails](_.toJson)
+  implicit def writes(implicit logPrefix: LogPrefix): OWrites[ProductsResponse] = Json.writes[ProductsResponse]
 
   def from(user: UserFromToken, products: List[AccountDetails]) =
     ProductsResponse(

--- a/membership-attribute-service/app/models/UserFromToken.scala
+++ b/membership-attribute-service/app/models/UserFromToken.scala
@@ -2,6 +2,7 @@ package models
 
 import com.gu.identity.auth._
 import com.gu.identity.model.User
+import com.gu.monitoring.SafeLogger.LogPrefix
 
 import java.time.{Instant, ZoneId, ZonedDateTime}
 
@@ -26,7 +27,11 @@ case class UserFromToken(
     username: Option[String] = None,
     userEmailValidated: Option[Boolean] = None,
     authTime: Option[ZonedDateTime], // optional because not available from Idapi
-) extends AccessClaims
+) extends AccessClaims {
+  implicit val logPrefix: LogPrefix = new LogPrefix {
+    override def message: String = identityId
+  }
+}
 
 object UserFromToken {
 

--- a/membership-attribute-service/app/models/UserFromToken.scala
+++ b/membership-attribute-service/app/models/UserFromToken.scala
@@ -28,9 +28,7 @@ case class UserFromToken(
     userEmailValidated: Option[Boolean] = None,
     authTime: Option[ZonedDateTime], // optional because not available from Idapi
 ) extends AccessClaims {
-  implicit val logPrefix: LogPrefix = new LogPrefix {
-    override def message: String = identityId
-  }
+  implicit val logPrefix: LogPrefix = LogPrefix(identityId)
 }
 
 object UserFromToken {

--- a/membership-attribute-service/app/monitoring/ErrorHandling.scala
+++ b/membership-attribute-service/app/monitoring/ErrorHandling.scala
@@ -46,9 +46,7 @@ class ErrorHandler(
     result.foreach { result: Result =>
       val aaa = result.header.headers.get(xGuIdentityIdHeaderName)
       val prefix = aaa.getOrElse("no-identity-id")
-      implicit val logPrefix: LogPrefix = new LogPrefix {
-        override def message: String = prefix
-      }
+      implicit val logPrefix: LogPrefix = LogPrefix(prefix)
       // now log with the identity id so it appears in searches
       logger.error(scrub"Error handling request request: $request", ex)
     }

--- a/membership-attribute-service/app/monitoring/ErrorHandling.scala
+++ b/membership-attribute-service/app/monitoring/ErrorHandling.scala
@@ -1,7 +1,9 @@
 package monitoring
+import com.gu.monitoring.SafeLogger.LogPrefix
 import com.gu.monitoring.SafeLogging
 import controllers.{Cached, NoCache}
 import filters.AddGuIdentityHeaders
+import filters.AddGuIdentityHeaders.{identityHeaderNames, xGuIdentityIdHeaderName}
 import models.ApiErrors.{badRequest, internalError, notFound}
 import play.api._
 import play.api.http.DefaultHttpErrorHandler
@@ -38,11 +40,24 @@ class ErrorHandler(
   }
 
   override protected def onProdServerError(request: RequestHeader, ex: UsefulException): Future[Result] = {
-    logger.error(scrub"Error handling request request: $request", ex)
-    addGuIdentityHeaders.fromIdapiIfMissing(request, internalError)
+    // log first to make sure it's not lost
+    logger.errorNoPrefix(scrub"Error handling request request: $request", ex)
+    val result = addGuIdentityHeaders.fromIdapiIfMissing(request, internalError)
+    result.foreach { result: Result =>
+      val aaa = result.header.headers.get(xGuIdentityIdHeaderName)
+      val prefix = aaa.getOrElse("no-identity-id")
+      implicit val logPrefix: LogPrefix = new LogPrefix {
+        override def message: String = prefix
+      }
+      // now log with the identity id so it appears in searches
+      logger.error(scrub"Error handling request request: $request", ex)
+    }
+    result
   }
+
   override protected def onBadRequest(request: RequestHeader, message: String): Future[Result] = {
     logServerError(request, new PlayException("Bad request", message))
     Future.successful(NoCache(BadRequest(Json.toJson(badRequest(message)))))
   }
+
 }

--- a/membership-attribute-service/app/monitoring/ErrorHandling.scala
+++ b/membership-attribute-service/app/monitoring/ErrorHandling.scala
@@ -44,8 +44,8 @@ class ErrorHandler(
     logger.errorNoPrefix(scrub"Error handling request request: $request", ex)
     val result = addGuIdentityHeaders.fromIdapiIfMissing(request, internalError)
     result.foreach { result: Result =>
-      val aaa = result.header.headers.get(xGuIdentityIdHeaderName)
-      val prefix = aaa.getOrElse("no-identity-id")
+      val identityId = result.header.headers.get(xGuIdentityIdHeaderName)
+      val prefix = identityId.getOrElse("no-identity-id")
       implicit val logPrefix: LogPrefix = LogPrefix(prefix)
       // now log with the identity id so it appears in searches
       logger.error(scrub"Error handling request request: $request", ex)

--- a/membership-attribute-service/app/monitoring/SentryLogging.scala
+++ b/membership-attribute-service/app/monitoring/SentryLogging.scala
@@ -12,9 +12,9 @@ import scala.util.{Failure, Success, Try}
 object SentryLogging extends SafeLogging {
   def init(config: SentryConfig): Unit = {
     config.sentryDsn match {
-      case None => logger.warn("No Sentry logging configured (OK for dev)")
+      case None => logger.warnNoPrefix("No Sentry logging configured (OK for dev)")
       case Some(sentryDSN) =>
-        logger.info(s"Initialising Sentry logging")
+        logger.infoNoPrefix(s"Initialising Sentry logging")
         Try {
           Sentry.init(sentryDSN)
           val buildInfo: Map[String, String] = app.BuildInfo.toMap.view.mapValues(_.toString).toMap

--- a/membership-attribute-service/app/services/AccountDetailsFromZuora.scala
+++ b/membership-attribute-service/app/services/AccountDetailsFromZuora.scala
@@ -75,7 +75,7 @@ class AccountDetailsFromZuora(
     }
   }
 
-  private def getPaymentMethod(id: PaymentMethodId): Future[Either[String, ZuoraRestService.PaymentMethodResponse]] =
+  private def getPaymentMethod(id: PaymentMethodId)(implicit logPrefix: LogPrefix): Future[Either[String, ZuoraRestService.PaymentMethodResponse]] =
     zuoraRestService.getPaymentMethod(id.get).map(_.toEither)
 
   private def nonGiftContactAndSubscriptionsFor(contact: Contact)(implicit logPrefix: LogPrefix): Future[List[ContactAndSubscription]] = {
@@ -170,7 +170,7 @@ class AccountDetailsFromZuora(
       userId: String,
       nonGiftSubscription: List[ContactAndSubscription],
       contact: Contact,
-  ): SimpleEitherT[List[ContactAndSubscription]] = {
+  )(implicit logPrefix: LogPrefix): SimpleEitherT[List[ContactAndSubscription]] = {
     metrics.measureDurationEither("checkForGiftSubscription") {
       for {
         records <- SimpleEitherT(zuoraRestService.getGiftSubscriptionRecordsFromIdentityId(userId))
@@ -183,7 +183,7 @@ class AccountDetailsFromZuora(
   private def reuseAlreadyFetchedSubscriptionIfAvailable(
       giftRecords: List[ZuoraRestService.GiftSubscriptionsFromIdentityIdRecord],
       nonGiftSubs: List[ContactAndSubscription],
-  ): SimpleEitherT[List[Subscription[AnyPlan]]] = {
+  )(implicit logPrefix: LogPrefix): SimpleEitherT[List[Subscription[AnyPlan]]] = {
     val all = giftRecords.map { giftRecord =>
       val subscriptionName = Name(giftRecord.Name)
       // If the current user is both the gifter and the giftee we will have already retrieved their

--- a/membership-attribute-service/app/services/GuardianPatronService.scala
+++ b/membership-attribute-service/app/services/GuardianPatronService.scala
@@ -38,7 +38,7 @@ class GuardianPatronService(
     }
   }
 
-  private def getListDetailsFromStripe(items: List[DynamoSupporterRatePlanItem]): Future[List[AccountDetails]] = {
+  private def getListDetailsFromStripe(items: List[DynamoSupporterRatePlanItem])(implicit logPrefix: LogPrefix): Future[List[AccountDetails]] = {
     Future.sequence(
       items
         .filter(isGuardianPatronProduct)
@@ -50,7 +50,7 @@ class GuardianPatronService(
   private def isGuardianPatronProduct(item: DynamoSupporterRatePlanItem) =
     item.productRatePlanId == guardianPatronProductRatePlanId
 
-  private def fetchAccountDetailsFromStripe(subscriptionId: String): Future[AccountDetails] =
+  private def fetchAccountDetailsFromStripe(subscriptionId: String)(implicit logPrefix: LogPrefix): Future[AccountDetails] =
     metrics.measureDuration("fetchAccountDetailsFromStripe") {
       for {
         subscription <- patronsStripeService.fetchSubscription(subscriptionId)

--- a/membership-attribute-service/app/services/IdentityAuthService.scala
+++ b/membership-attribute-service/app/services/IdentityAuthService.scala
@@ -27,21 +27,21 @@ class IdentityAuthService(identityPlayAuthService: IdentityPlayAuthService)(impl
         case Left(OktaValidationException(validationError: ValidationError)) =>
           validationError match {
             case MissingRequiredScope(_) =>
-              logger.warn(s"could not validate okta token - $validationError")
+              logger.warnNoPrefix(s"could not validate okta token - $validationError")
               Left(Forbidden)
             case OktaValidationError(originalException) =>
-              logger.warn(
+              logger.warnNoPrefix(
                 s"could not validate okta token - $validationError. Path: ${requestHeader.path}. User-Agent: ${requestHeader.headers.get("User-Agent")}",
                 originalException,
               )
               Left(Unauthorised)
             case _ =>
-              logger.warn(s"could not validate okta token - $validationError")
+              logger.warnNoPrefix(s"could not validate okta token - $validationError")
               Left(Unauthorised)
           }
 
         case Left(err) =>
-          logger.warn(s"valid request but expired token or cookie so user must log in again - $err")
+          logger.warnNoPrefix(s"valid request but expired token or cookie so user must log in again - $err")
           Left(Unauthorised)
 
         case Right(Some(user)) => Right(user)
@@ -84,6 +84,7 @@ class IdentityAuthService(identityPlayAuthService: IdentityPlayAuthService)(impl
         case (_: OktaUserCredentials, claims) =>
           Some(claims)
         case (_: IdapiUserCredentials, claims) =>
+          import claims.logPrefix
           logger.warn("Authorised by Idapi token")
           Some(claims)
       }

--- a/membership-attribute-service/app/services/MobileSubscriptionService.scala
+++ b/membership-attribute-service/app/services/MobileSubscriptionService.scala
@@ -1,6 +1,7 @@
 package services
 
 import com.github.nscala_time.time.OrderingImplicits._
+import com.gu.monitoring.SafeLogger.LogPrefix
 import com.gu.monitoring.SafeLogging
 import com.typesafe.config.Config
 import models.MobileSubscriptionStatus
@@ -11,7 +12,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 trait MobileSubscriptionService {
 
-  def getSubscriptionStatusForUser(identityId: String): Future[Either[String, Option[MobileSubscriptionStatus]]]
+  def getSubscriptionStatusForUser(identityId: String)(implicit logPrefix: LogPrefix): Future[Either[String, Option[MobileSubscriptionStatus]]]
 
 }
 
@@ -25,7 +26,9 @@ class MobileSubscriptionServiceImpl(wsClient: WSClient, config: Config)(implicit
     case _ => "https://mobile-purchases.mobile-aws.code.dev-guardianapis.com"
   }
 
-  override def getSubscriptionStatusForUser(identityId: String): Future[Either[String, Option[MobileSubscriptionStatus]]] = {
+  override def getSubscriptionStatusForUser(
+      identityId: String,
+  )(implicit logPrefix: LogPrefix): Future[Either[String, Option[MobileSubscriptionStatus]]] = {
     val response = wsClient
       .url(s"$subscriptionURL/user/subscriptions/$identityId")
       .withHttpHeaders("Authorization" -> s"Bearer $mobileSubscriptionApiKey")

--- a/membership-attribute-service/app/services/mail/SendEmail.scala
+++ b/membership-attribute-service/app/services/mail/SendEmail.scala
@@ -1,15 +1,16 @@
 package services.mail
 
+import com.gu.monitoring.SafeLogger.LogPrefix
 import play.api.libs.json.Json
 
 import scala.concurrent.Future
 
 trait SendEmail {
-  def apply(emailData: EmailData): Future[Unit]
+  def send(emailData: EmailData)(implicit logPrefix: LogPrefix): Future[Unit]
 }
 
 class SendEmailToSQS(queueName: QueueName) extends SendEmail {
   val sendAsync = new SqsAsync
 
-  override def apply(emailData: EmailData): Future[Unit] = sendAsync.send(queueName, Json.prettyPrint(emailData.toJson))
+  override def send(emailData: EmailData)(implicit logPrefix: LogPrefix): Future[Unit] = sendAsync.send(queueName, Json.prettyPrint(emailData.toJson))
 }

--- a/membership-attribute-service/app/services/mail/SqsAsync.scala
+++ b/membership-attribute-service/app/services/mail/SqsAsync.scala
@@ -1,5 +1,6 @@
 package services.mail
 
+import com.gu.monitoring.SafeLogger.LogPrefix
 import com.gu.monitoring.SafeLogging
 import services.mail.SqsAsync.CredentialsProvider
 import software.amazon.awssdk.auth.credentials.{AwsCredentialsProviderChain, InstanceProfileCredentialsProvider, ProfileCredentialsProvider}
@@ -21,7 +22,7 @@ class SqsAsync extends SafeLogging {
     .credentialsProvider(CredentialsProvider)
     .build()
 
-  def send(queueName: QueueName, payload: String): Future[Unit] = {
+  def send(queueName: QueueName, payload: String)(implicit logPrefix: LogPrefix): Future[Unit] = {
     for {
       queueUrl <- queueUrlFor(queueName)
       _ <- sendToUrl(queueUrl, payload).transform {
@@ -43,7 +44,7 @@ class SqsAsync extends SafeLogging {
       .asScala
       .map(_.queueUrl)
 
-  private def sendToUrl(queueUrl: String, payload: String): Future[SendMessageResponse] = {
+  private def sendToUrl(queueUrl: String, payload: String)(implicit logPrefix: LogPrefix): Future[SendMessageResponse] = {
     val request = SendMessageRequest.builder.queueUrl(queueUrl).messageBody(payload).build()
     logger.info(s"Sending message to SQS queue $queueUrl:\n$payload")
     client.sendMessage(request).asScala

--- a/membership-attribute-service/app/services/salesforce/ContactRepository.scala
+++ b/membership-attribute-service/app/services/salesforce/ContactRepository.scala
@@ -1,5 +1,6 @@
 package services.salesforce
 
+import com.gu.monitoring.SafeLogger.LogPrefix
 import com.gu.salesforce.{Contact, ContactId}
 import play.api.libs.json._
 import scalaz.\/
@@ -8,7 +9,7 @@ import scala.concurrent.Future
 
 trait ContactRepository {
 
-  def get(identityId: String): Future[String \/ Option[Contact]]
+  def get(identityId: String)(implicit logPrefix: LogPrefix): Future[String \/ Option[Contact]]
 
-  def update(contactId: String, contactFields: Map[String, String]): Future[Unit]
+  def update(contactId: String, contactFields: Map[String, String])(implicit logPrefix: LogPrefix): Future[Unit]
 }

--- a/membership-attribute-service/app/services/salesforce/SimpleContactRepository.scala
+++ b/membership-attribute-service/app/services/salesforce/SimpleContactRepository.scala
@@ -1,5 +1,6 @@
 package services.salesforce
 
+import com.gu.monitoring.SafeLogger.LogPrefix
 import com.gu.okhttp.RequestRunners
 import com.gu.okhttp.RequestRunners.FutureHttpClient
 import com.gu.salesforce.ContactDeserializer._
@@ -22,7 +23,7 @@ class SimpleContactRepository(private val salesforce: Scalaforce)(implicit execu
     \/.right,
   )
 
-  private def get(key: String, value: String): Future[String \/ Option[Contact]] = {
+  private def get(key: String, value: String)(implicit logPrefix: LogPrefix): Future[String \/ Option[Contact]] = {
     salesforce.Contact.read(key, value).map { failableJsonContact =>
       (for {
         resultOpt <- failableJsonContact
@@ -36,10 +37,12 @@ class SimpleContactRepository(private val salesforce: Scalaforce)(implicit execu
     }
   }
 
-  def get(identityId: String): Future[String \/ Option[Contact]] = // this returns right of None if the person isn't a member
+  def get(
+      identityId: String,
+  )(implicit logPrefix: LogPrefix): Future[String \/ Option[Contact]] = // this returns right of None if the person isn't a member
     get(Keys.IDENTITY_ID, identityId)
 
-  override def update(contactId: String, contactFields: Map[String, String]): Future[Unit] =
+  override def update(contactId: String, contactFields: Map[String, String])(implicit logPrefix: LogPrefix): Future[Unit] =
     salesforce.Contact.update(SFContactId(contactId), contactFields)
 }
 

--- a/membership-attribute-service/app/services/stripe/BasicStripeService.scala
+++ b/membership-attribute-service/app/services/stripe/BasicStripeService.scala
@@ -1,19 +1,20 @@
 package services.stripe
 
+import com.gu.monitoring.SafeLogger.LogPrefix
 import com.gu.stripe.Stripe
 import com.gu.stripe.Stripe.{Customer, CustomersPaymentMethods, StripeObject}
 
 import scala.concurrent.Future
 
 trait BasicStripeService {
-  def fetchCustomer(customerId: String): Future[Customer]
+  def fetchCustomer(customerId: String)(implicit logPrefix: LogPrefix): Future[Customer]
 
   @Deprecated
-  def createCustomer(card: String): Future[Customer]
+  def createCustomer(card: String)(implicit logPrefix: LogPrefix): Future[Customer]
 
-  def createCustomerWithStripePaymentMethod(stripePaymentMethodID: String): Future[Customer]
+  def createCustomerWithStripePaymentMethod(stripePaymentMethodID: String)(implicit logPrefix: LogPrefix): Future[Customer]
 
-  def fetchPaymentMethod(customerId: String): Future[CustomersPaymentMethods]
+  def fetchPaymentMethod(customerId: String)(implicit logPrefix: LogPrefix): Future[CustomersPaymentMethods]
 
-  def fetchSubscription(id: String): Future[Stripe.Subscription]
+  def fetchSubscription(id: String)(implicit logPrefix: LogPrefix): Future[Stripe.Subscription]
 }

--- a/membership-attribute-service/app/services/stripe/StripeService.scala
+++ b/membership-attribute-service/app/services/stripe/StripeService.scala
@@ -1,17 +1,18 @@
 package services.stripe
 
+import com.gu.monitoring.SafeLogger.LogPrefix
 import com.gu.stripe.Stripe._
 import com.gu.stripe.StripeServiceConfig
 import com.gu.zuora.api.{InvoiceTemplate, PaymentGateway, RegionalStripeGateways}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class StripeService(apiConfig: StripeServiceConfig, val basicStripeService: BasicStripeService)(implicit ec: ExecutionContext) {
+class StripeService(apiConfig: StripeServiceConfig, val basicStripeService: BasicStripeService) {
   val paymentIntentsGateway: PaymentGateway = RegionalStripeGateways.getPaymentIntentsGatewayForCountry(apiConfig.stripeAccountCountry)
   val invoiceTemplateOverride: Option[InvoiceTemplate] = apiConfig.invoiceTemplateOverride
 
-  def createCustomer(card: String): Future[Customer] = basicStripeService.createCustomer(card)
+  def createCustomer(card: String)(implicit logPrefix: LogPrefix): Future[Customer] = basicStripeService.createCustomer(card)
 
-  def createCustomerWithStripePaymentMethod(stripePaymentMethodID: String): Future[Customer] =
+  def createCustomerWithStripePaymentMethod(stripePaymentMethodID: String)(implicit logPrefix: LogPrefix): Future[Customer] =
     basicStripeService.createCustomerWithStripePaymentMethod(stripePaymentMethodID)
 }

--- a/membership-attribute-service/app/services/subscription/SubscriptionService.scala
+++ b/membership-attribute-service/app/services/subscription/SubscriptionService.scala
@@ -20,10 +20,11 @@ object SubscriptionService {
 }
 
 trait SubscriptionService {
+
   def get[P <: AnyPlan: SubPlanReads](
       name: memsub.Subscription.Name,
       isActiveToday: Boolean = false,
-  ): Future[Option[Subscription[P]]]
+  )(implicit logPrefix: LogPrefix): Future[Option[Subscription[P]]]
 
   def current[P <: AnyPlan: SubPlanReads](contact: ContactId)(implicit logPrefix: LogPrefix): Future[List[Subscription[P]]]
 
@@ -35,7 +36,9 @@ trait SubscriptionService {
       lastNMonths: Int = 3, // cancelled in the last N months
   )(implicit ev: SubPlanReads[AnyPlan], logPrefix: LogPrefix): Future[String \/ List[Subscription[AnyPlan]]]
 
-  def subscriptionsForAccountId[P <: AnyPlan: SubPlanReads](accountId: AccountId): Future[Disjunction[String, List[Subscription[P]]]]
+  def subscriptionsForAccountId[P <: AnyPlan: SubPlanReads](accountId: AccountId)(implicit
+      logPrefix: LogPrefix,
+  ): Future[Disjunction[String, List[Subscription[P]]]]
 
   def jsonSubscriptionsFromContact(contact: ContactId)(implicit logPrefix: LogPrefix): Future[Disjunction[String, List[JsValue]]]
 
@@ -60,5 +63,5 @@ trait SubscriptionService {
       subscriptionName: memsub.Subscription.Name,
       wallClockTimeNow: LocalTime = LocalTime.now(),
       today: LocalDate = LocalDate.now(),
-  ): EitherT[String, Future, Option[LocalDate]]
+  )(implicit logPrefix: LogPrefix): EitherT[String, Future, Option[LocalDate]]
 }

--- a/membership-attribute-service/app/services/subscription/SubscriptionTransform.scala
+++ b/membership-attribute-service/app/services/subscription/SubscriptionTransform.scala
@@ -8,6 +8,7 @@ import com.gu.memsub.subsv2.reads.CommonReads._
 import com.gu.memsub.subsv2.reads.SubJsonReads._
 import com.gu.memsub.subsv2.reads.SubPlanReads
 import com.gu.memsub.subsv2.services.SubscriptionService.CatalogMap
+import com.gu.monitoring.SafeLogger.LogPrefix
 import com.gu.monitoring.SafeLogging
 import org.joda.time.LocalDate
 import play.api.libs.json.{Reads => JsReads, _}
@@ -33,7 +34,7 @@ object SubscriptionTransform extends SafeLogging {
     }
   }
 
-  def backdoorRatePlanIdsFromJson(subJson: JsValue): Disjunction[String, List[SubIds]] = {
+  def backdoorRatePlanIdsFromJson(subJson: JsValue)(implicit logPrefix: LogPrefix): Disjunction[String, List[SubIds]] = {
     val ids = (subJson \ "ratePlans").validate[List[SubIds]](niceListReads(subIdsReads)).asEither.toDisjunction.leftMap(_.toString)
     // didn't actually check if they're current
 

--- a/membership-attribute-service/app/services/zuora/rest/SimpleClient.scala
+++ b/membership-attribute-service/app/services/zuora/rest/SimpleClient.scala
@@ -1,5 +1,6 @@
 package services.zuora.rest
 
+import com.gu.monitoring.SafeLogger.LogPrefix
 import com.gu.monitoring.{NoOpZuoraMetrics, ZuoraMetrics}
 import com.gu.okhttp.RequestRunners.FutureHttpClient
 import com.gu.zuora.ZuoraRestConfig
@@ -21,7 +22,7 @@ case class SimpleClient(
     client: FutureHttpClient,
     metrics: ZuoraMetrics = NoOpZuoraMetrics,
 )(implicit functor: Functor[Future], ec: ExecutionContext) {
-  def authenticated(url: String): Request.Builder = {
+  def authenticated(url: String)(implicit logPrefix: LogPrefix): Request.Builder = {
     metrics.countRequest() // to count total number of request hitting Zuora
 
     new Request.Builder()
@@ -60,13 +61,13 @@ case class SimpleClient(
 
   def jsonBody(in: JsValue): RequestBody = RequestBody.create(MediaType.parse("application/json"), in.toString())
 
-  def get[B](url: String)(implicit r: Reads[B]): Future[String \/ B] =
+  def get[B](url: String)(implicit r: Reads[B], logPrefix: LogPrefix): Future[String \/ B] =
     client.execute(authenticated(url).get.build).map(parseResponse(_)(r))
 
-  def put[A, B](url: String, in: A)(implicit r: Reads[B], w: Writes[A]): Future[String \/ B] =
+  def put[A, B](url: String, in: A)(implicit r: Reads[B], w: Writes[A], logPrefix: LogPrefix): Future[String \/ B] =
     client.execute(authenticated(url).put(body(in)).build).map(parseResponse(_)(r))
 
-  def post[A, B](url: String, in: A)(implicit r: Reads[B], w: Writes[A]): Future[String \/ B] =
+  def post[A, B](url: String, in: A)(implicit r: Reads[B], w: Writes[A], logPrefix: LogPrefix): Future[String \/ B] =
     client.execute(authenticated(url).post(body(in)).build).map(parseResponse(_)(r))
 
 }

--- a/membership-attribute-service/app/services/zuora/rest/ZuoraRestService.scala
+++ b/membership-attribute-service/app/services/zuora/rest/ZuoraRestService.scala
@@ -3,6 +3,7 @@ package services.zuora.rest
 import com.gu.i18n.{Country, Currency, Title}
 import com.gu.memsub.Subscription.{AccountId, AccountNumber, Name, RatePlanId, SubscriptionRatePlanChargeId}
 import com.gu.memsub.subsv2.reads.CommonReads._
+import com.gu.monitoring.SafeLogger.LogPrefix
 import com.gu.salesforce.ContactId
 import com.gu.zuora.ZuoraLookup
 import com.gu.zuora.api.PaymentGateway
@@ -398,13 +399,15 @@ object ZuoraRestService {
 }
 
 trait ZuoraRestService {
-  def getAccount(accountId: AccountId): Future[String \/ AccountSummary]
+  def getAccount(accountId: AccountId)(implicit logPrefix: LogPrefix): Future[String \/ AccountSummary]
 
-  def getObjectAccount(accountId: AccountId): Future[String \/ ObjectAccount]
+  def getObjectAccount(accountId: AccountId)(implicit logPrefix: LogPrefix): Future[String \/ ObjectAccount]
 
-  def getGiftSubscriptionRecordsFromIdentityId(identityId: String): Future[String \/ List[GiftSubscriptionsFromIdentityIdRecord]]
+  def getGiftSubscriptionRecordsFromIdentityId(identityId: String)(implicit
+      logPrefix: LogPrefix,
+  ): Future[String \/ List[GiftSubscriptionsFromIdentityIdRecord]]
 
-  def getPaymentMethod(paymentMethodId: String): Future[String \/ PaymentMethodResponse]
+  def getPaymentMethod(paymentMethodId: String)(implicit logPrefix: LogPrefix): Future[String \/ PaymentMethodResponse]
 
   def cancelSubscription(
       subscriptionName: Name,
@@ -412,11 +415,11 @@ trait ZuoraRestService {
       maybeChargedThroughDate: Option[
         LocalDate,
       ], // FIXME: Optionality should probably be removed and semantics changed to cancellationEffectiveDate (see comments bellow)
-  )(implicit ex: ExecutionContext): Future[String \/ Unit]
+  )(implicit ex: ExecutionContext, logPrefix: LogPrefix): Future[String \/ Unit]
 
-  def updateCancellationReason(subscriptionName: Name, userCancellationReason: String): Future[String \/ Unit]
+  def updateCancellationReason(subscriptionName: Name, userCancellationReason: String)(implicit logPrefix: LogPrefix): Future[String \/ Unit]
 
-  def disableAutoPay(accountId: AccountId): Future[String \/ Unit]
+  def disableAutoPay(accountId: AccountId)(implicit logPrefix: LogPrefix): Future[String \/ Unit]
 
   def updateChargeAmount(
       subscriptionName: Name,
@@ -425,7 +428,7 @@ trait ZuoraRestService {
       amount: Double,
       reason: String,
       applyFromDate: LocalDate,
-  )(implicit ex: ExecutionContext): Future[\/[String, Unit]]
+  )(implicit ex: ExecutionContext, logPrefix: LogPrefix): Future[\/[String, Unit]]
 
-  def getCancellationEffectiveDate(name: Name): Future[String \/ Option[String]]
+  def getCancellationEffectiveDate(name: Name)(implicit logPrefix: LogPrefix): Future[String \/ Option[String]]
 }

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -5,6 +5,7 @@ import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.stream.Materializer
 import com.gu.identity.auth.AccessScope
 import com.gu.identity.{RedirectAdviceResponse, SignedInRecently}
+import com.gu.monitoring.SafeLogger.LogPrefix
 import com.typesafe.config.ConfigFactory
 import components.{TouchpointBackends, TouchpointComponents}
 import configuration.{CreateTestUsernames, Stage}
@@ -209,7 +210,9 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
     }
 
   object FakeMobileSubscriptionService extends MobileSubscriptionService {
-    override def getSubscriptionStatusForUser(identityId: String): Future[Either[String, Option[MobileSubscriptionStatus]]] = {
+    override def getSubscriptionStatusForUser(
+        identityId: String,
+    )(implicit logPrefix: LogPrefix): Future[Either[String, Option[MobileSubscriptionStatus]]] = {
       if (identityId == userWithLiveAppUserId)
         Future.successful(Right(Some(MobileSubscriptionStatus(valid = true, dateTimeInTheFuture))))
       else

--- a/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
+++ b/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
@@ -8,6 +8,7 @@ import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mutable.Specification
 import testdata.AccountObjectTestData._
 import testdata.AccountSummaryTestData.{accountSummaryWithBalance, accountSummaryWithZeroBalance}
+import testdata.TestLogPrefix.testLogPrefix
 import testdata.{InvoiceAndPaymentTestData, SubscriptionTestData}
 
 import java.util.Locale

--- a/membership-attribute-service/test/testdata/TestLogPrefix.scala
+++ b/membership-attribute-service/test/testdata/TestLogPrefix.scala
@@ -4,8 +4,6 @@ import com.gu.monitoring.SafeLogger.LogPrefix
 
 object TestLogPrefix {
 
-  implicit val testLogPrefix: LogPrefix = new LogPrefix {
-    override def message: String = "TestLogPrefix"
-  }
+  implicit val testLogPrefix: LogPrefix = LogPrefix("TestLogPrefix")
 
 }

--- a/membership-common/src/main/scala/com/gu/aws/AwsS3Client.scala
+++ b/membership-common/src/main/scala/com/gu/aws/AwsS3Client.scala
@@ -2,6 +2,7 @@ package com.gu.aws
 
 import com.amazonaws.services.s3.model.{GetObjectRequest, S3ObjectInputStream}
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3Client}
+import com.gu.monitoring.SafeLogger.LogPrefix
 import com.gu.monitoring.SafeLogging
 import play.api.libs.json.{JsValue, Json}
 import scalaz.{-\/, \/, \/-}
@@ -15,7 +16,7 @@ object AwsS3 extends SafeLogging {
 
   def fetchObject(s3Client: AmazonS3, request: GetObjectRequest): Try[S3ObjectInputStream] = Try(s3Client.getObject(request).getObjectContent)
 
-  def fetchJson(s3Client: AmazonS3, request: GetObjectRequest): String \/ JsValue = {
+  def fetchJson(s3Client: AmazonS3, request: GetObjectRequest)(implicit logPrefix: LogPrefix): String \/ JsValue = {
     logger.info(s"Getting file from S3. Bucket: ${request.getBucketName} | Key: ${request.getKey}")
     val attempt = for {
       s3Stream <- fetchObject(s3Client, request)

--- a/membership-common/src/main/scala/com/gu/identity/IdapiService.scala
+++ b/membership-common/src/main/scala/com/gu/identity/IdapiService.scala
@@ -1,6 +1,7 @@
 package com.gu.identity
 
 import com.gu.memsub.util.WebServiceHelper
+import com.gu.monitoring.SafeLogger.LogPrefix
 import com.gu.okhttp.RequestRunners._
 import okhttp3.{Headers, Request}
 import play.api.libs.json._
@@ -43,7 +44,7 @@ class IdapiService(apiConfig: IdapiConfig, client: FutureHttpClient)(implicit ec
 
   implicit val readsIdapiError = Json.reads[IdapiError]
 
-  override def wsPreExecute(req: Request.Builder): Request.Builder = {
+  override def wsPreExecute(req: Request.Builder)(implicit logPrefix: LogPrefix): Request.Builder = {
     req.addHeader("X-GU-ID-Client-Access-Token", s"Bearer ${apiConfig.token}")
   }
 
@@ -61,7 +62,7 @@ class IdapiService(apiConfig: IdapiConfig, client: FutureHttpClient)(implicit ec
 
     private implicit val readsRedirectResponse: Reads[RedirectAdviceResponse] = Json.reads[RedirectAdviceResponse]
 
-    def getRedirectAdvice(cookieValue: String, scope: Option[String] = None): Future[RedirectAdviceResponse] =
+    def getRedirectAdvice(cookieValue: String, scope: Option[String] = None)(implicit logPrefix: LogPrefix): Future[RedirectAdviceResponse] =
       get[RedirectAdviceResponse](
         "auth/redirect",
         Headers.of(

--- a/membership-common/src/main/scala/com/gu/memsub/promo/LogImplicit.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/promo/LogImplicit.scala
@@ -1,11 +1,12 @@
 package com.gu.memsub.promo
 
+import com.gu.monitoring.SafeLogger.LogPrefix
 import com.gu.monitoring.SafeLogging
 
 object LogImplicit {
 
   implicit class Loggable[T](t: T) extends SafeLogging {
-    def withLogging(message: String): T = {
+    def withLogging(message: String)(implicit logPrefix: LogPrefix): T = {
       logger.info(s"$message {$t}")
       t
     }

--- a/membership-common/src/main/scala/com/gu/memsub/util/ScheduledTask.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/util/ScheduledTask.scala
@@ -26,7 +26,7 @@ trait ScheduledTask[T] extends SafeLogging {
   def task(): Future[T]
 
   def start(): Unit = {
-    logger.info(s"Starting $name scheduled task with an initial delay of: $initialDelay. This task will refresh every: $interval")
+    logger.infoNoPrefix(s"Starting $name scheduled task with an initial delay of: $initialDelay. This task will refresh every: $interval")
     system.scheduler.schedule(initialDelay, interval) {
       task.onComplete {
         case Success(t) => atomicReference.set(t)

--- a/membership-common/src/main/scala/com/gu/memsub/util/Timing.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/util/Timing.scala
@@ -1,12 +1,13 @@
 package com.gu.memsub.util
 
+import com.gu.monitoring.SafeLogger.LogPrefix
 import com.gu.monitoring.{CloudWatch, SafeLogging}
 
 import scala.concurrent.{ExecutionContext, Future}
 
 object Timing extends SafeLogging {
 
-  def record[T](cloudWatch: CloudWatch, metricName: String)(block: => Future[T])(implicit ec: ExecutionContext): Future[T] = {
+  def record[T](cloudWatch: CloudWatch, metricName: String)(block: => Future[T])(implicit ec: ExecutionContext, logPrefix: LogPrefix): Future[T] = {
     logger.debug(s"$metricName started...")
     cloudWatch.put(metricName, 1)
     val startTime = System.currentTimeMillis()

--- a/membership-common/src/main/scala/com/gu/monitoring/Metrics.scala
+++ b/membership-common/src/main/scala/com/gu/monitoring/Metrics.scala
@@ -1,6 +1,7 @@
 package com.gu.monitoring
 
-import com.amazonaws.regions.{Regions, Region}
+import com.amazonaws.regions.{Region, Regions}
+import com.gu.monitoring.SafeLogger.LogPrefix
 
 trait ApplicationMetrics extends CloudWatch {
   val region = Region.getRegion(Regions.EU_WEST_1)
@@ -9,21 +10,21 @@ trait ApplicationMetrics extends CloudWatch {
 }
 
 trait StatusMetrics extends CloudWatch {
-  def putResponseCode(status: Int, responseMethod: String) {
+  def putResponseCode(status: Int, responseMethod: String)(implicit logPrefix: LogPrefix) {
     val statusClass = status / 100
     put(s"${statusClass}XX-response-code", 1, responseMethod)
   }
 }
 
 trait RequestMetrics extends CloudWatch {
-  def putRequest {
+  def putRequest()(implicit logPrefix: LogPrefix) {
     put("request-count", 1)
   }
 }
 
 trait AuthenticationMetrics extends CloudWatch {
   def putAuthenticationError {
-    put("auth-error", 1)
+    put("auth-error", 1)(LogPrefix.noLogPrefix)
   }
 }
 

--- a/membership-common/src/main/scala/com/gu/monitoring/SafeLogger.scala
+++ b/membership-common/src/main/scala/com/gu/monitoring/SafeLogger.scala
@@ -25,13 +25,10 @@ object SafeLogger extends SafeLogging {
     override val toString = withoutPersonalData
   }
 
-  trait LogPrefix {
-    def message: String
-  }
+  case class LogPrefix(message: String)
+
   object LogPrefix {
-    val noLogPrefix: LogPrefix = new LogPrefix {
-      override def message: String = "no-id"
-    }
+    val noLogPrefix: LogPrefix = LogPrefix("no-id")
   }
 
 }

--- a/membership-common/src/main/scala/com/gu/monitoring/SafeLogger.scala
+++ b/membership-common/src/main/scala/com/gu/monitoring/SafeLogger.scala
@@ -28,6 +28,11 @@ object SafeLogger extends SafeLogging {
   trait LogPrefix {
     def message: String
   }
+  object LogPrefix {
+    val noLogPrefix: LogPrefix = new LogPrefix {
+      override def message: String = "no-id"
+    }
+  }
 
 }
 
@@ -37,16 +42,28 @@ class SafeLoggerImpl(logger: Logger) {
     logger.debug(logMessage)
   }
 
-  def info(logMessage: String): Unit = {
+  def infoNoPrefix(logMessage: String): Unit = {
     logger.info(logMessage)
   }
 
-  def warn(logMessage: String): Unit = {
+  def info(logMessage: String)(implicit logPrefix: LogPrefix): Unit = {
+    logger.info(logPrefix.message + ": " + logMessage)
+  }
+
+  def warnNoPrefix(logMessage: String): Unit = {
     logger.warn(logMessage)
   }
 
-  def warn(logMessage: String, throwable: Throwable): Unit = {
+  def warn(logMessage: String)(implicit logPrefix: LogPrefix): Unit = {
+    logger.warn(logPrefix.message + ": " + logMessage)
+  }
+
+  def warnNoPrefix(logMessage: String, throwable: Throwable): Unit = {
     logger.warn(logMessage, throwable)
+  }
+
+  def warn(logMessage: String, throwable: Throwable)(implicit logPrefix: LogPrefix): Unit = {
+    logger.warn(logPrefix.message + ": " + logMessage, throwable)
   }
 
   def errorNoPrefix(logMessage: LogMessage): Unit = {
@@ -59,8 +76,13 @@ class SafeLoggerImpl(logger: Logger) {
     logger.error(SafeLogger.sanitizedLogMessage, logMessage.withoutPersonalData)
   }
 
-  def error(logMessage: LogMessage, throwable: Throwable): Unit = {
+  def errorNoPrefix(logMessage: LogMessage, throwable: Throwable): Unit = {
     logger.error(logMessage.withPersonalData, throwable)
+    logger.error(SafeLogger.sanitizedLogMessage, s"${logMessage.withoutPersonalData} due to ${throwable.getCause}")
+  }
+
+  def error(logMessage: LogMessage, throwable: Throwable)(implicit logPrefix: LogPrefix): Unit = {
+    logger.error(logPrefix.message + ": " + logMessage.withPersonalData, throwable)
     logger.error(SafeLogger.sanitizedLogMessage, s"${logMessage.withoutPersonalData} due to ${throwable.getCause}")
   }
 

--- a/membership-common/src/main/scala/com/gu/monitoring/SalesforceMetrics.scala
+++ b/membership-common/src/main/scala/com/gu/monitoring/SalesforceMetrics.scala
@@ -1,6 +1,7 @@
 package com.gu.monitoring
 
-import com.amazonaws.regions.{Regions, Region}
+import com.amazonaws.regions.{Region, Regions}
+import com.gu.monitoring.SafeLogger.LogPrefix
 
 class SalesforceMetrics(val stage: String, val application: String)
     extends CloudWatch
@@ -11,11 +12,11 @@ class SalesforceMetrics(val stage: String, val application: String)
   val region = Region.getRegion(Regions.EU_WEST_1)
   val service = "Salesforce"
 
-  def recordRequest() {
+  def recordRequest()(implicit logPrefix: LogPrefix) {
     putRequest
   }
 
-  def recordResponse(status: Int, responseMethod: String) {
+  def recordResponse(status: Int, responseMethod: String)(implicit logPrefix: LogPrefix) {
     putResponseCode(status, responseMethod)
   }
 

--- a/membership-common/src/main/scala/com/gu/monitoring/ZuoraMetrics.scala
+++ b/membership-common/src/main/scala/com/gu/monitoring/ZuoraMetrics.scala
@@ -2,6 +2,7 @@ package com.gu.monitoring
 
 import java.util.concurrent.{CompletableFuture, Future}
 import com.amazonaws.services.cloudwatch.model.{Dimension, PutMetricDataResult}
+import com.gu.monitoring.SafeLogger.LogPrefix
 
 class ZuoraMetrics(val stage: String, val application: String, val service: String = "Zuora")
     extends CloudWatch
@@ -9,11 +10,11 @@ class ZuoraMetrics(val stage: String, val application: String, val service: Stri
     with RequestMetrics
     with AuthenticationMetrics {
 
-  def countRequest(): Unit = putRequest // just a nicer name
+  def countRequest()(implicit logPrefix: LogPrefix): Unit = putRequest // just a nicer name
 }
 
 // Dummy for tests, and as default argument so API clients do not have to change
 object NoOpZuoraMetrics extends ZuoraMetrics("dummy", "dummy") {
-  override def put(name: String, count: Double, extraDimensions: Dimension*): Future[PutMetricDataResult] =
+  override def put(name: String, count: Double, extraDimensions: Dimension*)(implicit logPrefix: LogPrefix): Future[PutMetricDataResult] =
     CompletableFuture.completedFuture(null.asInstanceOf[PutMetricDataResult])
 }

--- a/membership-common/src/main/scala/com/gu/okhttp/RequestRunners.scala
+++ b/membership-common/src/main/scala/com/gu/okhttp/RequestRunners.scala
@@ -1,5 +1,6 @@
 package com.gu.okhttp
 
+import com.gu.monitoring.SafeLogger.LogPrefix
 import com.gu.monitoring.SafeLogging
 import okhttp3.{Call, Callback, OkHttpClient, Request, Response}
 
@@ -15,12 +16,12 @@ object RequestRunners {
   lazy val client = new OkHttpClient()
 
   trait HttpClient[M[_]] {
-    def execute(request: Request): M[Response]
+    def execute(request: Request)(implicit logPrefix: LogPrefix): M[Response]
   }
 
   class FutureHttpClient(client: OkHttpClient) extends HttpClient[Future] with SafeLogging {
 
-    def execute(request: Request): Future[Response] = {
+    def execute(request: Request)(implicit logPrefix: LogPrefix): Future[Response] = {
       val p = Promise[Response]()
 
       client

--- a/membership-common/src/main/scala/com/gu/stripe/StripeService.scala
+++ b/membership-common/src/main/scala/com/gu/stripe/StripeService.scala
@@ -2,6 +2,7 @@ package com.gu.stripe
 
 import com.gu.i18n.{Country, Currency}
 import com.gu.memsub.util.WebServiceHelper
+import com.gu.monitoring.SafeLogger.LogPrefix
 import com.gu.okhttp.RequestRunners._
 import com.gu.stripe.Stripe.Deserializer._
 import com.gu.stripe.Stripe._
@@ -62,7 +63,7 @@ class StripeService(apiConfig: StripeServiceConfig, client: FutureHttpClient)(im
   val paymentIntentsGateway: PaymentGateway = RegionalStripeGateways.getPaymentIntentsGatewayForCountry(apiConfig.stripeAccountCountry)
   val invoiceTemplateOverride: Option[InvoiceTemplate] = apiConfig.invoiceTemplateOverride
 
-  override def wsPreExecute(req: Request.Builder): Request.Builder = {
+  override def wsPreExecute(req: Request.Builder)(implicit logPrefix: LogPrefix): Request.Builder = {
     req.addHeader("Authorization", s"Bearer ${apiConfig.credentials.secretKey}")
 
     apiConfig.version match {

--- a/membership-common/src/main/scala/com/gu/zuora/rest/SimpleClient.scala
+++ b/membership-common/src/main/scala/com/gu/zuora/rest/SimpleClient.scala
@@ -1,5 +1,6 @@
 package com.gu.zuora.rest
 
+import com.gu.monitoring.SafeLogger.LogPrefix
 import com.gu.monitoring.{NoOpZuoraMetrics, ZuoraMetrics}
 import com.gu.okhttp.RequestRunners.HttpClient
 import com.gu.zuora.ZuoraRestConfig
@@ -20,7 +21,7 @@ case class SimpleClient[M[_]: Functor](
     client: HttpClient[M],
     metrics: ZuoraMetrics = NoOpZuoraMetrics,
 ) {
-  def authenticated(url: String): Request.Builder = {
+  def authenticated(url: String)(implicit logPrefix: LogPrefix): Request.Builder = {
     metrics.countRequest() // to count total number of request hitting Zuora
 
     new Request.Builder()
@@ -59,16 +60,16 @@ case class SimpleClient[M[_]: Functor](
 
   def jsonBody(in: JsValue): RequestBody = RequestBody.create(MediaType.parse("application/json"), in.toString())
 
-  def get[B](url: String)(implicit r: Reads[B]): M[String \/ B] =
+  def get[B](url: String)(implicit r: Reads[B], logPrefix: LogPrefix): M[String \/ B] =
     client.execute(authenticated(url).get.build).map(parseResponse(_)(r))
 
-  def getJson(url: String): M[String \/ JsValue] =
+  def getJson(url: String)(implicit logPrefix: LogPrefix): M[String \/ JsValue] =
     client.execute(authenticated(url).get.build).map(parseJson(_))
 
-  def put[A, B](url: String, in: A)(implicit r: Reads[B], w: Writes[A]): M[String \/ B] =
+  def put[A, B](url: String, in: A)(implicit r: Reads[B], w: Writes[A], logPrefix: LogPrefix): M[String \/ B] =
     client.execute(authenticated(url).put(body(in)).build).map(parseResponse(_)(r))
 
-  def post[A, B](url: String, in: A)(implicit r: Reads[B], w: Writes[A]): M[String \/ B] =
+  def post[A, B](url: String, in: A)(implicit r: Reads[B], w: Writes[A], logPrefix: LogPrefix): M[String \/ B] =
     client.execute(authenticated(url).post(body(in)).build).map(parseResponse(_)(r))
 
 }

--- a/membership-common/src/main/scala/com/gu/zuora/soap/Client.scala
+++ b/membership-common/src/main/scala/com/gu/zuora/soap/Client.scala
@@ -35,14 +35,14 @@ class Client(
   actorSystem.scheduler.schedule(0.seconds, 15.minutes)(authentication())
 
   private def authentication(): Unit =
-    retry(request(Actions.Login(apiConfig), None, authenticationReader)(noLogPrefix))(ec, actorSystem.scheduler)
+    retry(request(Actions.Login(apiConfig), None, authenticationReader)(LogPrefix.noLogPrefix))(ec, actorSystem.scheduler)
       .onComplete {
         case Success(auth) =>
           periodicAuth.set(auth)
-          logger.info(s"Successfully authenticated Zuora SOAP client in ${apiConfig.envName}")
+          logger.infoNoPrefix(s"Successfully authenticated Zuora SOAP client in ${apiConfig.envName}")
 
         case Failure(ex) =>
-          logger.error(scrub"Failed Zuora SOAP client authentication in ${apiConfig.envName}", ex)
+          logger.errorNoPrefix(scrub"Failed Zuora SOAP client authentication in ${apiConfig.envName}", ex)
       }
 
   private def request[T <: models.Result](
@@ -108,9 +108,5 @@ object Client {
 
   def childFilter[C <: Query, P <: Query with Identifiable](parent: P): SimpleFilter =
     SimpleFilter(parent.objectName + "Id", parent.id)
-
-  val noLogPrefix: LogPrefix = new LogPrefix {
-    override def message: String = "no-id"
-  }
 
 }

--- a/membership-common/src/test/scala/utils/TestLogPrefix.scala
+++ b/membership-common/src/test/scala/utils/TestLogPrefix.scala
@@ -1,0 +1,11 @@
+package utils
+
+import com.gu.monitoring.SafeLogger.LogPrefix
+
+object TestLogPrefix {
+
+  implicit val testLogPrefix: LogPrefix = new LogPrefix {
+    override def message: String = "TestLogPrefix"
+  }
+
+}

--- a/membership-common/src/test/scala/utils/TestLogPrefix.scala
+++ b/membership-common/src/test/scala/utils/TestLogPrefix.scala
@@ -4,8 +4,6 @@ import com.gu.monitoring.SafeLogger.LogPrefix
 
 object TestLogPrefix {
 
-  implicit val testLogPrefix: LogPrefix = new LogPrefix {
-    override def message: String = "TestLogPrefix"
-  }
+  implicit val testLogPrefix: LogPrefix = LogPrefix("TestLogPrefix")
 
 }


### PR DESCRIPTION
This PR follows on from https://github.com/guardian/members-data-api/pull/1060 which added this pattern to only logger.error statements.

This adds the identity ID to the rest of the log statements (i.e. info, warn)

All passes tests locally.

 tested in CODE and working /me/mma and /me
See here for how to search https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/members-data-api-CODE/log-events/members-data-api-CODE-application-i-0c83f2280aec43b54$3FfilterPattern$3D200235544