### PR TITLE
make supporter plus a subscription in MMA rather than recurring support

### DIFF
--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -221,7 +221,7 @@ object AccountDetails {
   def mmaCategoryFrom(product: Product): String = product match {
     case _: Product.Paper => "subscriptions" // Paper includes GW 🤦‍
     case _: Product.ZDigipack => "subscriptions"
-    case _: Product.SupporterPlus => "recurringSupport"
+    case _: Product.SupporterPlus => "subscriptions"
     case _: Product.GuardianPatron => "subscriptions"
     case _: Product.Contribution => "recurringSupport"
     case _: Product.Membership => "membership"


### PR DESCRIPTION
At the moment supporter plus is classed as recurring support in MMA.
```
    {
      "mmaCategory": "recurringSupport",
      "tier": "Supporter Plus",
...
```

It's needed (TBC) to change it so we describe it as a subscription to align with the main checkout language.

This PR moves it over accordingly.

TODO
- confirm whether this is definitely ok cc @rBangay 
- fix test at https://github.com/guardian/members-data-api/blob/jd-splus-subscription/membership-attribute-service/test/acceptance/AccountControllerAcceptanceTest.scala#L260