### PR TITLE
use basic "reads" for update contribution amount

### DIFF
--- a/membership-attribute-service/app/controllers/PaymentUpdateController.scala
+++ b/membership-attribute-service/app/controllers/PaymentUpdateController.scala
@@ -61,7 +61,7 @@ class PaymentUpdateController(
           subscription <- EitherT.fromEither(
             services.subscriptionService
               .current[SubscriptionPlan.AnyPlan](contact)
-              .map(subs => subscriptionSelector(Some(memsub.Subscription.Name(subscriptionName)), s"the sfUser $contact")(subs)),
+              .map(subs => subscriptionSelector(memsub.Subscription.Name(subscriptionName), s"the sfUser $contact", subs)),
           )
           (stripeCardIdentifier, stripePublicKey) = stripeDetails
           updateResult <- services
@@ -150,7 +150,7 @@ class PaymentUpdateController(
           subscription <- SimpleEitherT(
             services.subscriptionService
               .current[SubscriptionPlan.AnyPlan](contact)
-              .map(subs => subscriptionSelector(Some(memsub.Subscription.Name(subscriptionName)), s"the sfUser $contact")(subs)),
+              .map(subs => subscriptionSelector(memsub.Subscription.Name(subscriptionName), s"the sfUser $contact", subs)),
           )
           account <- SimpleEitherT(
             annotateFailableFuture(services.zuoraSoapService.getAccount(subscription.accountId), s"get account with id ${subscription.accountId}"),

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -27,4 +27,3 @@ PUT         /user-attributes/me/delivery-address/:contactId                     
 # OLD ENDPOINTS below will be phased out as traffic moves over to the new endpoints above
 GET         /user-attributes/me/membership                              controllers.AttributeController.membership
 GET         /user-attributes/me/features                                controllers.AttributeController.features
-POST        /user-attributes/me/contribution-update-amount              controllers.AccountController.contributionUpdateAmount


### PR DESCRIPTION
This PR is a simpification preparation.

I was having a look through the whole SubPlanReads etc stuff and I noticed some opportunities to simplify.

We pass around a **lot** of `[P <: AnyPlan : SubPlanReads]` type parameters throughout the code.  The intention behind this was that we could ask for a "Partner" or whatever effectively based on its shape, and it would fail to read if it was the wrong thing, and the type checker would help us out.  Kind of like json parser implicits replicated into very deeply nested and general structures.
However I think that cleverness was mainly used by membership and subscribe frontends - I noticed that in this repo we almost always use AnyPlan, apart from in update contribution amount.

1. (**This PR**) update update contribution amount to also use AnyPlan and remove the non subscription specific version (it hasn't been called in the last fortnight according to the ELB logs)
2. (next PR) will remove the type parameter from everywhere, as well as from the `Subscription[P <: AnyPlan]` object, so that all subscriptions are of type AnyPlan.
3. (next PR) will remove Friend from the "Catalog readers" as noone has it any more -the last Friend plan ended in 2020 according to bigquery
4. (next PR) will remove "Free" plans and ChargeLists completely and flatten it out so that everything is treated as Paid.   it looks like Staff can just deserialise as a one time charge of zero.  I will need to test to make sure things aren't broken for staff, but we should probably cancel them all in zuora anyway.

Possibly other stuff will pop up along the way.

Tested in DEV that it rejects non contributions still with an error
```
Name(A-S00879989) plan is not a contribution: PaidSubscriptionPlan(RatePlanId(8ad081dd8f390950018f39c7311a26da),ProductRatePlanId(8ad08cbd8586721c01858804e3275376),Supporter Plus V2 - Monthly,,Supporter Plus,None,Supporter Plus,SupporterPlus,List(),SupporterPlusCharges(Month,List(PricingSummary(Map(GBP -> Price(0.0,GBP))), PricingSummary(Map(GBP -> Price(10.0,GBP))))),Some(2024-05-18),2024-04-18,2025-04-18)
```
, and there's also a (happy case) test in the AcccountControllerAcceptanceTest