### PR TITLE
filter out free/zero months from mma next payment date/amount

### DIFF
--- a/membership-attribute-service/app/controllers/ExistingPaymentOptionsController.scala
+++ b/membership-attribute-service/app/controllers/ExistingPaymentOptionsController.scala
@@ -119,9 +119,10 @@ class ExistingPaymentOptionsController(
             -\/[String, ObjectAccount](s"error receiving OBJECT account with account id $accountId. Reason: $x")
           }) if currencyMatchesFilter(objectAccount.currency) &&
             objectAccount.defaultPaymentMethodId.isDefined
+          account <- ListTEither.singleRightT(tp.zuoraSoapService.getAccount(accountId))
           paymentMethodOption <- ListTEither.single(
             tp.paymentService
-              .getPaymentMethod(accountId, Some(defaultMandateIdIfApplicable))
+              .getPaymentMethod(account.defaultPaymentMethodId, Some(defaultMandateIdIfApplicable))
               .map(Right(_))
               .recover { case x => Left(s"error retrieving payment method for account: $accountId. Reason: $x") },
           )

--- a/membership-attribute-service/app/controllers/PaymentUpdateController.scala
+++ b/membership-attribute-service/app/controllers/PaymentUpdateController.scala
@@ -176,8 +176,14 @@ class PaymentUpdateController(
           _ <- SimpleEitherT(
             annotateFailableFuture(services.zuoraSoapService.createPaymentMethod(createPaymentMethod), "create direct debit payment method"),
           )
+          freshAccount <- SimpleEitherT(
+            annotateFailableFuture(
+              services.zuoraSoapService.getAccount(subscription.accountId),
+              s"get fresh account with id ${subscription.accountId}",
+            ),
+          )
           freshDefaultPaymentMethodOption <- SimpleEitherT(
-            annotateFailableFuture(services.paymentService.getPaymentMethod(subscription.accountId), "get fresh default payment method"),
+            annotateFailableFuture(services.paymentService.getPaymentMethod(freshAccount.defaultPaymentMethodId), "get fresh default payment method"),
           )
           _ <- sendPaymentMethodChangedEmail(user.primaryEmailAddress, contact, DirectDebit, subscription.plan)
         } yield checkDirectDebitUpdateResult(userId, freshDefaultPaymentMethodOption, bankAccountName, bankAccountNumber, bankSortCode)).run

--- a/membership-attribute-service/app/services/zuora/payment/ZuoraPaymentService.scala
+++ b/membership-attribute-service/app/services/zuora/payment/ZuoraPaymentService.scala
@@ -109,19 +109,16 @@ class PaymentService(zuoraService: ZuoraSoapService, planMap: Map[ProductRatePla
       logPrefix: LogPrefix,
   ): Future[Option[PaymentMethod]] =
     for {
-      maybePaymentMethod <- getPaymentMethodByAccount(defaultPaymentMethodId).withLogging(s"get payment method for $defaultPaymentMethodId")
+      maybePaymentMethod <- getPaymentMethod(defaultPaymentMethodId).withLogging(s"get payment method for $defaultPaymentMethodId")
     } yield for {
       soapPaymentMethod <- maybePaymentMethod
       memsubPaymentMethod <- buildPaymentMethod(defaultMandateIdIfApplicable, soapPaymentMethod)
     } yield memsubPaymentMethod
 
-  private def getPaymentMethodByAccount(
-      defaultPaymentMethodId: Option[String],
-  )(implicit logPrefix: LogPrefix): Future[Option[Queries.PaymentMethod]] = {
-    defaultPaymentMethodId match {
-      case Some(defaultPaymentMethodId) => zuoraService.getPaymentMethod(defaultPaymentMethodId).map(Some(_))
+  private def getPaymentMethod(maybePaymentMethodId: Option[String])(implicit logPrefix: LogPrefix): Future[Option[Queries.PaymentMethod]] =
+    maybePaymentMethodId match {
+      case Some(paymentMethodId) => zuoraService.getPaymentMethod(paymentMethodId).map(Some(_))
       case None => Future.successful(None)
     }
-  }
 
 }

--- a/membership-attribute-service/app/services/zuora/payment/ZuoraPaymentService.scala
+++ b/membership-attribute-service/app/services/zuora/payment/ZuoraPaymentService.scala
@@ -1,8 +1,9 @@
 package services.zuora.payment
 
 import _root_.services.zuora.soap.ZuoraSoapService
+import com.gu.memsub.BillingSchedule.Bill
 import com.gu.memsub.Subscription._
-import com.gu.memsub.subsv2.SubscriptionPlan.Contributor
+import com.gu.memsub.promo.LogImplicit._
 import com.gu.memsub.subsv2.{Subscription, SubscriptionPlan}
 import com.gu.memsub.{BillingSchedule, Subscription => _, _}
 import com.gu.monitoring.SafeLogger.LogPrefix
@@ -35,47 +36,22 @@ class PaymentService(zuoraService: ZuoraSoapService, planMap: Map[ProductRatePla
   )(sub: Subscription[SubscriptionPlan.Paid])(implicit logPrefix: LogPrefix): Future[PaymentDetails] = {
     val currency = sub.plan.charges.currencies.head
     // I am not convinced this function is very safe, hence the option
-    val lastPaymentDate = zuoraService
+    val eventualMaybeLastPaymentDate = zuoraService
       .getPaymentSummary(sub.name, currency)
       .map(_.current.serviceStartDate.some)
       .recover { case _ => None }
-    lastPaymentDate.onComplete {
-      case Failure(exception) =>
-        val message = scrub"Failed to get last payment date for sub $sub"
-        logger.error(message, exception)
-      case Success(_) => logger.info(s"Successfully got payment details for $sub")
-    }
+    eventualMaybeLastPaymentDate.withLogging(s"lastPaymentDate for $sub")
 
-    val nextPaymentDate = sub.plan match {
-      case _: Contributor =>
-        sub.plan.chargedThrough.getOrElse(
-          sub.plan.start,
-        ) // If the user has updated their contribution amount via MMA, there may be no charged through date
-      case _ => sub.plan.chargedThrough.getOrElse(sub.acceptanceDate) // If the user hasn't paid us yet, there's no charged through date
-    }
-    val futureMaybePrice = sub.plan.product.name match {
-      // There's no need to get the billing schedule for membership - since there are no promos etc.
-      case "membership" => {
-        Future.successful(sub.plan.charges.price.prices.headOption)
-      }
-      case _ => {
-        val schedule = billingSchedule(sub.id, sub.accountId, 15).map { maybeSchedule =>
-          maybeSchedule.map(schedule => Price(schedule.first.amount, currency))
-        }
-        schedule.onComplete {
-          case Failure(exception) =>
-            val message = scrub"Failed to get billing schedule for sub $sub"
-            logger.error(message, exception)
-          case Success(_) => logger.info(s"Successfully got billing schedule for $sub")
-        }
-        schedule
-      }
-    }
-    (futureMaybePrice |@| getPaymentMethod(sub.accountId, defaultMandateIdIfApplicable) |@| lastPaymentDate) {
-      case (maybePrice, paymentMethod, lpd) => {
-        val nextPayment = maybePrice.map { price => Payment(price, nextPaymentDate) }
-        PaymentDetails(sub, paymentMethod, nextPayment, lpd)
-      }
+    for {
+      account <- zuoraService.getAccount(sub.accountId)
+      eventualMaybeBill = getNextBill(sub.id, account, 15).withLogging(s"next bill for $sub")
+      eventualMaybePaymentMethod = getPaymentMethod(account.defaultPaymentMethodId, defaultMandateIdIfApplicable) // kick off async
+      maybeBill <- eventualMaybeBill
+      maybePaymentMethod <- eventualMaybePaymentMethod
+      lpd <- eventualMaybeLastPaymentDate
+    } yield {
+      val maybePayment = maybeBill.map(bill => Payment(Price(bill.amount, currency), bill.date))
+      PaymentDetails(sub, maybePaymentMethod, maybePayment, lpd)
     }
   }
 
@@ -97,7 +73,8 @@ class PaymentService(zuoraService: ZuoraSoapService, planMap: Map[ProductRatePla
 
   private def buildPaymentMethod(
       defaultMandateIdIfApplicable: Option[String] = None,
-  )(soapPaymentMethod: Queries.PaymentMethod): Option[PaymentMethod] =
+      soapPaymentMethod: Queries.PaymentMethod,
+  ): Option[PaymentMethod] =
     soapPaymentMethod.`type` match {
       case `CreditCard` | `CreditCardReferenceTransaction` =>
         val isReferenceTransaction = soapPaymentMethod.`type` == `CreditCardReferenceTransaction`
@@ -113,59 +90,36 @@ class PaymentService(zuoraService: ZuoraSoapService, planMap: Map[ProductRatePla
       case _ => None
     }
 
-  private def billingSchedule(subId: Id, accountFuture: Future[Account], numberOfBills: Int)(implicit
+  private def getNextBill(subId: Id, account: Account, numberOfBills: Int)(implicit
       logPrefix: LogPrefix,
-  ): Future[Option[BillingSchedule]] = {
-    val finder: ProductRatePlanChargeId => Option[Benefit] = planMap.get
-    val adapter: Seq[Queries.PreviewInvoiceItem] => Option[BillingSchedule] = BillingSchedule.fromPreviewInvoiceItems(finder)
-    val scheduleFuture = zuoraService.previewInvoices(subId, numberOfBills).map(adapter)
-    for {
-      account <- accountFuture
-      scheduleOpt <- scheduleFuture
-    } yield {
-      scheduleOpt.map(_.withCreditBalanceApplied(account.creditBalance))
+  ): Future[Option[Bill]] =
+    zuoraService.previewInvoices(subId, numberOfBills).map { previewInvoiceItems =>
+      val maybeBillingSchedule = BillingSchedule.fromPreviewInvoiceItems(planMap, previewInvoiceItems)
+      maybeBillingSchedule.flatMap { billingSched =>
+        billingSched
+          .withCreditBalanceApplied(account.creditBalance)
+          .invoices
+          .list
+          .find(_.amount > 0)
+          .toOption
+      }
     }
-  }
 
-  def billingSchedule(subId: Id, accountId: AccountId, numberOfBills: Int)(implicit logPrefix: LogPrefix): Future[Option[BillingSchedule]] =
-    billingSchedule(subId, zuoraService.getAccount(accountId), numberOfBills)
-
-  def getPaymentMethod(accountId: AccountId, defaultMandateIdIfApplicable: Option[String] = None)(implicit
+  def getPaymentMethod(defaultPaymentMethodId: Option[String], defaultMandateIdIfApplicable: Option[String] = None)(implicit
       logPrefix: LogPrefix,
   ): Future[Option[PaymentMethod]] =
-    getPaymentMethodByAccountId(accountId).map(_.flatMap(buildPaymentMethod(defaultMandateIdIfApplicable)))
-
-  private def getPaymentMethodByAccountId(accountId: AccountId)(implicit logPrefix: LogPrefix): Future[Option[Queries.PaymentMethod]] = {
-    val accountFuture = {
-      val account = zuoraService.getAccount(accountId)
-      account.onComplete {
-        case Failure(exception) =>
-          val message = scrub"Failed to get account for account $accountId"
-          logger.error(message, exception)
-        case Success(_) => logger.info(s"Successfully got account for $accountId")
-      }
-      account
-    }
-    def getPaymentMethod(account: Account) = {
-      val paymentMethod = getPaymentMethodByAccount(account)
-      paymentMethod.onComplete {
-        case Failure(exception) =>
-          val message = scrub"Failed to get payment method for account $accountId"
-          logger.error(message, exception)
-        case Success(_) => logger.info(s"Successfully got payment method for $accountId")
-      }
-      paymentMethod
-    }
     for {
-      account <- accountFuture
-      paymentMethod <- getPaymentMethod(account)
-    } yield paymentMethod
-  }
+      maybePaymentMethod <- getPaymentMethodByAccount(defaultPaymentMethodId).withLogging(s"get payment method for $defaultPaymentMethodId")
+    } yield for {
+      soapPaymentMethod <- maybePaymentMethod
+      memsubPaymentMethod <- buildPaymentMethod(defaultMandateIdIfApplicable, soapPaymentMethod)
+    } yield memsubPaymentMethod
 
-  private def getPaymentMethodByAccount(account: Account)(implicit logPrefix: LogPrefix): Future[Option[Queries.PaymentMethod]] = {
-    val maybeEventualPaymentMethod = account.defaultPaymentMethodId.map(zuoraService.getPaymentMethod)
-    maybeEventualPaymentMethod match {
-      case Some(eventualPaymentMethod) => eventualPaymentMethod.map(Some.apply)
+  private def getPaymentMethodByAccount(
+      defaultPaymentMethodId: Option[String],
+  )(implicit logPrefix: LogPrefix): Future[Option[Queries.PaymentMethod]] = {
+    defaultPaymentMethodId match {
+      case Some(defaultPaymentMethodId) => zuoraService.getPaymentMethod(defaultPaymentMethodId).map(Some(_))
       case None => Future.successful(None)
     }
   }

--- a/membership-attribute-service/test/acceptance/AccountControllerAcceptanceTest.scala
+++ b/membership-attribute-service/test/acceptance/AccountControllerAcceptanceTest.scala
@@ -6,9 +6,11 @@ import acceptance.data.{
   TestAccountSummary,
   TestCatalog,
   TestContact,
+  TestInvoiceItem,
   TestPaidCharge,
   TestPaidSubscriptionPlan,
   TestPaymentSummary,
+  TestPreviewInvoiceItem,
   TestQueriesAccount,
   TestSubscription,
 }
@@ -18,6 +20,7 @@ import com.gu.memsub.Subscription.Name
 import com.gu.memsub.subsv2.{CovariantNonEmptyList, SubscriptionPlan}
 import com.gu.memsub.{Product, Subscription}
 import com.gu.monitoring.SafeLogger.LogPrefix
+import com.gu.zuora.soap.models.Queries.PreviewInvoiceItem
 import kong.unirest.Unirest
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.{LocalDate, LocalTime}
@@ -186,6 +189,7 @@ class AccountControllerAcceptanceTest extends AcceptanceTest {
 
       zuoraSoapServiceMock.getPaymentSummary(nonGiftSubscription.name, Currency.GBP)(any) returns Future(TestPaymentSummary())
       zuoraSoapServiceMock.getAccount(nonGiftSubscriptionAccountId)(any) returns Future(TestQueriesAccount())
+      zuoraSoapServiceMock.previewInvoices(nonGiftSubscription.id, 15)(any) returns Future(Seq(TestPreviewInvoiceItem()))
 
       val patronSubscription = TestDynamoSupporterRatePlanItem(
         identityId = "200067388",
@@ -229,6 +233,7 @@ class AccountControllerAcceptanceTest extends AcceptanceTest {
 
       zuoraSoapServiceMock.getAccount(nonGiftSubscriptionAccountId)(any) was called
       zuoraSoapServiceMock.getPaymentSummary(nonGiftSubscription.name, Currency.GBP)(any) was called
+      zuoraSoapServiceMock.previewInvoices(nonGiftSubscription.id, 15)(any) was called
 
       supporterProductDataServiceMock wasNever calledAgain
       contactRepositoryMock wasNever calledAgain

--- a/membership-attribute-service/test/acceptance/data/TestPreviewInvoiceItem.scala
+++ b/membership-attribute-service/test/acceptance/data/TestPreviewInvoiceItem.scala
@@ -1,0 +1,16 @@
+package acceptance.data
+
+import com.gu.zuora.soap.models.Queries.PreviewInvoiceItem
+import org.joda.time.LocalDate
+
+object TestPreviewInvoiceItem {
+  def apply(): PreviewInvoiceItem = PreviewInvoiceItem(
+    1f,
+    new LocalDate(2024, 5, 14),
+    new LocalDate(2024, 6, 14),
+    "testProductId",
+    "testProductRatePlanChargeId",
+    "testChangeName",
+    1f,
+  )
+}

--- a/membership-common/src/main/scala/com/gu/memsub/promo/LogImplicit.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/promo/LogImplicit.scala
@@ -3,7 +3,20 @@ package com.gu.memsub.promo
 import com.gu.monitoring.SafeLogger.LogPrefix
 import com.gu.monitoring.SafeLogging
 
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+
 object LogImplicit {
+
+  implicit class LoggableFuture[T](eventualT: Future[T]) extends SafeLogging {
+    def withLogging(message: String)(implicit logPrefix: LogPrefix, ec: ExecutionContext): Future[T] = {
+      eventualT.onComplete {
+        case Failure(exception) => logger.warn(s"Failed: $message", exception)
+        case Success(_) => logger.info(s"Success: $message")
+      }
+      eventualT
+    }
+  }
 
   implicit class Loggable[T](t: T) extends SafeLogging {
     def withLogging(message: String)(implicit logPrefix: LogPrefix): T = {


### PR DESCRIPTION
This is part of the cancellation saves work - previously the mma response will tell the user they have a payment on (x date) of 0.00 if they are on a free month.
This PR changes it so it filters out all free months, and if there are any non-free months in the preview, it will display that date and amount.

members-data-api: /user-attributes/me/mma
before:
<img width="403" alt="image" src="https://github.com/guardian/members-data-api/assets/7304387/0ce70999-1680-4225-b9a8-9e44b11f52b7">

After:
<img width="327" alt="image" src="https://github.com/guardian/members-data-api/assets/7304387/cb7662f3-84fc-4193-be31-6ae755237a2f">

subscription is this one: https://apisandbox.zuora.com/platform/subscriptions/8ad081dd8f390950018f39c730e226d3

If we were to give out more than a year free we would have to extend the preview window, but so far it's only 2 months.