### PR TITLE
remove type parameters from Subscription and SubscriptionPlan and ass…

### DIFF
--- a/membership-attribute-service/app/controllers/ExistingPaymentOptionsController.scala
+++ b/membership-attribute-service/app/controllers/ExistingPaymentOptionsController.scala
@@ -44,11 +44,11 @@ class ExistingPaymentOptionsController(
       maybeUserId: Option[String],
       contactRepository: ContactRepository,
       subscriptionService: SubscriptionService[Future],
-  )(implicit logPrefix: LogPrefix): SimpleEitherT[Map[AccountId, List[Subscription[SubscriptionPlan.AnyPlan]]]] =
+  )(implicit logPrefix: LogPrefix): SimpleEitherT[Map[AccountId, List[Subscription]]] =
     (for {
       user <- ListTEither.fromOption(maybeUserId)
       contact <- ListTEither.fromFutureOption(contactRepository.get(user))
-      subscription <- ListTEither.fromFutureList(subscriptionService.since[SubscriptionPlan.AnyPlan](date)(contact))
+      subscription <- ListTEither.fromFutureList(subscriptionService.since(date)(contact))
     } yield subscription).toList.map(_.groupBy(_.accountId))
 
   def consolidatePaymentMethod(existingPaymentOptions: List[ExistingPaymentOption]): Iterable[ExistingPaymentOption] = {

--- a/membership-attribute-service/app/controllers/PaymentUpdateController.scala
+++ b/membership-attribute-service/app/controllers/PaymentUpdateController.scala
@@ -60,7 +60,7 @@ class PaymentUpdateController(
           contact <- EitherT.fromEither(services.contactRepository.get(userId).map(_.toEither).map(_.flatMap(_.toRight(s"no SF user $userId"))))
           subscription <- EitherT.fromEither(
             services.subscriptionService
-              .current[SubscriptionPlan.AnyPlan](contact)
+              .current(contact)
               .map(subs => subscriptionSelector(memsub.Subscription.Name(subscriptionName), s"the sfUser $contact", subs)),
           )
           (stripeCardIdentifier, stripePublicKey) = stripeDetails
@@ -90,7 +90,7 @@ class PaymentUpdateController(
       emailAddress: String,
       contact: Contact,
       paymentMethod: PaymentType,
-      plan: SubscriptionPlan.AnyPlan,
+      plan: SubscriptionPlan,
   )(implicit logPrefix: LogPrefix): SimpleEitherT[Unit] =
     SimpleEitherT.rightT(sendEmail.send(paymentMethodChangedEmail(emailAddress, contact, paymentMethod, plan)))
 
@@ -149,7 +149,7 @@ class PaymentUpdateController(
           contact <- SimpleEitherT(services.contactRepository.get(userId).map(_.toEither.flatMap(_.toRight(s"no SF user $userId"))))
           subscription <- SimpleEitherT(
             services.subscriptionService
-              .current[SubscriptionPlan.AnyPlan](contact)
+              .current(contact)
               .map(subs => subscriptionSelector(memsub.Subscription.Name(subscriptionName), s"the sfUser $contact", subs)),
           )
           account <- SimpleEitherT(

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -1,6 +1,5 @@
 package models
 import com.gu.i18n.Country
-import com.gu.memsub.subsv2.SubscriptionPlan.AnyPlan
 import com.gu.memsub.subsv2._
 import com.gu.memsub.{Subscription, _}
 import com.gu.monitoring.SafeLogger.LogPrefix
@@ -21,7 +20,7 @@ case class AccountDetails(
     regNumber: Option[String],
     email: Option[String],
     deliveryAddress: Option[DeliveryAddress],
-    subscription: Subscription[SubscriptionPlan.AnyPlan],
+    subscription: Subscription,
     paymentDetails: PaymentDetails,
     billingCountry: Option[Country],
     stripePublicKey: String,
@@ -97,13 +96,13 @@ object AccountDetails {
         case _ => Json.obj()
       }
 
-      def externalisePlanName(plan: SubscriptionPlan.AnyPlan): Option[String] = plan.product match {
+      def externalisePlanName(plan: SubscriptionPlan): Option[String] = plan.product match {
         case _: Product.Weekly => if (plan.name.contains("Six for Six")) Some("currently on '6 for 6'") else None
         case _: Product.Paper => Some(plan.name.replace("+", " plus Digital Subscription"))
         case _ => None
       }
 
-      def jsonifyPlan(plan: SubscriptionPlan.AnyPlan) = Json.obj(
+      def jsonifyPlan(plan: SubscriptionPlan) = Json.obj(
         "name" -> externalisePlanName(plan),
         "start" -> plan.start,
         "end" -> plan.end,
@@ -226,7 +225,7 @@ object AccountDetails {
 
 object CancelledSubscription {
   import AccountDetails._
-  def apply(subscription: Subscription[AnyPlan]): JsObject = {
+  def apply(subscription: Subscription): JsObject = {
     GetCurrentPlans
       .bestCancelledPlan(subscription)
       .map { plan =>

--- a/membership-attribute-service/app/models/AccountWithSubscriptions.scala
+++ b/membership-attribute-service/app/models/AccountWithSubscriptions.scala
@@ -1,7 +1,0 @@
-package models
-
-import com.gu.memsub.subsv2.Subscription
-import com.gu.memsub.subsv2.SubscriptionPlan.AnyPlan
-import services.zuora.rest.ZuoraRestService.AccountObject
-
-case class AccountWithSubscriptions(account: AccountObject, subscriptions: List[Subscription[AnyPlan]])

--- a/membership-attribute-service/app/models/ContactAndSubscription.scala
+++ b/membership-attribute-service/app/models/ContactAndSubscription.scala
@@ -1,11 +1,10 @@
 package models
 
 import com.gu.memsub.subsv2.Subscription
-import com.gu.memsub.subsv2.SubscriptionPlan.AnyPlan
 import com.gu.salesforce.Contact
 
 case class ContactAndSubscription(
     contact: Contact,
-    subscription: Subscription[AnyPlan],
+    subscription: Subscription,
     isGiftRedemption: Boolean,
 )

--- a/membership-attribute-service/app/models/ExistingPaymentOption.scala
+++ b/membership-attribute-service/app/models/ExistingPaymentOption.scala
@@ -11,7 +11,7 @@ case class ExistingPaymentOption(
     freshlySignedIn: Boolean,
     objectAccount: ObjectAccount,
     paymentMethodOption: Option[PaymentMethod],
-    subscriptions: List[Subscription[SubscriptionPlan.AnyPlan]],
+    subscriptions: List[Subscription],
 )
 
 object ExistingPaymentOption {
@@ -20,7 +20,7 @@ object ExistingPaymentOption {
 
     import existingPaymentOption._
 
-    private def getSubscriptionFriendlyName(plan: SubscriptionPlan.AnyPlan): String = plan.product match {
+    private def getSubscriptionFriendlyName(plan: SubscriptionPlan): String = plan.product match {
       case _: Product.Weekly => "Guardian Weekly"
       case _: Product.Membership => plan.productName + " Membership"
       case _: Product.Contribution => plan.name

--- a/membership-attribute-service/app/services/PaymentDetailsForSubscription.scala
+++ b/membership-attribute-service/app/services/PaymentDetailsForSubscription.scala
@@ -23,7 +23,7 @@ class PaymentDetailsForSubscription(paymentService: PaymentService) extends Safe
       paymentService.paymentDetails(subscription, defaultMandateIdIfApplicable = Some("")).withLogging(s"get payment details for $subscription")
   }
 
-  private def giftPaymentDetailsFor(giftSubscription: Subscription[SubscriptionPlan.AnyPlan]): PaymentDetails = PaymentDetails(
+  private def giftPaymentDetailsFor(giftSubscription: Subscription): PaymentDetails = PaymentDetails(
     pendingCancellation = giftSubscription.isCancelled,
     chargedThroughDate = None,
     startDate = giftSubscription.startDate,

--- a/membership-attribute-service/app/services/PaymentFailureAlerter.scala
+++ b/membership-attribute-service/app/services/PaymentFailureAlerter.scala
@@ -3,8 +3,7 @@ package services
 import com.gu.memsub.Product
 import com.gu.memsub.Product.{Contribution, Membership}
 import com.gu.memsub.Subscription.AccountId
-import com.gu.memsub.subsv2.SubscriptionPlan.AnyPlan
-import com.gu.memsub.subsv2.{Subscription, SubscriptionPlan}
+import com.gu.memsub.subsv2.Subscription
 import com.gu.monitoring.SafeLogger.LogPrefix
 import com.gu.monitoring.SafeLogging
 import com.gu.zuora.api.{RegionalStripeGateways, StripeAUMembershipGateway, StripeUKMembershipGateway}
@@ -39,7 +38,7 @@ object PaymentFailureAlerter extends SafeLogging {
 
   def alertText(
       accountSummary: AccountSummary,
-      subscription: Subscription[AnyPlan],
+      subscription: Subscription,
       paymentMethodGetter: PaymentMethodId => Future[Either[String, PaymentMethodResponse]],
   )(implicit ec: ExecutionContext, logPrefix: LogPrefix): Future[Option[String]] = {
 
@@ -54,7 +53,7 @@ object PaymentFailureAlerter extends SafeLogging {
         case None => Future.successful(None)
       }
 
-      def getProductDescription(subscription: Subscription[SubscriptionPlan.AnyPlan]) =
+      def getProductDescription(subscription: Subscription) =
         if (subscription.plans.head.product == Membership) {
           s"${subscription.plan.productName} membership"
         } else if (subscription.plans.head.product == Contribution) {
@@ -85,7 +84,7 @@ object PaymentFailureAlerter extends SafeLogging {
 
   def alertAvailableFor(
       account: AccountObject,
-      subscription: Subscription[AnyPlan],
+      subscription: Subscription,
       paymentMethodGetter: PaymentMethodId => Future[Either[String, PaymentMethodResponse]],
   )(implicit ec: ExecutionContext): Future[Boolean] = {
     def isAlertableProduct = !nonAlertableProducts.contains(subscription.plan.product)

--- a/membership-attribute-service/app/services/mail/Emails.scala
+++ b/membership-attribute-service/app/services/mail/Emails.scala
@@ -12,7 +12,7 @@ import java.text.DecimalFormat
 object Emails {
   private val dateFormat = DateTimeFormat.forPattern("d MMMM yyyy")
 
-  def paymentMethodChangedEmail(emailAddress: String, contact: Contact, paymentMethod: PaymentType, plan: SubscriptionPlan.AnyPlan): EmailData = {
+  def paymentMethodChangedEmail(emailAddress: String, contact: Contact, paymentMethod: PaymentType, plan: SubscriptionPlan): EmailData = {
     EmailData(
       emailAddress = emailAddress,
       salesforceContactId = contact.salesforceContactId,
@@ -29,7 +29,7 @@ object Emails {
   def subscriptionCancelledEmail(
       emailAddress: String,
       contact: Contact,
-      plan: SubscriptionPlan.AnyPlan,
+      plan: SubscriptionPlan,
       cancellationEffectiveDate: Option[LocalDate],
   ): EmailData = {
     EmailData(

--- a/membership-attribute-service/app/services/subscription/CancelSubscription.scala
+++ b/membership-attribute-service/app/services/subscription/CancelSubscription.scala
@@ -16,13 +16,13 @@ import utils.SimpleEitherT.SimpleEitherT
 import scala.concurrent.{ExecutionContext, Future}
 
 class CancelSubscription(subscriptionService: SubscriptionService[Future], zuoraRestService: ZuoraRestService)(implicit m: Monad[Future]) {
-  def cancel[P <: SubscriptionPlan.AnyPlan](
+  def cancel(
       subscriptionName: Name,
       cancellationEffectiveDate: Option[LocalDate],
       reason: String,
       accountId: memsub.Subscription.AccountId,
       endOfTermDate: LocalDate,
-  )(implicit ec: ExecutionContext, reads: SubPlanReads[P], logPrefix: LogPrefix): EitherT[ApiError, Future, Option[LocalDate]] =
+  )(implicit ec: ExecutionContext, logPrefix: LogPrefix): EitherT[ApiError, Future, Option[LocalDate]] =
     (for {
       _ <- disableAutoPayOnlyIfAccountHasOneSubscription(accountId).leftMap(message => s"Failed to disable AutoPay: $message")
       _ <- EitherT(zuoraRestService.updateCancellationReason(subscriptionName, reason)).leftMap(message =>
@@ -37,10 +37,10 @@ class CancelSubscription(subscriptionService: SubscriptionService[Future], zuora
     * all subscriptions including the non-cancelled ones. In this case debt would start to accumulate in the form of positive Zuora account balance,
     * and if at any point auto-pay is switched back on, then payment for the entire amount would be attempted.
     */
-  def disableAutoPayOnlyIfAccountHasOneSubscription[P <: SubscriptionPlan.AnyPlan](
+  def disableAutoPayOnlyIfAccountHasOneSubscription(
       accountId: memsub.Subscription.AccountId,
-  )(implicit ec: ExecutionContext, reads: SubPlanReads[P], logPrefix: LogPrefix): SimpleEitherT[Unit] = {
-    EitherT(subscriptionService.subscriptionsForAccountId[P](accountId)).flatMap { currentSubscriptions =>
+  )(implicit ec: ExecutionContext, logPrefix: LogPrefix): SimpleEitherT[Unit] = {
+    EitherT(subscriptionService.subscriptionsForAccountId(accountId)).flatMap { currentSubscriptions =>
       if (currentSubscriptions.size <= 1)
         SimpleEitherT(zuoraRestService.disableAutoPay(accountId).map(_.toEither))
       else // do not disable auto pay

--- a/membership-attribute-service/app/services/zuora/payment/ZuoraPaymentService.scala
+++ b/membership-attribute-service/app/services/zuora/payment/ZuoraPaymentService.scala
@@ -24,7 +24,7 @@ class PaymentService(zuoraService: ZuoraSoapService, planMap: Map[ProductRatePla
     extends SafeLogging {
 
   def paymentDetails(
-      sub: Subscription[SubscriptionPlan.AnyPlan],
+      sub: Subscription,
       defaultMandateIdIfApplicable: Option[String] = None,
   )(implicit logPrefix: LogPrefix): Future[PaymentDetails] = {
     val currency = sub.plan.charges.currencies.head

--- a/membership-attribute-service/test/acceptance/AccountControllerAcceptanceTest.scala
+++ b/membership-attribute-service/test/acceptance/AccountControllerAcceptanceTest.scala
@@ -142,7 +142,7 @@ class AccountControllerAcceptanceTest extends AcceptanceTest {
       val nonGiftSubscription = TestSubscription()
       val nonGiftSubscriptionAccountId = nonGiftSubscription.accountId
 
-      subscriptionServiceMock.current[SubscriptionPlan.AnyPlan](contact)(any, any) returns
+      subscriptionServiceMock.current(contact)(any) returns
         Future(List(nonGiftSubscription))
 
       val giftSubscriptionFromSubscriptionService = TestSubscription(
@@ -152,7 +152,7 @@ class AccountControllerAcceptanceTest extends AcceptanceTest {
       )
       val giftSubscriptionAccountId = giftSubscriptionFromSubscriptionService.accountId
 
-      subscriptionServiceMock.get[SubscriptionPlan.AnyPlan](Subscription.Name(giftSubscription.Name), false)(any, any) returns Future.successful(
+      subscriptionServiceMock.get(Subscription.Name(giftSubscription.Name), false)(any) returns Future.successful(
         Some(giftSubscriptionFromSubscriptionService),
       )
 
@@ -199,9 +199,9 @@ class AccountControllerAcceptanceTest extends AcceptanceTest {
 
       contactRepositoryMock.get("200067388")(any) was called
       supporterProductDataServiceMock.getSupporterRatePlanItems("200067388")(any[LogPrefix]) was called
-      subscriptionServiceMock.current[SubscriptionPlan.AnyPlan](contact)(any, any) was called
+      subscriptionServiceMock.current(contact)(any) was called
       zuoraRestServiceMock.getGiftSubscriptionRecordsFromIdentityId("200067388")(any) was called
-      subscriptionServiceMock.get[SubscriptionPlan.AnyPlan](Subscription.Name(giftSubscription.Name), isActiveToday = false)(any, any) was called
+      subscriptionServiceMock.get(Subscription.Name(giftSubscription.Name), isActiveToday = false)(any) was called
       catalogServiceMock.unsafeCatalog was called
 
       zuoraRestServiceMock.getAccount(giftSubscriptionAccountId)(any) was called
@@ -322,7 +322,7 @@ class AccountControllerAcceptanceTest extends AcceptanceTest {
         plans = CovariantNonEmptyList(plan, Nil),
       )
 
-      subscriptionServiceMock.current[SubscriptionPlan.AnyPlan](contact)(any, any) returns Future(List(subscription))
+      subscriptionServiceMock.current(contact)(any) returns Future(List(subscription))
 
       zuoraRestServiceMock.updateChargeAmount(
         subscription.name,
@@ -350,7 +350,7 @@ class AccountControllerAcceptanceTest extends AcceptanceTest {
       contactRepositoryMock.get("200067388")(any) was called
 
       identityMockClientAndServer.verify(identityRequest)
-      subscriptionServiceMock.current[SubscriptionPlan.AnyPlan](contact)(any, any) was called
+      subscriptionServiceMock.current(contact)(any) was called
       zuoraRestServiceMock.updateChargeAmount(
         subscription.name,
         charge.subRatePlanChargeId,
@@ -427,15 +427,15 @@ class AccountControllerAcceptanceTest extends AcceptanceTest {
         termEndDate = new LocalDate(2024, 4, 12),
       )
 
-      subscriptionServiceMock.current[SubscriptionPlan.AnyPlan](contact)(any, any) returns Future(List(subscription))
+      subscriptionServiceMock.current(contact)(any) returns Future(List(subscription))
 
       val cancellationEffectiveDate = new LocalDate(2024, 4, 5)
       subscriptionServiceMock
-        .decideCancellationEffectiveDate[SubscriptionPlan.AnyPlan](Name(subscriptionId), any, any)(any, any) returns SimpleEitherT
+        .decideCancellationEffectiveDate(Name(subscriptionId), any, any)(any) returns SimpleEitherT
         .right(Some(cancellationEffectiveDate))
 
       subscriptionServiceMock
-        .subscriptionsForAccountId[SubscriptionPlan.AnyPlan](subscription.accountId)(any, any) shouldReturn SimpleEitherT
+        .subscriptionsForAccountId(subscription.accountId)(any) shouldReturn SimpleEitherT
         .right(List(subscription))
         .run
 
@@ -465,10 +465,10 @@ class AccountControllerAcceptanceTest extends AcceptanceTest {
       contactRepositoryMock.get("200067388")(any) was called
 
       identityMockClientAndServer.verify(identityRequest)
-      subscriptionServiceMock.current[SubscriptionPlan.AnyPlan](contact)(any, any) was called
+      subscriptionServiceMock.current(contact)(any) was called
 
-      subscriptionServiceMock.decideCancellationEffectiveDate[SubscriptionPlan.AnyPlan](Name(subscriptionId), any, any)(any, any) was called
-      subscriptionServiceMock.subscriptionsForAccountId[SubscriptionPlan.AnyPlan](subscription.accountId)(any, any) was called
+      subscriptionServiceMock.decideCancellationEffectiveDate(Name(subscriptionId), any, any)(any) was called
+      subscriptionServiceMock.subscriptionsForAccountId(subscription.accountId)(any) was called
       zuoraRestServiceMock.disableAutoPay(subscription.accountId)(any) was called
       zuoraRestServiceMock.updateCancellationReason(Name(subscriptionId), "My reason")(any) was called
       zuoraRestServiceMock.cancelSubscription(Name(subscriptionId), subscription.termEndDate, Some(cancellationEffectiveDate))(any, any) was called

--- a/membership-attribute-service/test/acceptance/PaymentUpdateControllerAcceptanceTest.scala
+++ b/membership-attribute-service/test/acceptance/PaymentUpdateControllerAcceptanceTest.scala
@@ -158,7 +158,7 @@ class PaymentUpdateControllerAcceptanceTest extends AcceptanceTest {
         plans = CovariantNonEmptyList(TestPaidSubscriptionPlan(productType = "Newspaper - Home Delivery"), Nil),
       )
 
-      subscriptionServiceMock.current[SubscriptionPlan.AnyPlan](contact)(any, any) returns Future(List(subscription))
+      subscriptionServiceMock.current(contact)(any) returns Future(List(subscription))
 
       val account = TestQueriesAccount()
       val paymentMethodId = randomId("paymentMethod")
@@ -214,7 +214,7 @@ class PaymentUpdateControllerAcceptanceTest extends AcceptanceTest {
       httpResponse.getStatus shouldEqual 200
 
       identityMockClientAndServer.verify(identityRequest)
-      subscriptionServiceMock.current[SubscriptionPlan.AnyPlan](contact)(any, any) was called
+      subscriptionServiceMock.current(contact)(any) was called
       contactRepositoryMock.get("200067388")(any) was called
       catalogServiceMock.unsafeCatalog was called
       zuoraSoapServiceMock.getAccount(subscription.accountId)(any) wasCalled twice
@@ -319,7 +319,7 @@ class PaymentUpdateControllerAcceptanceTest extends AcceptanceTest {
         plans = CovariantNonEmptyList(TestPaidSubscriptionPlan(productType = "Digital Pack"), Nil),
       )
 
-      subscriptionServiceMock.current[SubscriptionPlan.AnyPlan](contact)(any, any) returns Future(List(subscription))
+      subscriptionServiceMock.current(contact)(any) returns Future(List(subscription))
 
       val customer = TestStripeCustomer(card =
         TestStripeCard(
@@ -364,7 +364,7 @@ class PaymentUpdateControllerAcceptanceTest extends AcceptanceTest {
       httpResponse.getStatus shouldEqual 200
 
       identityMockClientAndServer.verify(identityRequest)
-      subscriptionServiceMock.current[SubscriptionPlan.AnyPlan](contact)(any, any) was called
+      subscriptionServiceMock.current(contact)(any) was called
       contactRepositoryMock.get("200067388")(any) was called
       ukStripeServiceMock.createCustomerWithStripePaymentMethod("myStripePaymentMethodId")(any) was called
       ukStripeServiceMock.paymentIntentsGateway was called

--- a/membership-attribute-service/test/acceptance/data/TestPaidSubscriptionPlan.scala
+++ b/membership-attribute-service/test/acceptance/data/TestPaidSubscriptionPlan.scala
@@ -8,7 +8,7 @@ import com.gu.memsub.subsv2.{ChargeList, SubscriptionPlan}
 import org.joda.time.LocalDate
 
 object TestPaidSubscriptionPlan {
-  def apply[P <: Product, C <: ChargeList](
+  def apply(
       id: RatePlanId = RatePlanId(randomId("ratePlan")),
       productRatePlanId: ProductRatePlanId = ProductRatePlanId(randomId("productRatePlan")),
       name: String = randomId("paidSubscriptionPlanName"),
@@ -16,13 +16,13 @@ object TestPaidSubscriptionPlan {
       productName: String = randomId("paidSubscriptionPlanProductName"),
       lastChangeType: Option[String] = None,
       productType: String = randomId("paidSubscriptionPlanProductType"),
-      product: P = Membership,
+      product: Product = Membership,
       features: List[Feature] = Nil,
-      charges: C = TestSingleCharge(),
+      charges: ChargeList = TestSingleCharge(),
       chargedThrough: Option[LocalDate] = None, // this is None if the sub hasn't been billed yet (on a free trial)
       start: LocalDate = LocalDate.now().minusDays(13),
       end: LocalDate = LocalDate.now().minusDays(13).plusYears(1),
-  ): SubscriptionPlan[P, C] = SubscriptionPlan(
+  ): SubscriptionPlan = SubscriptionPlan(
     id: RatePlanId,
     productRatePlanId,
     name,

--- a/membership-attribute-service/test/acceptance/data/TestSubscription.scala
+++ b/membership-attribute-service/test/acceptance/data/TestSubscription.scala
@@ -3,7 +3,6 @@ package acceptance.data
 import acceptance.data.Randoms.randomId
 import com.gu.memsub
 import com.gu.memsub.promo.PromoCode
-import com.gu.memsub.subsv2.SubscriptionPlan.AnyPlan
 import com.gu.memsub.subsv2.{CovariantNonEmptyList, ReaderType, Subscription, SubscriptionPlan}
 import org.joda.time.{DateTime, LocalDate}
 
@@ -20,12 +19,12 @@ object TestSubscription {
       promoCode: Option[PromoCode] = None,
       isCancelled: Boolean = false,
       hasPendingFreePlan: Boolean = false,
-      plans: CovariantNonEmptyList[AnyPlan] = CovariantNonEmptyList(TestPaidSubscriptionPlan(), Nil),
+      plans: CovariantNonEmptyList[SubscriptionPlan] = CovariantNonEmptyList(TestPaidSubscriptionPlan(), Nil),
       readerType: ReaderType = ReaderType.Direct,
       gifteeIdentityId: Option[String] = None,
       autoRenew: Boolean = false,
-  ): Subscription[AnyPlan] =
-    Subscription[AnyPlan](
+  ): Subscription =
+    Subscription(
       id: memsub.Subscription.Id,
       name,
       accountId,

--- a/membership-attribute-service/test/services/PaymentDetailsForSubscriptionTest.scala
+++ b/membership-attribute-service/test/services/PaymentDetailsForSubscriptionTest.scala
@@ -61,7 +61,7 @@ class PaymentDetailsForSubscriptionTest(implicit ee: ExecutionEnv) extends Speci
       val expectedPaymentDetails = PaymentDetails(digipackGift, None, None, None)
 
       paymentService.paymentDetails(
-        any[Subscription[SubscriptionPlan.AnyPlan]],
+        any[Subscription],
         any[Option[String]],
       ) returns Future.successful(expectedPaymentDetails)
 
@@ -77,7 +77,7 @@ class PaymentDetailsForSubscriptionTest(implicit ee: ExecutionEnv) extends Speci
       val expectedPaymentDetails = PaymentDetails(digipack, None, None, None)
 
       paymentService.paymentDetails(
-        any[Subscription[SubscriptionPlan.AnyPlan]](),
+        any[Subscription](),
         any[Option[String]](),
       ) returns Future.successful(expectedPaymentDetails)
 

--- a/membership-attribute-service/test/testdata/SubscriptionTestData.scala
+++ b/membership-attribute-service/test/testdata/SubscriptionTestData.scala
@@ -15,8 +15,8 @@ trait SubscriptionTestData {
 
   def referenceDate: LocalDate
 
-  def supporterPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan.AnyPlan =
-    SubscriptionPlan[Product.Membership, SingleCharge[Benefit.Supporter.type, BillingPeriod]](
+  def supporterPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan =
+    SubscriptionPlan(
       RatePlanId("idSupporter"),
       ProductRatePlanId("prpi"),
       "Supporter",
@@ -37,8 +37,8 @@ trait SubscriptionTestData {
       startDate,
       endDate,
     )
-  def digipackPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan.AnyPlan =
-    SubscriptionPlan[Product.ZDigipack, SingleCharge[Benefit.Digipack.type, BillingPeriod]](
+  def digipackPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan =
+    SubscriptionPlan(
       RatePlanId("idDigipack"),
       ProductRatePlanId("prpi"),
       "Digipack",
@@ -59,7 +59,7 @@ trait SubscriptionTestData {
       startDate,
       endDate,
     )
-  def paperPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan.AnyPlan = SubscriptionPlan[Product.Delivery, PaperCharges](
+  def paperPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan = SubscriptionPlan(
     RatePlanId("idPaperPlan"),
     ProductRatePlanId("prpi"),
     "Sunday",
@@ -74,7 +74,7 @@ trait SubscriptionTestData {
     startDate,
     endDate,
   )
-  def paperPlusPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan.AnyPlan = SubscriptionPlan[Product.Delivery, PaperCharges](
+  def paperPlusPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan = SubscriptionPlan(
     RatePlanId("idPaperPlusPlan"),
     ProductRatePlanId("prpi"),
     "Sunday+",
@@ -89,8 +89,8 @@ trait SubscriptionTestData {
     startDate,
     endDate,
   )
-  def contributorPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan.AnyPlan =
-    SubscriptionPlan[Product.Contribution, SingleCharge[Benefit.Contributor.type, BillingPeriod]](
+  def contributorPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan =
+    SubscriptionPlan(
       RatePlanId("idContributor"),
       ProductRatePlanId("prpi"),
       "Monthly Contribution",
@@ -111,8 +111,8 @@ trait SubscriptionTestData {
       startDate,
       endDate,
     )
-  def guardianWeeklyPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan.AnyPlan =
-    SubscriptionPlan[Product.WeeklyDomestic, SingleCharge[Benefit.Weekly.type, BillingPeriod]](
+  def guardianWeeklyPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan =
+    SubscriptionPlan(
       RatePlanId("idGuardianWeeklyPlan"),
       ProductRatePlanId("prpi"),
       "Guardian Weekly",
@@ -134,8 +134,8 @@ trait SubscriptionTestData {
       endDate,
     )
 
-  def supporterPlusPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan.AnyPlan =
-    SubscriptionPlan[Product.SupporterPlus, SingleCharge[Benefit.SupporterPlus.type, BillingPeriod]](
+  def supporterPlusPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan =
+    SubscriptionPlan(
       RatePlanId("idSupporterPlusPlan"),
       ProductRatePlanId("prpi"),
       "Supporter Plus",
@@ -157,7 +157,7 @@ trait SubscriptionTestData {
       endDate,
     )
 
-  def toSubscription[P <: SubscriptionPlan.AnyPlan](isCancelled: Boolean)(plans: NonEmptyList[P]): Subscription[P] = {
+  def toSubscription(isCancelled: Boolean)(plans: NonEmptyList[SubscriptionPlan]): Subscription = {
     Subscription(
       id = Id(plans.head.id.get),
       name = Name("AS-123123"),

--- a/membership-common/src/main/scala/com/gu/memsub/subsv2/Plan.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/subsv2/Plan.scala
@@ -396,16 +396,7 @@ case class SupporterPlusCharges(billingPeriod: BillingPeriod, pricingSummaries: 
   override def benefits: NonEmptyList[Benefit] = NonEmptyList(SupporterPlus)
 }
 
-/** This is the higher level model of a zuora rate plan, This particular trait is stuff common to both catalog and subscription plans
-  */
-sealed trait Plan[+P <: Product, +C <: ChargeList] {
-  def name: String
-  def description: String
-  def charges: C
-  def product: P
-}
-
-case class SubscriptionPlan[+P <: Product, +C <: ChargeList](
+case class SubscriptionPlan(
     id: RatePlanId,
     productRatePlanId: ProductRatePlanId,
     name: String,
@@ -413,15 +404,15 @@ case class SubscriptionPlan[+P <: Product, +C <: ChargeList](
     productName: String,
     lastChangeType: Option[String],
     productType: String,
-    product: P,
+    product: Product,
     features: List[SubsFeature],
-    charges: C,
+    charges: ChargeList,
     chargedThrough: Option[
       LocalDate,
     ], // this is None if the sub hasn't been billed yet (on a free trial) or if you have been billed it is the date at which you'll next be billed
     start: LocalDate,
     end: LocalDate,
-) extends Plan[P, C]
+)
 
 case class CatalogPlan[+P <: Product, +C <: ChargeList, +S <: Status](
     id: ProductRatePlanId,
@@ -431,12 +422,4 @@ case class CatalogPlan[+P <: Product, +C <: ChargeList, +S <: Status](
     saving: Option[Int],
     charges: C,
     s: S,
-) extends Plan[P, C]
-
-/** So the benefit of all these type parameters on the higher level models is that you can uniquely identify a particular plan by its type signature
-  * and if you can do that then you can pass your super specific (or more generic) plan into subscription service to find the subscription of your
-  * dreams
-  */
-object SubscriptionPlan {
-  type AnyPlan = SubscriptionPlan[Product, ChargeList]
-}
+)

--- a/membership-common/src/main/scala/com/gu/memsub/subsv2/reads/ChargeListReads.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/subsv2/reads/ChargeListReads.scala
@@ -59,7 +59,31 @@ object ChargeListReads {
       delivery: ProductId,
       nationalDelivery: ProductId,
       contributor: ProductId,
-  )
+  ) {
+
+    val productMap: Map[ProductId, Product] = {
+      import Product._
+      Map[ProductId, Product](
+        weeklyZoneA -> Product.WeeklyZoneA,
+        voucher -> Voucher,
+        digitalVoucher -> DigitalVoucher,
+        delivery -> Delivery,
+        nationalDelivery -> NationalDelivery,
+        weeklyZoneA -> WeeklyZoneA,
+        weeklyZoneB -> WeeklyZoneB,
+        weeklyZoneC -> WeeklyZoneC,
+        weeklyDomestic -> WeeklyDomestic,
+        weeklyRestOfWorld -> WeeklyRestOfWorld,
+        digipack -> Digipack,
+        supporterPlus -> SupporterPlus,
+        supporter -> Membership,
+        partner -> Membership,
+        patron -> Membership,
+        contributor -> Contribution,
+      )
+    }
+
+  }
 
   implicit def readAnyProduct[P <: Benefit: ClassTag]: ChargeReads[P] = new ChargeReads[Benefit] {
     def read(cat: PlanChargeMap, charge: ZuoraCharge): ValidationNel[String, Benefit] =
@@ -121,7 +145,7 @@ object ChargeListReads {
     }
   }
 
-  implicit def readChargeList: ChargeListReads[ChargeList] = new ChargeListReads[ChargeList] {
+  def readChargeList: ChargeListReads[ChargeList] = new ChargeListReads[ChargeList] {
     def read(cat: PlanChargeMap, charges: List[ZuoraCharge]): ValidationNel[String, ChargeList] = {
       readPaperChargeList.read(cat, charges).map(identity[ChargeList]) orElse2
         readPaidCharge[Benefit, BillingPeriod](readAnyProduct, anyBpReads).read(cat, charges) orElse2

--- a/membership-common/src/main/scala/com/gu/memsub/subsv2/reads/SubJsonReads.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/subsv2/reads/SubJsonReads.scala
@@ -95,10 +95,10 @@ object SubJsonReads {
   implicit val lenientDateTimeReader: Reads[DateTime] =
     JodaReads.DefaultJodaDateTimeReads orElse Reads.IsoDateReads.map(new DateTime(_))
 
-  def subscriptionReads[P <: SubscriptionPlan.AnyPlan](
+  def subscriptionReads(
       now: LocalDate, /*TODO get rid when we fix the below*/
-  ): Reads[NonEmptyList[P] => Subscription[P]] = new Reads[NonEmptyList[P] => Subscription[P]] {
-    override def reads(json: JsValue): JsResult[NonEmptyList[P] => Subscription[P]] = {
+  ): Reads[NonEmptyList[SubscriptionPlan] => Subscription] = new Reads[NonEmptyList[SubscriptionPlan] => Subscription] {
+    override def reads(json: JsValue): JsResult[NonEmptyList[SubscriptionPlan] => Subscription] = {
 
       // ideally we'd use the plans list
       // on the main subscription model, but this is a quick fix.
@@ -129,7 +129,7 @@ object SubJsonReads {
               (__ \ "ReaderType__c").readNullable[String].map(ReaderType.apply) and
               (__ \ "GifteeIdentityId__c").readNullable[String] and
               (__ \ "autoRenew").read[Boolean]
-          )(memsub.subsv2.Subscription.partial[P](hasPendingFreePlan) _).reads(o)
+          )(memsub.subsv2.Subscription.partial(hasPendingFreePlan) _).reads(o)
         case e => JsError(s"Needed a JsObject, got ${e.getClass.getSimpleName}")
       }
     }

--- a/membership-common/src/main/scala/com/gu/memsub/subsv2/reads/SubPlanReads.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/subsv2/reads/SubPlanReads.scala
@@ -1,112 +1,40 @@
 package com.gu.memsub.subsv2.reads
-import com.gu.memsub.Product._
-import com.gu.memsub.Product
-import com.gu.memsub.Subscription.ProductId
 import com.gu.memsub.subsv2._
 import com.gu.memsub.subsv2.reads.ChargeListReads.{ProductIds, _}
 import com.gu.memsub.subsv2.reads.CommonReads._
-import com.gu.memsub.{Benefit, BillingPeriod}
-
 import scalaz.Validation.FlatMap._
-import scalaz.std.list._
-import scalaz.syntax.monad._
-import scalaz.syntax.nel._
-import scalaz.syntax.std.boolean._
+import scalaz.ValidationNel
 import scalaz.syntax.std.option._
-import scalaz.{Validation, ValidationNel, \/}
-import scalaz.syntax.apply.ToApplyOps
-
-/** Convert a catalog zuora plan and a subscription zuora plan into some type A Between them, the catalog zuora plan & sub zuora plan have enough info
-  * to construct a Plan
-  */
-trait SubPlanReads[A] {
-  def read(p: ProductIds, z: SubscriptionZuoraPlan, c: CatalogZuoraPlan): ValidationNel[String, A]
-}
 
 object SubPlanReads {
 
-  def findProduct[P <: Product](id: ProductIds => List[ProductId], product: P): SubPlanReads[P] = new SubPlanReads[P] {
-
-    override def read(p: ProductIds, z: SubscriptionZuoraPlan, c: CatalogZuoraPlan): ValidationNel[String, P] = {
-      id(p)
-        .contains(c.productId)
-        .option(product)
-        .toSuccess(s"couldn't read a $product: as the product id is ${c.productId} but we need one of $p".wrapNel)
-    }
-  }
-
-  private val voucherReads: SubPlanReads[Voucher] = findProduct(_.voucher.point[List], Voucher)
-  private val digitalVoucherReads: SubPlanReads[DigitalVoucher] = findProduct(_.digitalVoucher.point[List], DigitalVoucher)
-  private val deliveryReads: SubPlanReads[Delivery] = findProduct(_.delivery.point[List], Delivery)
-  private val nationalDeliveryReads: SubPlanReads[NationalDelivery] = findProduct(_.nationalDelivery.point[List], NationalDelivery)
-  private val zDigipackReads: SubPlanReads[ZDigipack] = findProduct(_.digipack.point[List], Digipack)
-  private val supporterPlusReads: SubPlanReads[SupporterPlus] = findProduct(_.supporterPlus.point[List], SupporterPlus)
-  private val membershipReads: SubPlanReads[Membership] = findProduct(ids => List(ids.supporter, ids.partner, ids.patron), Membership)
-  private val contributionReads: SubPlanReads[Contribution] = findProduct(_.contributor.point[List], Contribution)
-  private val weeklyZoneAReads: SubPlanReads[WeeklyZoneA] = findProduct(_.weeklyZoneA.point[List], WeeklyZoneA)
-  private val weeklyZoneBReads: SubPlanReads[WeeklyZoneB] = findProduct(_.weeklyZoneB.point[List], WeeklyZoneB)
-  private val weeklyZoneCReads: SubPlanReads[WeeklyZoneC] = findProduct(_.weeklyZoneC.point[List], WeeklyZoneC)
-  private val weeklyDomesticReads: SubPlanReads[WeeklyDomestic] = findProduct(_.weeklyDomestic.point[List], WeeklyDomestic)
-  private val weeklyRestOfWorldReads: SubPlanReads[WeeklyRestOfWorld] = findProduct(_.weeklyRestOfWorld.point[List], WeeklyRestOfWorld)
-
-  implicit val productReads: SubPlanReads[Product] = new SubPlanReads[Product] {
-    override def read(p: ProductIds, z: SubscriptionZuoraPlan, c: CatalogZuoraPlan): ValidationNel[String, Product] =
-      (contentSubscriptionReads.read(p, z, c) orElse2
-        membershipReads.read(p, z, c) orElse2
-        contributionReads.read(p, z, c)).withTrace("productReads")
-  }
-
-  private val contentSubscriptionReads: SubPlanReads[ContentSubscription] = new SubPlanReads[ContentSubscription] {
-    override def read(p: ProductIds, z: SubscriptionZuoraPlan, c: CatalogZuoraPlan): ValidationNel[String, ContentSubscription] =
-      (paperReads.read(p, z, c) orElse2
-        zDigipackReads.read(p, z, c) orElse2
-        supporterPlusReads.read(p, z, c)).withTrace("contentSubscriptionReads")
-  }
-
-  private val paperReads: SubPlanReads[Paper] = new SubPlanReads[Paper] {
-    override def read(p: ProductIds, z: SubscriptionZuoraPlan, c: CatalogZuoraPlan): ValidationNel[String, Paper] =
-      (voucherReads.read(p, z, c).map(identity[Paper]) orElse2
-        digitalVoucherReads.read(p, z, c) orElse2
-        deliveryReads.read(p, z, c) orElse2
-        nationalDeliveryReads.read(p, z, c) orElse2
-        weeklyZoneAReads.read(p, z, c) orElse2
-        weeklyZoneBReads.read(p, z, c) orElse2
-        weeklyZoneCReads.read(p, z, c) orElse2
-        weeklyDomesticReads.read(p, z, c) orElse2
-        weeklyRestOfWorldReads.read(p, z, c)).withTrace("paperReads")
-  }
-
-  implicit def anyPlanReads[P <: Product, C <: ChargeList](implicit
-      productReads: SubPlanReads[P],
-      chargeListReads: ChargeListReads[C],
-  ): SubPlanReads[SubscriptionPlan[P, C]] =
-    new SubPlanReads[SubscriptionPlan[P, C]] {
-      override def read(
-          ids: ProductIds,
-          subZuoraPlan: SubscriptionZuoraPlan,
-          catZuoraPlan: CatalogZuoraPlan,
-      ): ValidationNel[String, SubscriptionPlan[P, C]] =
-        (for {
-          charges <- chargeListReads.read(catZuoraPlan.benefits, subZuoraPlan.charges.list.toList)
-          product <- productReads.read(ids, subZuoraPlan, catZuoraPlan)
-        } yield {
-          val highLevelFeatures = subZuoraPlan.features.map(com.gu.memsub.Subscription.Feature.fromRest)
-          SubscriptionPlan(
-            subZuoraPlan.id,
-            catZuoraPlan.id,
-            catZuoraPlan.name,
-            catZuoraPlan.description,
-            subZuoraPlan.productName,
-            subZuoraPlan.lastChangeType,
-            catZuoraPlan.productType,
-            product,
-            highLevelFeatures,
-            charges,
-            subZuoraPlan.chargedThroughDate,
-            subZuoraPlan.start,
-            subZuoraPlan.end,
-          )
-        }).withTrace("paidPlanReads")
-    }
+  def anyPlanReads(
+      ids: ProductIds,
+      subZuoraPlan: SubscriptionZuoraPlan,
+      catZuoraPlan: CatalogZuoraPlan,
+  ): ValidationNel[String, SubscriptionPlan] =
+    (for {
+      charges <- readChargeList.read(catZuoraPlan.benefits, subZuoraPlan.charges.list.toList)
+      product <- ids.productMap
+        .get(catZuoraPlan.productId)
+        .toSuccessNel(s"couldn't read a product as the product id is ${catZuoraPlan.productId} but we need one of $ids")
+    } yield {
+      val highLevelFeatures = subZuoraPlan.features.map(com.gu.memsub.Subscription.Feature.fromRest)
+      SubscriptionPlan(
+        subZuoraPlan.id,
+        catZuoraPlan.id,
+        catZuoraPlan.name,
+        catZuoraPlan.description,
+        subZuoraPlan.productName,
+        subZuoraPlan.lastChangeType,
+        catZuoraPlan.productType,
+        product,
+        highLevelFeatures,
+        charges,
+        subZuoraPlan.chargedThroughDate,
+        subZuoraPlan.start,
+        subZuoraPlan.end,
+      )
+    }).withTrace("anyPlanReads")
 
 }

--- a/membership-common/src/main/scala/com/gu/memsub/subsv2/reads/SubPlanReads.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/subsv2/reads/SubPlanReads.scala
@@ -8,7 +8,7 @@ import scalaz.syntax.std.option._
 
 object SubPlanReads {
 
-  def anyPlanReads(
+  def planReads(
       ids: ProductIds,
       subZuoraPlan: SubscriptionZuoraPlan,
       catZuoraPlan: CatalogZuoraPlan,

--- a/membership-common/src/main/scala/com/gu/memsub/subsv2/services/SubscriptionTransform.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/subsv2/services/SubscriptionTransform.scala
@@ -113,7 +113,7 @@ object SubscriptionTransform extends SafeLogging {
                 .get(lowLevelPlan.productRatePlanId)
                 .toRightDisjunction(s"No catalog plan - prpId = ${lowLevelPlan.productRatePlanId}")
                 .flatMap { catalogPlan =>
-                  val maybePlans = SubPlanReads.anyPlanReads(pids, lowLevelPlan, catalogPlan)
+                  val maybePlans = SubPlanReads.planReads(pids, lowLevelPlan, catalogPlan)
                   maybePlans.toDisjunction
                     .leftMap(
                       _.list.zipWithIndex

--- a/membership-common/src/main/scala/com/gu/services/model/PaymentDetails.scala
+++ b/membership-common/src/main/scala/com/gu/services/model/PaymentDetails.scala
@@ -28,7 +28,7 @@ object PaymentDetails {
   implicit def dateToDateTime(date: LocalDate): DateTime = date.toDateTimeAtStartOfDay()
 
   def apply(
-      sub: Subscription[SubscriptionPlan.AnyPlan],
+      sub: Subscription,
       paymentMethod: Option[PaymentMethod],
       nextPayment: Option[Payment],
       lastPaymentDate: Option[LocalDate],
@@ -58,7 +58,7 @@ object PaymentDetails {
   case class PersonalPlan(name: String, price: Price, interval: String)
 
   object PersonalPlan {
-    def paid(subscription: Subscription[SubscriptionPlan.AnyPlan]): PersonalPlan = PersonalPlan(
+    def paid(subscription: Subscription): PersonalPlan = PersonalPlan(
       name = subscription.plan.productName,
       price = subscription.plan.charges.price.prices.head,
       interval = subscription.plan.charges.billingPeriod.noun,

--- a/membership-common/src/test/scala/com/gu/memsub/subsv2/reads/ChargeListReadsTest.scala
+++ b/membership-common/src/test/scala/com/gu/memsub/subsv2/reads/ChargeListReadsTest.scala
@@ -136,7 +136,7 @@ class ChargeListReadsTest extends AnyFlatSpec {
   }
 
   "ChargeList reads" should "read single-charge non-paper rate plans as generic PaidCharge type" in {
-    val result: ValidationNel[String, ChargeList] = implicitly[ChargeListReads[ChargeList]].read(planChargeMap, List(weeklyCharge))
+    val result: ValidationNel[String, ChargeList] = readChargeList.read(planChargeMap, List(weeklyCharge))
 
     val expected: ValidationNel[String, ChargeList] =
       Success(SingleCharge(Weekly, Month, weeklyCharge.pricing, weeklyCharge.productRatePlanChargeId, weeklyCharge.id))
@@ -151,7 +151,7 @@ class ChargeListReadsTest extends AnyFlatSpec {
 
     val sundayPrices = Seq((SundayPaper, paperCharge.pricing)).toMap[PaperDay, PricingSummary]
 
-    val result: ValidationNel[String, ChargeList] = implicitly[ChargeListReads[ChargeList]].read(planChargeMap, List(paperCharge))
+    val result: ValidationNel[String, ChargeList] = readChargeList.read(planChargeMap, List(paperCharge))
 
     val expected: ValidationNel[String, ChargeList] = Success(PaperCharges(dayPrices = sundayPrices, digipack = None))
 
@@ -162,7 +162,7 @@ class ChargeListReadsTest extends AnyFlatSpec {
   }
 
   "ChargeList reads" should "not confuse digipack rate plan with paper+digital plan" in {
-    val result: ValidationNel[String, ChargeList] = implicitly[ChargeListReads[ChargeList]].read(planChargeMap, List(digipackCharge))
+    val result: ValidationNel[String, ChargeList] = readChargeList.read(planChargeMap, List(digipackCharge))
 
     val expected: ValidationNel[String, ChargeList] =
       Success(SingleCharge(Digipack, Month, digipackCharge.pricing, digipackCharge.productRatePlanChargeId, digipackCharge.id))

--- a/membership-common/src/test/scala/com/gu/memsub/subsv2/reads/SubReadsTest.scala
+++ b/membership-common/src/test/scala/com/gu/memsub/subsv2/reads/SubReadsTest.scala
@@ -8,7 +8,6 @@ import com.gu.memsub.Product.WeeklyDomestic
 import com.gu.memsub.Subscription.{ProductRatePlanChargeId, ProductRatePlanId, RatePlanId, SubscriptionRatePlanChargeId}
 import com.gu.memsub._
 import com.gu.memsub.subsv2.ReaderType.Patron
-import com.gu.memsub.subsv2.SubscriptionPlan.AnyPlan
 import com.gu.memsub.subsv2._
 import com.gu.memsub.subsv2.reads.SubJsonReads._
 import org.joda.time.LocalDate
@@ -80,7 +79,7 @@ class SubReadsTest extends Specification {
         end = now,
       )
       val subscription =
-        SubJsonReads.subscriptionReads[AnyPlan](now).reads(json).get(NonEmptyList(plan))
+        SubJsonReads.subscriptionReads(now).reads(json).get(NonEmptyList(plan))
 
       subscription.readerType mustEqual Patron
     }

--- a/membership-common/src/test/scala/com/gu/memsub/subsv2/services/SubscriptionTransformTest.scala
+++ b/membership-common/src/test/scala/com/gu/memsub/subsv2/services/SubscriptionTransformTest.scala
@@ -67,10 +67,10 @@ class SubscriptionTransformTest extends AnyFlatSpec {
   "subscription transform" should "load a one year guardian weekly subscription" in {
 
     val json: JsValue = Resource.getJson("rest/plans/WeeklyOneYear.json")
-    val result: Disjunction[String, V2Subscription[SubscriptionPlan.AnyPlan]] =
-      SubscriptionTransform.getSubscription[SubscriptionPlan.AnyPlan](cat, Fixtures.productIds, () => 3 May 2017)(json)
-    val expected: String \/ V2Subscription[SubscriptionPlan.AnyPlan] = \/-(
-      V2Subscription[SubscriptionPlan[Product.WeeklyZoneB.type, SingleCharge[Weekly.type, BillingPeriod.OneYear.type]]](
+    val result: Disjunction[String, V2Subscription] =
+      SubscriptionTransform.getSubscription(cat, Fixtures.productIds, () => 3 May 2017)(json)
+    val expected: String \/ V2Subscription = \/-(
+      V2Subscription(
         id = Id("2c92c0f85bae511e015bcead968f69e0"),
         name = Name("A-S00069184"),
         accountId = AccountId("2c92c0f859b047b70159bc8dcc901253"),
@@ -117,11 +117,11 @@ class SubscriptionTransformTest extends AnyFlatSpec {
   "subscription transform" should "load a 6 month guardian weekly subscription" in {
 
     val json: JsValue = Resource.getJson("rest/plans/WeeklySixMonths.json")
-    val result: Disjunction[String, V2Subscription[SubscriptionPlan.AnyPlan]] =
-      SubscriptionTransform.getSubscription[SubscriptionPlan.AnyPlan](cat, Fixtures.productIds, () => 3 May 2017)(json)
+    val result: Disjunction[String, V2Subscription] =
+      SubscriptionTransform.getSubscription(cat, Fixtures.productIds, () => 3 May 2017)(json)
 
-    val expected: Disjunction[String, V2Subscription[SubscriptionPlan.AnyPlan]] = \/-(
-      V2Subscription[SubscriptionPlan[Product.WeeklyZoneB.type, SingleCharge[Weekly.type, BillingPeriod.SixMonths.type]]](
+    val expected: Disjunction[String, V2Subscription] = \/-(
+      V2Subscription(
         id = Id("2c92c0f95bae6218015bceaf243d0fa4"),
         name = Name("A-S00069185"),
         accountId = AccountId("2c92c0f859b047b70159bc8dcc901253"),
@@ -169,10 +169,10 @@ class SubscriptionTransformTest extends AnyFlatSpec {
   "subscription transform" should "load a 6 monthly recurring guardian weekly subscription" in {
 
     val json: JsValue = Resource.getJson("rest/plans/WeeklySixMonthly.json")
-    val result: Disjunction[String, V2Subscription[SubscriptionPlan.AnyPlan]] =
-      SubscriptionTransform.getSubscription[SubscriptionPlan.AnyPlan](cat, Fixtures.productIds, () => 3 May 2017)(json)
-    val expected: Disjunction[String, V2Subscription[SubscriptionPlan.AnyPlan]] = \/-(
-      V2Subscription[SubscriptionPlan[Product.WeeklyZoneB.type, SingleCharge[Weekly.type, BillingPeriod.SixMonthsRecurring.type]]](
+    val result: Disjunction[String, V2Subscription] =
+      SubscriptionTransform.getSubscription(cat, Fixtures.productIds, () => 3 May 2017)(json)
+    val expected: Disjunction[String, V2Subscription] = \/-(
+      V2Subscription(
         id = Id("2c92c0f85be67835015be8f374217f86"),
         name = Name("A-S00069279"),
         accountId = AccountId("2c92c0f859b047b70159bc8dcc901253"),


### PR DESCRIPTION
following on and branching from https://github.com/guardian/members-data-api/pull/1073

As per the previous PR it's very mechanical but I have self commented on any relevant lines.

---

This removes the type parameters from Subscription and SubscriptionPlan, as well as the type param and implicit from methods such as subscriptionService.get throughout the codebase.

This again loses a bit of compile time checking, and moves it to run time.

This code is moving away from the situation where if the code compiles, it's probably right, to a state where it can be maintained more easily.