### PR TITLE
feat: make members-data-api user attributes work with new 3-tier product rate plans (supporter plus with guardian weekly)

### DIFF
--- a/membership-attribute-service/app/services/SupporterRatePlanToAttributesMapper.scala
+++ b/membership-attribute-service/app/services/SupporterRatePlanToAttributesMapper.scala
@@ -53,6 +53,12 @@ object SupporterRatePlanToAttributesMapper {
       SupporterPlusExpiryDate = Some(supporterRatePlanItem.termEndDate),
     )
   val supporterPlusV2Transformer: AttributeTransformer = supporterPlusTransformer
+  val supporterPlusWithGuardianWeeklyTransformer: AttributeTransformer =
+    (attributes: Attributes, supporterRatePlanItem: DynamoSupporterRatePlanItem) =>
+      attributes.copy(
+        SupporterPlusExpiryDate = Some(supporterRatePlanItem.termEndDate),
+        GuardianWeeklySubscriptionExpiryDate = Some(supporterRatePlanItem.termEndDate),
+      )
   val monthlyContributionTransformer: AttributeTransformer = (attributes: Attributes, item: DynamoSupporterRatePlanItem) =>
     attributes.copy(
       RecurringContributionPaymentPlan = Some("Monthly Contribution"),
@@ -92,6 +98,12 @@ object SupporterRatePlanToAttributesMapper {
       "8a128ed885fc6ded018602296ace3eb8",
       "8a128ed885fc6ded01860228f77e3d5a",
     ) -> supporterPlusV2Transformer,
+    List(
+      "8a1292628f51a923018f52a324e45710", // Supporter Plus V2 & Guardian Weekly ROW - Annual
+      "8a1281f38f518d11018f52a599806a65", // Supporter Plus V2 & Guardian Weekly ROW - Monthly
+      "8a1282048f518d08018f529ead0f3d91", // Supporter Plus V2 & Guardian Weekly Domestic - Annual
+      "8a1288a38f518d01018f529a04443172", // Supporter Plus V2 & Guardian Weekly Domestic - Monthly
+    ) -> supporterPlusWithGuardianWeeklyTransformer,
     List(
       "2c92a0fb4edd70c8014edeaa4eae220a",
       "2c92a0fb4edd70c8014edeaa4e972204",
@@ -218,6 +230,12 @@ object SupporterRatePlanToAttributesMapper {
       "8ad08cbd8586721c01858804e3275376",
       "8ad08e1a8586721801858805663f6fab",
     ) -> supporterPlusV2Transformer,
+    List(
+      "8ad097b48f006681018f05a0496e01f4", // Supporter Plus V2 & Guardian Weekly ROW - Annual
+      "8ad097b48f006681018f05a2c0fb0227", // Supporter Plus V2 & Guardian Weekly ROW - Monthly
+      "8ad097b48f006681018f059b755e0140", // Supporter Plus V2 & Guardian Weekly Domestic - Annual
+      "8ad081dd8ef57784018ef6e159224bfa", // Supporter Plus V2 & Guardian Weekly Domestic - Monthly
+    ) -> supporterPlusWithGuardianWeeklyTransformer,
     List(
       "2c92c0f84bbfec8b014bc655f4852d9d",
       "2c92c0f94bbffaaa014bc6a4212e205b",

--- a/membership-attribute-service/test/services/SupporterRatePlanToAttributesMapperTest.scala
+++ b/membership-attribute-service/test/services/SupporterRatePlanToAttributesMapperTest.scala
@@ -113,6 +113,29 @@ class SupporterRatePlanToAttributesMapperTest extends Specification {
       )
     }
 
+    "handle a SupporterPlusWithGuardianWeekly subscription" in {
+      testMapper(
+        Map(
+          "PROD" -> List(
+            ratePlanItem("8a1292628f51a923018f52a324e45710"), // Supporter Plus V2 & Guardian Weekly ROW - Annual
+            ratePlanItem("8a1281f38f518d11018f52a599806a65"), // Supporter Plus V2 & Guardian Weekly ROW - Monthly
+            ratePlanItem("8a1282048f518d08018f529ead0f3d91"), // Supporter Plus V2 & Guardian Weekly Domestic - Annual
+            ratePlanItem("8a1288a38f518d01018f529a04443172"), // Supporter Plus V2 & Guardian Weekly Domestic - Monthly
+          ),
+          "CODE" -> List(
+            ratePlanItem("8ad097b48f006681018f05a0496e01f4"), // Supporter Plus V2 & Guardian Weekly ROW - Annual
+            ratePlanItem("8ad097b48f006681018f05a2c0fb0227"), // Supporter Plus V2 & Guardian Weekly ROW - Monthly
+            ratePlanItem("8ad097b48f006681018f059b755e0140"), // Supporter Plus V2 & Guardian Weekly Domestic - Annual
+            ratePlanItem("8ad081dd8ef57784018ef6e159224bfa"), // Supporter Plus V2 & Guardian Weekly Domestic - Monthly
+          ),
+        ),
+        _ should beSome.which { attributes: Attributes =>
+          attributes.SupporterPlusExpiryDate should beSome(termEndDate)
+          attributes.GuardianWeeklySubscriptionExpiryDate should beSome(termEndDate)
+        },
+      )
+    }
+
     "identify a Digital Subscription" in {
       val possibleProductRatePlanIds = List(
         "2c92a0fb4edd70c8014edeaa4eae220a", // Monthly


### PR DESCRIPTION
## What does this change?

[Trello](https://trello.com/c/c43i1tD0/754-check-that-members-data-api-understands-new-gw-digital-rate-plan-part-1-user-attributes)

This makes `members-data-api` user attributes work with the new 3-tier product rate plans:
- Add new attribute transformer for SupporterPlusWithGuardianWeekly
- Add Zuora product rate plan IDs for CODE and PROD
- Add test to check for correct user attributes
- Add test to check for correct handling of new IDs

## Why are you doing this?

At the moment 3-tier product purchases are handled by creating two subscriptions - one for Supporter Plus and one for Guardian Weekly.

This PR is part of the refactor to be able to just create one subscription containing the new rate plans.

## How to test

From the root of the repository, run `sbt` and then `test`.

## How can we measure success?

Subscribers to 3-tier products can get correct access to the relevant products.

## Next

Check that `members-data-api` understands new GW + Digital rate plan for MMA.
