### PR TITLE
rename data types to reflect zuora's naming better

### DIFF
--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -8,7 +8,7 @@ import com.gu.memsub.Product.Contribution
 import com.gu.memsub.subsv2.reads.ChargeListReads._
 import com.gu.memsub.subsv2.reads.SubPlanReads
 import com.gu.memsub.subsv2.reads.SubPlanReads._
-import com.gu.memsub.subsv2.{Subscription, SubscriptionPlan}
+import com.gu.memsub.subsv2.{Subscription, RatePlan}
 import com.gu.monitoring.SafeLogger.LogPrefix
 import com.gu.monitoring.SafeLogging
 import com.gu.salesforce.Contact
@@ -306,7 +306,7 @@ class AccountController(
   private def sendSubscriptionCancelledEmail(
       email: String,
       contact: Contact,
-      plan: SubscriptionPlan,
+      plan: RatePlan,
       cancellationEffectiveDate: Option[LocalDate],
   )(implicit logPrefix: LogPrefix) =
     SimpleEitherT

--- a/membership-attribute-service/app/controllers/ExistingPaymentOptionsController.scala
+++ b/membership-attribute-service/app/controllers/ExistingPaymentOptionsController.scala
@@ -10,7 +10,7 @@ import com.gu.memsub._
 import com.gu.memsub.subsv2.reads.ChargeListReads._
 import com.gu.memsub.subsv2.reads.SubPlanReads._
 import com.gu.memsub.subsv2.services.SubscriptionService
-import com.gu.memsub.subsv2.{Subscription, SubscriptionPlan}
+import com.gu.memsub.subsv2.{Subscription, RatePlan}
 import com.gu.monitoring.SafeLogger.LogPrefix
 import com.gu.monitoring.SafeLogging
 import components.TouchpointComponents

--- a/membership-attribute-service/app/controllers/PaymentUpdateController.scala
+++ b/membership-attribute-service/app/controllers/PaymentUpdateController.scala
@@ -2,7 +2,7 @@ package controllers
 
 import actions.{CommonActions, Return401IfNotSignedInRecently}
 import com.gu.memsub
-import com.gu.memsub.subsv2.SubscriptionPlan
+import com.gu.memsub.subsv2.RatePlan
 import com.gu.memsub.{CardUpdateFailure, CardUpdateSuccess, GoCardless, PaymentMethod}
 import com.gu.monitoring.SafeLogger.LogPrefix
 import com.gu.monitoring.SafeLogging
@@ -90,7 +90,7 @@ class PaymentUpdateController(
       emailAddress: String,
       contact: Contact,
       paymentMethod: PaymentType,
-      plan: SubscriptionPlan,
+      plan: RatePlan,
   )(implicit logPrefix: LogPrefix): SimpleEitherT[Unit] =
     SimpleEitherT.rightT(sendEmail.send(paymentMethodChangedEmail(emailAddress, contact, paymentMethod, plan)))
 

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -96,13 +96,13 @@ object AccountDetails {
         case _ => Json.obj()
       }
 
-      def externalisePlanName(plan: SubscriptionPlan): Option[String] = plan.product match {
+      def externalisePlanName(plan: RatePlan): Option[String] = plan.product match {
         case _: Product.Weekly => if (plan.name.contains("Six for Six")) Some("currently on '6 for 6'") else None
         case _: Product.Paper => Some(plan.name.replace("+", " plus Digital Subscription"))
         case _ => None
       }
 
-      def jsonifyPlan(plan: SubscriptionPlan) = Json.obj(
+      def jsonifyPlan(plan: RatePlan) = Json.obj(
         "name" -> externalisePlanName(plan),
         "start" -> plan.start,
         "end" -> plan.end,

--- a/membership-attribute-service/app/models/ExistingPaymentOption.scala
+++ b/membership-attribute-service/app/models/ExistingPaymentOption.scala
@@ -2,7 +2,7 @@ package models
 
 import _root_.services.zuora.rest.ZuoraRestService.ObjectAccount
 import com.gu.memsub._
-import com.gu.memsub.subsv2.{Subscription, SubscriptionPlan}
+import com.gu.memsub.subsv2.{Subscription, RatePlan}
 import com.gu.monitoring.SafeLogging
 import org.joda.time.LocalDate.now
 import play.api.libs.json.Json
@@ -20,7 +20,7 @@ object ExistingPaymentOption {
 
     import existingPaymentOption._
 
-    private def getSubscriptionFriendlyName(plan: SubscriptionPlan): String = plan.product match {
+    private def getSubscriptionFriendlyName(plan: RatePlan): String = plan.product match {
       case _: Product.Weekly => "Guardian Weekly"
       case _: Product.Membership => plan.productName + " Membership"
       case _: Product.Contribution => plan.name

--- a/membership-attribute-service/app/services/GuardianPatronService.scala
+++ b/membership-attribute-service/app/services/GuardianPatronService.scala
@@ -8,7 +8,7 @@ import com.gu.memsub.Product.GuardianPatron
 import com.gu.memsub.Subscription._
 import com.gu.memsub._
 import com.gu.memsub.subsv2.ReaderType.Direct
-import com.gu.memsub.subsv2.{CovariantNonEmptyList, SingleCharge, Subscription, SubscriptionPlan}
+import com.gu.memsub.subsv2.{CovariantNonEmptyList, RatePlanCharge, Subscription, RatePlan}
 import com.gu.monitoring.SafeLogger.LogPrefix
 import com.gu.services.model.PaymentDetails
 import com.gu.services.model.PaymentDetails.PersonalPlan
@@ -86,7 +86,7 @@ class GuardianPatronService(
         promoCode = None,
         isCancelled = subscription.isCancelled,
         plans = CovariantNonEmptyList(
-          SubscriptionPlan(
+          RatePlan(
             id = RatePlanId(guardianPatronProductRatePlanId),
             productRatePlanId = ProductRatePlanId(guardianPatronProductRatePlanId),
             name = subscription.plan.id,
@@ -96,7 +96,7 @@ class GuardianPatronService(
             productType = "Membership",
             product = GuardianPatron,
             features = Nil,
-            charges = SingleCharge(
+            charges = RatePlanCharge(
               benefit = Benefit.GuardianPatron,
               billingPeriod = billingPeriodFromInterval(subscription.plan.interval),
               price = PricingSummary(Map(subscription.plan.currency -> price)),

--- a/membership-attribute-service/app/services/PaymentDetailsForSubscription.scala
+++ b/membership-attribute-service/app/services/PaymentDetailsForSubscription.scala
@@ -1,7 +1,7 @@
 package services
 
 import com.gu.memsub.promo.LogImplicit.LoggableFuture
-import com.gu.memsub.subsv2.{Subscription, SubscriptionPlan}
+import com.gu.memsub.subsv2.{Subscription, RatePlan}
 import com.gu.memsub.{BillingPeriod, Price}
 import com.gu.monitoring.SafeLogger.LogPrefix
 import com.gu.monitoring.SafeLogging

--- a/membership-attribute-service/app/services/mail/Emails.scala
+++ b/membership-attribute-service/app/services/mail/Emails.scala
@@ -2,7 +2,7 @@ package services.mail
 
 import com.gu.i18n.Currency
 import com.gu.memsub.BillingPeriod.RecurringPeriod
-import com.gu.memsub.subsv2.SubscriptionPlan
+import com.gu.memsub.subsv2.RatePlan
 import com.gu.salesforce.Contact
 import org.joda.time.LocalDate
 import org.joda.time.format.DateTimeFormat
@@ -12,7 +12,7 @@ import java.text.DecimalFormat
 object Emails {
   private val dateFormat = DateTimeFormat.forPattern("d MMMM yyyy")
 
-  def paymentMethodChangedEmail(emailAddress: String, contact: Contact, paymentMethod: PaymentType, plan: SubscriptionPlan): EmailData = {
+  def paymentMethodChangedEmail(emailAddress: String, contact: Contact, paymentMethod: PaymentType, plan: RatePlan): EmailData = {
     EmailData(
       emailAddress = emailAddress,
       salesforceContactId = contact.salesforceContactId,
@@ -29,7 +29,7 @@ object Emails {
   def subscriptionCancelledEmail(
       emailAddress: String,
       contact: Contact,
-      plan: SubscriptionPlan,
+      plan: RatePlan,
       cancellationEffectiveDate: Option[LocalDate],
   ): EmailData = {
     EmailData(

--- a/membership-attribute-service/app/services/subscription/CancelSubscription.scala
+++ b/membership-attribute-service/app/services/subscription/CancelSubscription.scala
@@ -2,7 +2,7 @@ package services.subscription
 
 import com.gu.memsub
 import com.gu.memsub.Subscription.Name
-import com.gu.memsub.subsv2.SubscriptionPlan
+import com.gu.memsub.subsv2.RatePlan
 import com.gu.memsub.subsv2.reads.SubPlanReads
 import com.gu.memsub.subsv2.services.SubscriptionService
 import com.gu.monitoring.SafeLogger.LogPrefix

--- a/membership-attribute-service/app/services/zuora/payment/ZuoraPaymentService.scala
+++ b/membership-attribute-service/app/services/zuora/payment/ZuoraPaymentService.scala
@@ -3,7 +3,7 @@ package services.zuora.payment
 import com.gu.memsub.BillingSchedule.Bill
 import com.gu.memsub.Subscription._
 import com.gu.memsub.promo.LogImplicit._
-import com.gu.memsub.subsv2.{Subscription, SubscriptionPlan}
+import com.gu.memsub.subsv2.{Subscription, RatePlan}
 import com.gu.memsub.{BillingSchedule, Subscription => _, _}
 import com.gu.monitoring.SafeLogger.LogPrefix
 import com.gu.monitoring.SafeLogging

--- a/membership-attribute-service/test/acceptance/AccountControllerAcceptanceTest.scala
+++ b/membership-attribute-service/test/acceptance/AccountControllerAcceptanceTest.scala
@@ -6,7 +6,7 @@ import com.gu.i18n.Currency
 import com.gu.memsub.Product.Contribution
 import com.gu.memsub.Subscription.Name
 import com.gu.memsub.subsv2.services.{CatalogService, SubscriptionService}
-import com.gu.memsub.subsv2.{CovariantNonEmptyList, SubscriptionPlan}
+import com.gu.memsub.subsv2.{CovariantNonEmptyList, RatePlan}
 import com.gu.memsub.{Product, Subscription}
 import com.gu.monitoring.SafeLogger.LogPrefix
 import com.gu.zuora.ZuoraSoapService

--- a/membership-attribute-service/test/acceptance/PaymentUpdateControllerAcceptanceTest.scala
+++ b/membership-attribute-service/test/acceptance/PaymentUpdateControllerAcceptanceTest.scala
@@ -6,7 +6,7 @@ import acceptance.data.stripe.{TestStripeCard, TestStripeCustomer}
 import com.gu.i18n.Country
 import com.gu.memsub.Subscription
 import com.gu.memsub.subsv2.services.{CatalogService, SubscriptionService}
-import com.gu.memsub.subsv2.{CovariantNonEmptyList, SubscriptionPlan}
+import com.gu.memsub.subsv2.{CovariantNonEmptyList, RatePlan}
 import com.gu.zuora.ZuoraSoapService
 import com.gu.zuora.api.{GoCardlessZuoraInstance, PaymentGateway}
 import com.gu.zuora.soap.models.Commands.{BankTransfer, CreatePaymentMethod}

--- a/membership-attribute-service/test/acceptance/data/TestCatalog.scala
+++ b/membership-attribute-service/test/acceptance/data/TestCatalog.scala
@@ -14,7 +14,7 @@ import scalaz.NonEmptyList
 object TestCatalogPlan {
   def randomPlanId(): ProductRatePlanId = ProductRatePlanId(randomId("productRatePlanId"))
 
-  def apply[P <: Product, C <: ChargeList, S <: Status](
+  def apply[P <: Product, C <: RatePlanChargeList, S <: Status](
       product: P,
       name: String,
       charges: C,
@@ -22,8 +22,8 @@ object TestCatalogPlan {
       id: ProductRatePlanId = randomPlanId(),
       description: String = "",
       saving: Option[Int] = None,
-  ): CatalogPlan[P, C, S] =
-    CatalogPlan[P, C, S](id, product, name, description, saving, charges, status)
+  ): ProductRatePlan[P, C, S] =
+    ProductRatePlan[P, C, S](id, product, name, description, saving, charges, status)
 
   def paid[P <: Product, B <: Benefit, BP <: BillingPeriod](
       product: P,
@@ -31,8 +31,8 @@ object TestCatalogPlan {
       billingPeriod: BP,
       name: String,
       amount: Double,
-  ): CatalogPlan[P, SingleCharge[B, BP], Current] =
-    TestCatalogPlan[P, SingleCharge[B, BP], Current](
+  ): ProductRatePlan[P, RatePlanCharge[B, BP], Current] =
+    TestCatalogPlan[P, RatePlanCharge[B, BP], Current](
       product = product,
       name = name + "Paid",
       charges = TestSingleCharge[B, BP](benefit, billingPeriod, TestPricingSummary.gbp(amount)),
@@ -44,7 +44,7 @@ object TestCatalogPlan {
       benefit: B,
       name: String,
       amount: Double,
-  ): CatalogPlan[P, SingleCharge[B, Month.type], Current] =
+  ): ProductRatePlan[P, RatePlanCharge[B, Month.type], Current] =
     paid(product, benefit, Month, name + "Monthly", amount)
 
   def sixWeeksPaid[P <: Product, B <: Benefit](
@@ -52,7 +52,7 @@ object TestCatalogPlan {
       benefit: B,
       name: String,
       amount: Double,
-  ): CatalogPlan[P, SingleCharge[B, SixWeeks.type], Current] =
+  ): ProductRatePlan[P, RatePlanCharge[B, SixWeeks.type], Current] =
     paid(product, benefit, SixWeeks, name + "SixWeeks", amount)
 
   def quarterlyPaid[P <: Product, B <: Benefit](
@@ -60,7 +60,7 @@ object TestCatalogPlan {
       benefit: B,
       name: String,
       amount: Double,
-  ): CatalogPlan[P, SingleCharge[B, Quarter.type], Current] =
+  ): ProductRatePlan[P, RatePlanCharge[B, Quarter.type], Current] =
     paid(product, benefit, Quarter, name + "Quarterly", amount)
 
   def yearlyPaid[P <: Product, B <: Benefit](
@@ -68,7 +68,7 @@ object TestCatalogPlan {
       benefit: B,
       name: String,
       amount: Double,
-  ): CatalogPlan[P, SingleCharge[B, Year.type], Current] =
+  ): ProductRatePlan[P, RatePlanCharge[B, Year.type], Current] =
     paid(product, benefit, Year, name + "Yearly", amount)
 
   def threeMonthsPaid[P <: Product, B <: Benefit](
@@ -76,7 +76,7 @@ object TestCatalogPlan {
       benefit: B,
       name: String,
       amount: Double,
-  ): CatalogPlan[P, SingleCharge[B, ThreeMonths.type], Current] =
+  ): ProductRatePlan[P, RatePlanCharge[B, ThreeMonths.type], Current] =
     paid(product, benefit, ThreeMonths, name + "ThreeMonths", amount)
 
   def oneYearPaid[P <: Product, B <: Benefit](
@@ -84,10 +84,10 @@ object TestCatalogPlan {
       benefit: B,
       name: String,
       amount: Double,
-  ): CatalogPlan[P, SingleCharge[B, OneYear.type], Current] =
+  ): ProductRatePlan[P, RatePlanCharge[B, OneYear.type], Current] =
     paid(product, benefit, OneYear, name + "OneYear", amount)
 
-  def paperCharges[P <: Product, BP <: BillingPeriod](product: P, name: String): CatalogPlan[P, PaperCharges, Current] =
+  def paperCharges[P <: Product, BP <: BillingPeriod](product: P, name: String): ProductRatePlan[P, PaperCharges, Current] =
     TestCatalogPlan[P, PaperCharges, Current](
       product = product,
       name = name + "PaperCharges",
@@ -192,10 +192,10 @@ object TestCatalog {
       patron: MembershipPlans[Patron.type] = testPaidMembershipPlans(Patron),
       digipack: DigipackPlans = testDigipackPlans(),
       supporterPlus: SupporterPlusPlans = testSupporterPlusPlans(),
-      contributor: CatalogPlan.Contributor = monthlyPaid(Product.Contribution, Benefit.Contributor, "Contributor", 12),
-      voucher: NonEmptyList[CatalogPlan.Voucher] = NonEmptyList(paperCharges(Product.Voucher, "Voucher")),
-      digitalVoucher: NonEmptyList[CatalogPlan.DigitalVoucher] = NonEmptyList(paperCharges(Product.DigitalVoucher, "DigitalVoucher")),
-      delivery: NonEmptyList[CatalogPlan.Delivery] = NonEmptyList(paperCharges(Product.Delivery, "Delivery")),
+      contributor: ProductRatePlan.Contributor = monthlyPaid(Product.Contribution, Benefit.Contributor, "Contributor", 12),
+      voucher: NonEmptyList[ProductRatePlan.Voucher] = NonEmptyList(paperCharges(Product.Voucher, "Voucher")),
+      digitalVoucher: NonEmptyList[ProductRatePlan.DigitalVoucher] = NonEmptyList(paperCharges(Product.DigitalVoucher, "DigitalVoucher")),
+      delivery: NonEmptyList[ProductRatePlan.Delivery] = NonEmptyList(paperCharges(Product.Delivery, "Delivery")),
       weekly: WeeklyPlans = weeklyPlans(),
       map: Map[ProductRatePlanId, CatalogZuoraPlan] = Map.empty,
   ): Catalog = Catalog(

--- a/membership-attribute-service/test/acceptance/data/TestPaidSubscriptionPlan.scala
+++ b/membership-attribute-service/test/acceptance/data/TestPaidSubscriptionPlan.scala
@@ -4,7 +4,7 @@ import acceptance.data.Randoms.randomId
 import com.gu.memsub.Product
 import com.gu.memsub.Product.Membership
 import com.gu.memsub.Subscription.{Feature, ProductRatePlanId, RatePlanId}
-import com.gu.memsub.subsv2.{ChargeList, SubscriptionPlan}
+import com.gu.memsub.subsv2.{RatePlanChargeList, RatePlan}
 import org.joda.time.LocalDate
 
 object TestPaidSubscriptionPlan {
@@ -18,11 +18,11 @@ object TestPaidSubscriptionPlan {
       productType: String = randomId("paidSubscriptionPlanProductType"),
       product: Product = Membership,
       features: List[Feature] = Nil,
-      charges: ChargeList = TestSingleCharge(),
+      charges: RatePlanChargeList = TestSingleCharge(),
       chargedThrough: Option[LocalDate] = None, // this is None if the sub hasn't been billed yet (on a free trial)
       start: LocalDate = LocalDate.now().minusDays(13),
       end: LocalDate = LocalDate.now().minusDays(13).plusYears(1),
-  ): SubscriptionPlan = SubscriptionPlan(
+  ): RatePlan = RatePlan(
     id: RatePlanId,
     productRatePlanId,
     name,

--- a/membership-attribute-service/test/acceptance/data/TestSingleCharge.scala
+++ b/membership-attribute-service/test/acceptance/data/TestSingleCharge.scala
@@ -3,7 +3,7 @@ package acceptance.data
 import acceptance.data.Randoms.randomId
 import com.gu.memsub.BillingPeriod.Year
 import com.gu.memsub.Subscription.{ProductRatePlanChargeId, SubscriptionRatePlanChargeId}
-import com.gu.memsub.subsv2.SingleCharge
+import com.gu.memsub.subsv2.RatePlanCharge
 import com.gu.memsub.{Benefit, BillingPeriod, PricingSummary}
 
 object TestSingleCharge {
@@ -13,7 +13,7 @@ object TestSingleCharge {
       price: PricingSummary = TestPricingSummary(),
       chargeId: ProductRatePlanChargeId = randomProductRatePlanChargeId(),
       subRatePlanChargeId: SubscriptionRatePlanChargeId = SubscriptionRatePlanChargeId(randomId("subscriptionRatePlanChargeId")),
-  ): SingleCharge[B, BP] = SingleCharge[B, BP](benefit, billingPeriod, price, chargeId, subRatePlanChargeId)
+  ): RatePlanCharge[B, BP] = RatePlanCharge[B, BP](benefit, billingPeriod, price, chargeId, subRatePlanChargeId)
 
   def randomProductRatePlanChargeId(): ProductRatePlanChargeId = ProductRatePlanChargeId(randomId("productRatePlanChargeId"))
 }

--- a/membership-attribute-service/test/acceptance/data/TestSubscription.scala
+++ b/membership-attribute-service/test/acceptance/data/TestSubscription.scala
@@ -3,7 +3,7 @@ package acceptance.data
 import acceptance.data.Randoms.randomId
 import com.gu.memsub
 import com.gu.memsub.promo.PromoCode
-import com.gu.memsub.subsv2.{CovariantNonEmptyList, ReaderType, Subscription, SubscriptionPlan}
+import com.gu.memsub.subsv2.{CovariantNonEmptyList, ReaderType, Subscription, RatePlan}
 import org.joda.time.{DateTime, LocalDate}
 
 object TestSubscription {
@@ -18,7 +18,7 @@ object TestSubscription {
       casActivationDate: Option[DateTime] = None,
       promoCode: Option[PromoCode] = None,
       isCancelled: Boolean = false,
-      plans: CovariantNonEmptyList[SubscriptionPlan] = CovariantNonEmptyList(TestPaidSubscriptionPlan(), Nil),
+      plans: CovariantNonEmptyList[RatePlan] = CovariantNonEmptyList(TestPaidSubscriptionPlan(), Nil),
       readerType: ReaderType = ReaderType.Direct,
       gifteeIdentityId: Option[String] = None,
       autoRenew: Boolean = false,

--- a/membership-attribute-service/test/services/PaymentDetailsForSubscriptionTest.scala
+++ b/membership-attribute-service/test/services/PaymentDetailsForSubscriptionTest.scala
@@ -3,7 +3,7 @@ package services
 import acceptance.data.Randoms.randomId
 import acceptance.data.TestContact
 import com.gu.i18n.Currency.GBP
-import com.gu.memsub.subsv2.{Subscription, SubscriptionPlan}
+import com.gu.memsub.subsv2.{Subscription, RatePlan}
 import com.gu.memsub.{BillingPeriod, Price}
 import com.gu.services.model.PaymentDetails
 import com.gu.services.model.PaymentDetails.PersonalPlan

--- a/membership-attribute-service/test/testdata/SubscriptionTestData.scala
+++ b/membership-attribute-service/test/testdata/SubscriptionTestData.scala
@@ -15,8 +15,8 @@ trait SubscriptionTestData {
 
   def referenceDate: LocalDate
 
-  def supporterPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan =
-    SubscriptionPlan(
+  def supporterPlan(startDate: LocalDate, endDate: LocalDate): RatePlan =
+    RatePlan(
       RatePlanId("idSupporter"),
       ProductRatePlanId("prpi"),
       "Supporter",
@@ -26,7 +26,7 @@ trait SubscriptionTestData {
       "Membership",
       Product.Membership,
       List.empty,
-      SingleCharge(
+      RatePlanCharge(
         Supporter,
         BillingPeriod.Year,
         PricingSummary(Map(GBP -> Price(49.0f, GBP))),
@@ -37,8 +37,8 @@ trait SubscriptionTestData {
       startDate,
       endDate,
     )
-  def digipackPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan =
-    SubscriptionPlan(
+  def digipackPlan(startDate: LocalDate, endDate: LocalDate): RatePlan =
+    RatePlan(
       RatePlanId("idDigipack"),
       ProductRatePlanId("prpi"),
       "Digipack",
@@ -48,7 +48,7 @@ trait SubscriptionTestData {
       "Digital Pack",
       Product.Digipack,
       List.empty,
-      SingleCharge(
+      RatePlanCharge(
         Digipack,
         BillingPeriod.Year,
         PricingSummary(Map(GBP -> Price(119.90f, GBP))),
@@ -59,7 +59,7 @@ trait SubscriptionTestData {
       startDate,
       endDate,
     )
-  def paperPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan = SubscriptionPlan(
+  def paperPlan(startDate: LocalDate, endDate: LocalDate): RatePlan = RatePlan(
     RatePlanId("idPaperPlan"),
     ProductRatePlanId("prpi"),
     "Sunday",
@@ -74,7 +74,7 @@ trait SubscriptionTestData {
     startDate,
     endDate,
   )
-  def paperPlusPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan = SubscriptionPlan(
+  def paperPlusPlan(startDate: LocalDate, endDate: LocalDate): RatePlan = RatePlan(
     RatePlanId("idPaperPlusPlan"),
     ProductRatePlanId("prpi"),
     "Sunday+",
@@ -89,8 +89,8 @@ trait SubscriptionTestData {
     startDate,
     endDate,
   )
-  def contributorPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan =
-    SubscriptionPlan(
+  def contributorPlan(startDate: LocalDate, endDate: LocalDate): RatePlan =
+    RatePlan(
       RatePlanId("idContributor"),
       ProductRatePlanId("prpi"),
       "Monthly Contribution",
@@ -100,7 +100,7 @@ trait SubscriptionTestData {
       "Contribution",
       Product.Contribution,
       List.empty,
-      SingleCharge(
+      RatePlanCharge(
         Contributor,
         BillingPeriod.Month,
         PricingSummary(Map(GBP -> Price(5.0f, GBP))),
@@ -111,8 +111,8 @@ trait SubscriptionTestData {
       startDate,
       endDate,
     )
-  def guardianWeeklyPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan =
-    SubscriptionPlan(
+  def guardianWeeklyPlan(startDate: LocalDate, endDate: LocalDate): RatePlan =
+    RatePlan(
       RatePlanId("idGuardianWeeklyPlan"),
       ProductRatePlanId("prpi"),
       "Guardian Weekly",
@@ -122,7 +122,7 @@ trait SubscriptionTestData {
       "Guardian Weekly",
       Product.WeeklyDomestic,
       List.empty,
-      SingleCharge(
+      RatePlanCharge(
         Weekly,
         BillingPeriod.Quarter,
         PricingSummary(Map(GBP -> Price(37.50f, GBP))),
@@ -134,8 +134,8 @@ trait SubscriptionTestData {
       endDate,
     )
 
-  def supporterPlusPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan =
-    SubscriptionPlan(
+  def supporterPlusPlan(startDate: LocalDate, endDate: LocalDate): RatePlan =
+    RatePlan(
       RatePlanId("idSupporterPlusPlan"),
       ProductRatePlanId("prpi"),
       "Supporter Plus",
@@ -145,7 +145,7 @@ trait SubscriptionTestData {
       "Supporter Plus",
       Product.SupporterPlus,
       List.empty,
-      SingleCharge(
+      RatePlanCharge(
         Benefit.SupporterPlus,
         BillingPeriod.Month,
         PricingSummary(Map(GBP -> Price(10.0f, GBP))),
@@ -157,7 +157,7 @@ trait SubscriptionTestData {
       endDate,
     )
 
-  def toSubscription(isCancelled: Boolean)(plans: NonEmptyList[SubscriptionPlan]): Subscription = {
+  def toSubscription(isCancelled: Boolean)(plans: NonEmptyList[RatePlan]): Subscription = {
     Subscription(
       id = Id(plans.head.id.get),
       name = Name("AS-123123"),

--- a/membership-common/src/main/scala/com/gu/memsub/subsv2/Plan.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/subsv2/Plan.scala
@@ -225,87 +225,86 @@ object FrontendId {
 
 }
 
-object CatalogPlan {
+object ProductRatePlan {
 
-  type Supporter[+B <: BillingPeriod] = CatalogPlan[Product.Membership, SingleCharge[Supporter.type, B], Current]
-  type Partner[+B <: BillingPeriod] = CatalogPlan[Product.Membership, SingleCharge[Partner.type, B], Current]
-  type Patron[+B <: BillingPeriod] = CatalogPlan[Product.Membership, SingleCharge[Patron.type, B], Current]
+  type Supporter[+B <: BillingPeriod] = ProductRatePlan[Product.Membership, RatePlanCharge[Supporter.type, B], Current]
+  type Partner[+B <: BillingPeriod] = ProductRatePlan[Product.Membership, RatePlanCharge[Partner.type, B], Current]
+  type Patron[+B <: BillingPeriod] = ProductRatePlan[Product.Membership, RatePlanCharge[Patron.type, B], Current]
 
-  type Contributor = CatalogPlan[Product.Contribution, SingleCharge[Contributor.type, Month.type], Current]
+  type Contributor = ProductRatePlan[Product.Contribution, RatePlanCharge[Contributor.type, Month.type], Current]
 
-  type Digipack[+B <: BillingPeriod] = CatalogPlan[Product.ZDigipack, SingleCharge[Digipack.type, B], Current]
-  type SupporterPlus[+B <: BillingPeriod] = CatalogPlan[Product.SupporterPlus, SupporterPlusCharges, Current]
-  type Delivery = CatalogPlan[Product.Delivery, PaperCharges, Current]
-  type Voucher = CatalogPlan[Product.Voucher, PaperCharges, Current]
-  type DigitalVoucher = CatalogPlan[Product.DigitalVoucher, PaperCharges, Current]
-  type AnyPlan = CatalogPlan[Product, ChargeList, Current]
+  type Digipack[+B <: BillingPeriod] = ProductRatePlan[Product.ZDigipack, RatePlanCharge[Digipack.type, B], Current]
+  type SupporterPlus[+B <: BillingPeriod] = ProductRatePlan[Product.SupporterPlus, SupporterPlusCharges, Current]
+  type Delivery = ProductRatePlan[Product.Delivery, PaperCharges, Current]
+  type Voucher = ProductRatePlan[Product.Voucher, PaperCharges, Current]
+  type DigitalVoucher = ProductRatePlan[Product.DigitalVoucher, PaperCharges, Current]
 
-  type WeeklyZoneA[+B <: BillingPeriod] = CatalogPlan[Product.WeeklyZoneA, SingleCharge[Weekly.type, B], Current]
-  type WeeklyZoneB[+B <: BillingPeriod] = CatalogPlan[Product.WeeklyZoneB, SingleCharge[Weekly.type, B], Current]
-  type WeeklyZoneC[+B <: BillingPeriod] = CatalogPlan[Product.WeeklyZoneC, SingleCharge[Weekly.type, B], Current]
-  type WeeklyDomestic[+B <: BillingPeriod] = CatalogPlan[Product.WeeklyDomestic, SingleCharge[Weekly.type, B], Current]
-  type WeeklyRestOfWorld[+B <: BillingPeriod] = CatalogPlan[Product.WeeklyRestOfWorld, SingleCharge[Weekly.type, B], Current]
+  type WeeklyZoneA[+B <: BillingPeriod] = ProductRatePlan[Product.WeeklyZoneA, RatePlanCharge[Weekly.type, B], Current]
+  type WeeklyZoneB[+B <: BillingPeriod] = ProductRatePlan[Product.WeeklyZoneB, RatePlanCharge[Weekly.type, B], Current]
+  type WeeklyZoneC[+B <: BillingPeriod] = ProductRatePlan[Product.WeeklyZoneC, RatePlanCharge[Weekly.type, B], Current]
+  type WeeklyDomestic[+B <: BillingPeriod] = ProductRatePlan[Product.WeeklyDomestic, RatePlanCharge[Weekly.type, B], Current]
+  type WeeklyRestOfWorld[+B <: BillingPeriod] = ProductRatePlan[Product.WeeklyRestOfWorld, RatePlanCharge[Weekly.type, B], Current]
 
-  type Paper = CatalogPlan[Product.Paper, ChargeList, Current]
-  type ContentSubscription = CatalogPlan[Product.ContentSubscription, ChargeList, Current]
+  type Paper = ProductRatePlan[Product.Paper, RatePlanChargeList, Current]
+  type ContentSubscription = ProductRatePlan[Product.ContentSubscription, RatePlanChargeList, Current]
 
 }
 
 case class PlansWithIntroductory[+B](plans: List[B], associations: List[(B, B)])
 
 case class MembershipPlans[+B <: Benefit](
-    month: CatalogPlan[Product.Membership, SingleCharge[B, Month.type], Current],
-    year: CatalogPlan[Product.Membership, SingleCharge[B, Year.type], Current],
+    month: ProductRatePlan[Product.Membership, RatePlanCharge[B, Month.type], Current],
+    year: ProductRatePlan[Product.Membership, RatePlanCharge[B, Year.type], Current],
 ) {
   lazy val plans = List(month, year)
 }
 
 case class DigipackPlans(
-    month: CatalogPlan.Digipack[Month.type],
-    quarter: CatalogPlan.Digipack[Quarter.type],
-    year: CatalogPlan.Digipack[Year.type],
+    month: ProductRatePlan.Digipack[Month.type],
+    quarter: ProductRatePlan.Digipack[Quarter.type],
+    year: ProductRatePlan.Digipack[Year.type],
 ) {
   lazy val plans = List(month, quarter, year)
 }
 
-case class SupporterPlusPlans(month: CatalogPlan.SupporterPlus[Month.type], year: CatalogPlan.SupporterPlus[Year.type]) {
+case class SupporterPlusPlans(month: ProductRatePlan.SupporterPlus[Month.type], year: ProductRatePlan.SupporterPlus[Year.type]) {
   lazy val plans = List(month, year)
 }
 
 case class WeeklyZoneBPlans(
-    quarter: CatalogPlan.WeeklyZoneB[Quarter.type],
-    year: CatalogPlan.WeeklyZoneB[Year.type],
-    oneYear: CatalogPlan.WeeklyZoneB[OneYear.type],
+    quarter: ProductRatePlan.WeeklyZoneB[Quarter.type],
+    year: ProductRatePlan.WeeklyZoneB[Year.type],
+    oneYear: ProductRatePlan.WeeklyZoneB[OneYear.type],
 ) {
   lazy val plans = List(quarter, year, oneYear)
   val plansWithAssociations = PlansWithIntroductory(plans, List.empty)
 }
 case class WeeklyZoneAPlans(
-    sixWeeks: CatalogPlan.WeeklyZoneA[SixWeeks.type],
-    quarter: CatalogPlan.WeeklyZoneA[Quarter.type],
-    year: CatalogPlan.WeeklyZoneA[Year.type],
-    oneYear: CatalogPlan.WeeklyZoneA[OneYear.type],
+    sixWeeks: ProductRatePlan.WeeklyZoneA[SixWeeks.type],
+    quarter: ProductRatePlan.WeeklyZoneA[Quarter.type],
+    year: ProductRatePlan.WeeklyZoneA[Year.type],
+    oneYear: ProductRatePlan.WeeklyZoneA[OneYear.type],
 ) {
   val plans = List(sixWeeks, quarter, year, oneYear)
   val associations = List(sixWeeks -> quarter)
   val plansWithAssociations = PlansWithIntroductory(plans, associations)
 }
 case class WeeklyZoneCPlans(
-    sixWeeks: CatalogPlan.WeeklyZoneC[SixWeeks.type],
-    quarter: CatalogPlan.WeeklyZoneC[Quarter.type],
-    year: CatalogPlan.WeeklyZoneC[Year.type],
+    sixWeeks: ProductRatePlan.WeeklyZoneC[SixWeeks.type],
+    quarter: ProductRatePlan.WeeklyZoneC[Quarter.type],
+    year: ProductRatePlan.WeeklyZoneC[Year.type],
 ) {
   lazy val plans = List(sixWeeks, quarter, year)
   val associations = List(sixWeeks -> quarter)
   val plansWithAssociations = PlansWithIntroductory(plans, associations)
 }
 case class WeeklyDomesticPlans(
-    sixWeeks: CatalogPlan.WeeklyDomestic[SixWeeks.type],
-    quarter: CatalogPlan.WeeklyDomestic[Quarter.type],
-    year: CatalogPlan.WeeklyDomestic[Year.type],
-    month: CatalogPlan.WeeklyDomestic[Month.type],
-    oneYear: CatalogPlan.WeeklyDomestic[OneYear.type],
-    threeMonths: CatalogPlan.WeeklyDomestic[ThreeMonths.type],
+    sixWeeks: ProductRatePlan.WeeklyDomestic[SixWeeks.type],
+    quarter: ProductRatePlan.WeeklyDomestic[Quarter.type],
+    year: ProductRatePlan.WeeklyDomestic[Year.type],
+    month: ProductRatePlan.WeeklyDomestic[Month.type],
+    oneYear: ProductRatePlan.WeeklyDomestic[OneYear.type],
+    threeMonths: ProductRatePlan.WeeklyDomestic[ThreeMonths.type],
 ) {
   lazy val plans = List(sixWeeks, quarter, year, month, oneYear, threeMonths)
   val associations = List(sixWeeks -> quarter)
@@ -313,12 +312,12 @@ case class WeeklyDomesticPlans(
 }
 
 case class WeeklyRestOfWorldPlans(
-    sixWeeks: CatalogPlan.WeeklyRestOfWorld[SixWeeks.type],
-    quarter: CatalogPlan.WeeklyRestOfWorld[Quarter.type],
-    year: CatalogPlan.WeeklyRestOfWorld[Year.type],
-    month: CatalogPlan.WeeklyRestOfWorld[Month.type],
-    oneYear: CatalogPlan.WeeklyRestOfWorld[OneYear.type],
-    threeMonths: CatalogPlan.WeeklyRestOfWorld[ThreeMonths.type],
+    sixWeeks: ProductRatePlan.WeeklyRestOfWorld[SixWeeks.type],
+    quarter: ProductRatePlan.WeeklyRestOfWorld[Quarter.type],
+    year: ProductRatePlan.WeeklyRestOfWorld[Year.type],
+    month: ProductRatePlan.WeeklyRestOfWorld[Month.type],
+    oneYear: ProductRatePlan.WeeklyRestOfWorld[OneYear.type],
+    threeMonths: ProductRatePlan.WeeklyRestOfWorld[ThreeMonths.type],
 ) {
   lazy val plans = List(sixWeeks, quarter, year, month, oneYear, threeMonths)
   val associations = List(sixWeeks -> quarter)
@@ -341,10 +340,10 @@ case class Catalog(
     patron: MembershipPlans[Patron.type],
     digipack: DigipackPlans,
     supporterPlus: SupporterPlusPlans,
-    contributor: CatalogPlan.Contributor,
-    voucher: NonEmptyList[CatalogPlan.Voucher],
-    digitalVoucher: NonEmptyList[CatalogPlan.DigitalVoucher],
-    delivery: NonEmptyList[CatalogPlan.Delivery],
+    contributor: ProductRatePlan.Contributor,
+    voucher: NonEmptyList[ProductRatePlan.Voucher],
+    digitalVoucher: NonEmptyList[ProductRatePlan.DigitalVoucher],
+    delivery: NonEmptyList[ProductRatePlan.Delivery],
     weekly: WeeklyPlans,
     map: Map[ProductRatePlanId, CatalogZuoraPlan],
 ) {
@@ -355,7 +354,7 @@ case class Catalog(
 
 /** A higher level representation of a number of Zuora rate plan charges
   */
-sealed trait ChargeList {
+sealed trait RatePlanChargeList {
   def benefits: NonEmptyList[Benefit]
   def gbpPrice = price.getPrice(GBP).getOrElse(throw new Exception("No GBP price"))
   def currencies = price.currencies
@@ -366,20 +365,20 @@ sealed trait ChargeList {
 
 /** Same as above but we must have exactly one charge, giving us exactly one benefit This is used for supporter, partner, patron and digital pack subs
   */
-case class SingleCharge[+B <: Benefit, +BP <: BillingPeriod](
+case class RatePlanCharge[+B <: Benefit, +BP <: BillingPeriod](
     benefit: B,
     billingPeriod: BP,
     price: PricingSummary,
     chargeId: ProductRatePlanChargeId,
     subRatePlanChargeId: SubscriptionRatePlanChargeId,
-) extends ChargeList {
+) extends RatePlanChargeList {
   def benefits = NonEmptyList(benefit)
 }
 
 /** Paper plans will have lots of rate plan charges, but the general structure of them is that they'll give you the paper on a bunch of days, and if
   * you're on a plus plan you'll have a digipack
   */
-case class PaperCharges(dayPrices: Map[PaperDay, PricingSummary], digipack: Option[PricingSummary]) extends ChargeList {
+case class PaperCharges(dayPrices: Map[PaperDay, PricingSummary], digipack: Option[PricingSummary]) extends RatePlanChargeList {
   def benefits = NonEmptyList.fromSeq[Benefit](dayPrices.keys.head, dayPrices.keys.tail.toSeq ++ digipack.map(_ => Digipack))
   def price: PricingSummary = (dayPrices.values.toSeq ++ digipack.toSeq).reduce(_ |+| _)
   override def billingPeriod: BillingPeriod = BillingPeriod.Month
@@ -389,14 +388,14 @@ case class PaperCharges(dayPrices: Map[PaperDay, PricingSummary], digipack: Opti
 
 /** Supporter Plus V2 has two rate plan charges, one for the subscription element and one for the additional contribution.
   */
-case class SupporterPlusCharges(billingPeriod: BillingPeriod, pricingSummaries: List[PricingSummary]) extends ChargeList {
+case class SupporterPlusCharges(billingPeriod: BillingPeriod, pricingSummaries: List[PricingSummary]) extends RatePlanChargeList {
 
   val subRatePlanChargeId = SubscriptionRatePlanChargeId("")
   override def price: PricingSummary = pricingSummaries.reduce(_ |+| _)
   override def benefits: NonEmptyList[Benefit] = NonEmptyList(SupporterPlus)
 }
 
-case class SubscriptionPlan(
+case class RatePlan(
     id: RatePlanId,
     productRatePlanId: ProductRatePlanId,
     name: String,
@@ -406,7 +405,7 @@ case class SubscriptionPlan(
     productType: String,
     product: Product,
     features: List[SubsFeature],
-    charges: ChargeList,
+    charges: RatePlanChargeList,
     chargedThrough: Option[
       LocalDate,
     ], // this is None if the sub hasn't been billed yet (on a free trial) or if you have been billed it is the date at which you'll next be billed
@@ -414,7 +413,7 @@ case class SubscriptionPlan(
     end: LocalDate,
 )
 
-case class CatalogPlan[+P <: Product, +C <: ChargeList, +S <: Status](
+case class ProductRatePlan[+P <: Product, +C <: RatePlanChargeList, +S <: Status](
     id: ProductRatePlanId,
     product: P,
     name: String,

--- a/membership-common/src/main/scala/com/gu/memsub/subsv2/reads/CatPlanReads.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/subsv2/reads/CatPlanReads.scala
@@ -50,14 +50,14 @@ object CatPlanReads {
       (c.status == Status.current).option(Status.current).toSuccess(s"Needed current, got ${c.status}".wrapNel)
   }
 
-  implicit def planReads[P <: Product: CatPlanReads, C <: ChargeList: ChargeListReads, S <: Status: CatPlanReads]
-      : CatPlanReads[CatalogPlan[P, C, S]] =
-    new CatPlanReads[CatalogPlan[P, C, S]] {
-      override def read(p: ProductIds, c: CatalogZuoraPlan): ValidationNel[String, CatalogPlan[P, C, S]] =
+  implicit def planReads[P <: Product: CatPlanReads, C <: RatePlanChargeList: ChargeListReads, S <: Status: CatPlanReads]
+      : CatPlanReads[ProductRatePlan[P, C, S]] =
+    new CatPlanReads[ProductRatePlan[P, C, S]] {
+      override def read(p: ProductIds, c: CatalogZuoraPlan): ValidationNel[String, ProductRatePlan[P, C, S]] =
         (implicitly[ChargeListReads[C]].read(c.benefits, c.charges) |@|
           implicitly[CatPlanReads[P]].read(p, c) |@|
           implicitly[CatPlanReads[S]].read(p, c)) { case (charges, product, s) =>
-          CatalogPlan(c.id, product, c.name, c.description, Try(c.saving.get.toInt).toOption, charges, s)
+          ProductRatePlan(c.id, product, c.name, c.description, Try(c.saving.get.toInt).toOption, charges, s)
         }
     }
 }

--- a/membership-common/src/main/scala/com/gu/memsub/subsv2/reads/SubJsonReads.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/subsv2/reads/SubJsonReads.scala
@@ -79,7 +79,7 @@ object SubJsonReads {
     }
   }
 
-  implicit val subZuoraPlanListReads: Reads[List[SubscriptionZuoraPlan]] = new Reads[List[SubscriptionZuoraPlan]] {
+  val subZuoraPlanListReads: Reads[List[SubscriptionZuoraPlan]] = new Reads[List[SubscriptionZuoraPlan]] {
     override def reads(json: JsValue): JsResult[List[SubscriptionZuoraPlan]] = {
       (json \ "ratePlans").validate[List[SubscriptionZuoraPlan]](niceListReads(commonZuoraPlanReads))
     }
@@ -95,8 +95,8 @@ object SubJsonReads {
   private val lenientDateTimeReader: Reads[DateTime] =
     JodaReads.DefaultJodaDateTimeReads orElse Reads.IsoDateReads.map(new DateTime(_))
 
-  val subscriptionReads: Reads[NonEmptyList[SubscriptionPlan] => Subscription] = new Reads[NonEmptyList[SubscriptionPlan] => Subscription] {
-    override def reads(json: JsValue): JsResult[NonEmptyList[SubscriptionPlan] => Subscription] = {
+  val subscriptionReads: Reads[NonEmptyList[RatePlan] => Subscription] = new Reads[NonEmptyList[RatePlan] => Subscription] {
+    override def reads(json: JsValue): JsResult[NonEmptyList[RatePlan] => Subscription] = {
 
       json match {
         case o: JsObject =>

--- a/membership-common/src/main/scala/com/gu/memsub/subsv2/reads/SubPlanReads.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/subsv2/reads/SubPlanReads.scala
@@ -12,7 +12,7 @@ object SubPlanReads {
       ids: ProductIds,
       subZuoraPlan: SubscriptionZuoraPlan,
       catZuoraPlan: CatalogZuoraPlan,
-  ): ValidationNel[String, SubscriptionPlan] =
+  ): ValidationNel[String, RatePlan] =
     (for {
       charges <- readChargeList.read(catZuoraPlan.benefits, subZuoraPlan.charges.list.toList)
       product <- ids.productMap
@@ -20,7 +20,7 @@ object SubPlanReads {
         .toSuccessNel(s"couldn't read a product as the product id is ${catZuoraPlan.productId} but we need one of $ids")
     } yield {
       val highLevelFeatures = subZuoraPlan.features.map(com.gu.memsub.Subscription.Feature.fromRest)
-      SubscriptionPlan(
+      RatePlan(
         subZuoraPlan.id,
         catZuoraPlan.id,
         catZuoraPlan.name,

--- a/membership-common/src/main/scala/com/gu/memsub/subsv2/services/CatalogService.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/subsv2/services/CatalogService.scala
@@ -7,12 +7,12 @@ import com.gu.memsub.Benefit.{Partner, Patron, Supporter}
 import com.gu.memsub.BillingPeriod._
 import com.gu.memsub.Subscription.ProductRatePlanId
 import com.gu.memsub._
-import com.gu.memsub.subsv2.CatalogPlan._
+import com.gu.memsub.subsv2.ProductRatePlan._
 import com.gu.memsub.subsv2._
 import com.gu.memsub.subsv2.reads.CatJsonReads._
 import com.gu.memsub.subsv2.reads.CatPlanReads
 import com.gu.memsub.subsv2.reads.CatPlanReads._
-import com.gu.memsub.subsv2.reads.ChargeListReads.{ProductIds, _}
+import com.gu.memsub.subsv2.reads.ChargeListReads._
 import com.gu.monitoring.SafeLogger.LogPrefix
 import com.gu.zuora.rest.SimpleClient
 import play.api.libs.json.{Reads => JsReads, _}
@@ -55,7 +55,7 @@ class CatalogService[M[_]: Monad](productIds: ProductIds, fetchCatalog: M[String
   in time, I expect them all to be requested by the tag, so we can make frontend id non optional
   in time, I also expect they will all be tagged in zuora, so we don't need to then try untagged ones
    */
-  def one[P <: CatalogPlan[Product, ChargeList, Status]](plans: List[CatalogZuoraPlan], name: String, frontendId: FrontendId)(implicit
+  def one[P <: ProductRatePlan[Product, RatePlanChargeList, Status]](plans: List[CatalogZuoraPlan], name: String, frontendId: FrontendId)(implicit
       p: CatPlanReads[P],
   ): Validation[NonEmptyList[String], P] = {
     many(plans.filter(_.frontendId.contains(frontendId)), name).flatMap {
@@ -64,7 +64,7 @@ class CatalogService[M[_]: Monad](productIds: ProductIds, fetchCatalog: M[String
     }
   }
 
-  def many[P <: CatalogPlan[Product, ChargeList, Status]](plans: List[CatalogZuoraPlan], name: String)(implicit
+  def many[P <: ProductRatePlan[Product, RatePlanChargeList, Status]](plans: List[CatalogZuoraPlan], name: String)(implicit
       p: CatPlanReads[P],
   ): ValidationNel[String, NonEmptyList[P]] = {
     val parsed: List[(ProductRatePlanId, ValidationNel[String, P])] =

--- a/membership-common/src/main/scala/com/gu/memsub/subsv2/services/SubscriptionTransform.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/subsv2/services/SubscriptionTransform.scala
@@ -103,7 +103,7 @@ object SubscriptionTransform extends SafeLogging {
       .leftMap(_.toString)
       .withTrace("validate-lowLevelPlans")
     lowLevelPlans.flatMap { lowLevelPlans =>
-      val validHighLevelPlans: String \/ NonEmptyList[SubscriptionPlan] =
+      val validHighLevelPlans: String \/ NonEmptyList[RatePlan] =
         Sequence(
           lowLevelPlans
             .map { lowLevelPlan =>

--- a/membership-common/src/main/scala/com/gu/services/model/PaymentDetails.scala
+++ b/membership-common/src/main/scala/com/gu/services/model/PaymentDetails.scala
@@ -1,5 +1,5 @@
 package com.gu.services.model
-import com.gu.memsub.subsv2.{Subscription, SubscriptionPlan}
+import com.gu.memsub.subsv2.{Subscription, RatePlan}
 import com.gu.memsub.{BillingPeriod, PaymentMethod, Price}
 import com.gu.services.model.PaymentDetails.PersonalPlan
 import org.joda.time.{DateTime, Days, LocalDate}

--- a/membership-common/src/test/scala/com/gu/Diff.scala
+++ b/membership-common/src/test/scala/com/gu/Diff.scala
@@ -1,6 +1,6 @@
 package com.gu
 
-import com.gu.memsub.subsv2.{ChargeList, PaperCharges, SingleCharge}
+import com.gu.memsub.subsv2.{RatePlanChargeList, PaperCharges, RatePlanCharge}
 import com.gu.memsub.{Benefit, BillingPeriod}
 import com.softwaremill.diffx.scalatest.DiffShouldMatcher._
 import com.softwaremill.diffx.{DiffContext, DiffResultValue, Diff => Diffx}
@@ -18,13 +18,13 @@ object Diff {
   implicit val benefitDiff: Diffx[Benefit] = Diffx.diffForString.contramap(_.id)
   implicit def paidChargeListDiff[TheBenefit <: Benefit, TheBillingPeriod <: BillingPeriod](implicit
       e1: Diffx[PaperCharges],
-      e2: Diffx[SingleCharge[TheBenefit, TheBillingPeriod]],
-  ): Diffx[ChargeList] = (left: ChargeList, right: ChargeList, context: DiffContext) =>
+      e2: Diffx[RatePlanCharge[TheBenefit, TheBillingPeriod]],
+  ): Diffx[RatePlanChargeList] = (left: RatePlanChargeList, right: RatePlanChargeList, context: DiffContext) =>
     (left, right) match {
       case (cl: PaperCharges, cr: PaperCharges) =>
         Diffx[PaperCharges].apply(cl, cr)
-      case (cl: SingleCharge[TheBenefit, TheBillingPeriod], cr: SingleCharge[TheBenefit, TheBillingPeriod]) =>
-        Diffx[SingleCharge[TheBenefit, TheBillingPeriod]].apply(cl, cr)
+      case (cl: RatePlanCharge[TheBenefit, TheBillingPeriod], cr: RatePlanCharge[TheBenefit, TheBillingPeriod]) =>
+        Diffx[RatePlanCharge[TheBenefit, TheBillingPeriod]].apply(cl, cr)
       case _ =>
         DiffResultValue(left, right)
     }

--- a/membership-common/src/test/scala/com/gu/memsub/subsv2/reads/RatePlanChargeListReadsTest.scala
+++ b/membership-common/src/test/scala/com/gu/memsub/subsv2/reads/RatePlanChargeListReadsTest.scala
@@ -7,7 +7,7 @@ import com.gu.memsub.Benefit._
 import com.gu.memsub.BillingPeriod.Month
 import com.gu.memsub.Subscription.{ProductRatePlanChargeId, SubscriptionRatePlanChargeId}
 import com.gu.memsub._
-import com.gu.memsub.subsv2.{ChargeList, _}
+import com.gu.memsub.subsv2._
 import com.gu.memsub.subsv2.reads.ChargeListReads._
 import com.softwaremill.diffx
 import com.softwaremill.diffx._
@@ -17,7 +17,7 @@ import com.softwaremill.diffx.scalatest.DiffShouldMatcher._
 import org.scalatest.flatspec.AnyFlatSpec
 import scalaz.{Failure, NonEmptyList, Success, ValidationNel}
 
-class ChargeListReadsTest extends AnyFlatSpec {
+class RatePlanChargeListReadsTest extends AnyFlatSpec {
 
   val planChargeMap = Map[ProductRatePlanChargeId, Benefit](
     ProductRatePlanChargeId("weekly") -> Weekly,
@@ -136,10 +136,10 @@ class ChargeListReadsTest extends AnyFlatSpec {
   }
 
   "ChargeList reads" should "read single-charge non-paper rate plans as generic PaidCharge type" in {
-    val result: ValidationNel[String, ChargeList] = readChargeList.read(planChargeMap, List(weeklyCharge))
+    val result: ValidationNel[String, RatePlanChargeList] = readChargeList.read(planChargeMap, List(weeklyCharge))
 
-    val expected: ValidationNel[String, ChargeList] =
-      Success(SingleCharge(Weekly, Month, weeklyCharge.pricing, weeklyCharge.productRatePlanChargeId, weeklyCharge.id))
+    val expected: ValidationNel[String, RatePlanChargeList] =
+      Success(RatePlanCharge(Weekly, Month, weeklyCharge.pricing, weeklyCharge.productRatePlanChargeId, weeklyCharge.id))
 
     result shouldMatchTo expected
 
@@ -151,9 +151,9 @@ class ChargeListReadsTest extends AnyFlatSpec {
 
     val sundayPrices = Seq((SundayPaper, paperCharge.pricing)).toMap[PaperDay, PricingSummary]
 
-    val result: ValidationNel[String, ChargeList] = readChargeList.read(planChargeMap, List(paperCharge))
+    val result: ValidationNel[String, RatePlanChargeList] = readChargeList.read(planChargeMap, List(paperCharge))
 
-    val expected: ValidationNel[String, ChargeList] = Success(PaperCharges(dayPrices = sundayPrices, digipack = None))
+    val expected: ValidationNel[String, RatePlanChargeList] = Success(PaperCharges(dayPrices = sundayPrices, digipack = None))
 
     result shouldMatchTo expected
 
@@ -162,10 +162,10 @@ class ChargeListReadsTest extends AnyFlatSpec {
   }
 
   "ChargeList reads" should "not confuse digipack rate plan with paper+digital plan" in {
-    val result: ValidationNel[String, ChargeList] = readChargeList.read(planChargeMap, List(digipackCharge))
+    val result: ValidationNel[String, RatePlanChargeList] = readChargeList.read(planChargeMap, List(digipackCharge))
 
-    val expected: ValidationNel[String, ChargeList] =
-      Success(SingleCharge(Digipack, Month, digipackCharge.pricing, digipackCharge.productRatePlanChargeId, digipackCharge.id))
+    val expected: ValidationNel[String, RatePlanChargeList] =
+      Success(RatePlanCharge(Digipack, Month, digipackCharge.pricing, digipackCharge.productRatePlanChargeId, digipackCharge.id))
 
     result shouldMatchTo expected
 

--- a/membership-common/src/test/scala/com/gu/memsub/subsv2/reads/SubReadsTest.scala
+++ b/membership-common/src/test/scala/com/gu/memsub/subsv2/reads/SubReadsTest.scala
@@ -57,7 +57,7 @@ class SubReadsTest extends Specification {
     "parse Patron reader type correctly from subscription" in {
       val now = LocalDate.parse("2020-10-19")
       val json = Resource.getJson("rest/PatronReaderType.json")
-      val plan = SubscriptionPlan(
+      val plan = RatePlan(
         id = RatePlanId("rpid"),
         productRatePlanId = ProductRatePlanId("prpid"),
         name = "n",
@@ -67,7 +67,7 @@ class SubReadsTest extends Specification {
         productType = "pt",
         product = WeeklyDomestic,
         features = Nil,
-        charges = SingleCharge(
+        charges = RatePlanCharge(
           benefit = Weekly,
           billingPeriod = Quarter,
           price = PricingSummary(Map.empty),

--- a/membership-common/src/test/scala/com/gu/memsub/subsv2/reads/SubReadsTest.scala
+++ b/membership-common/src/test/scala/com/gu/memsub/subsv2/reads/SubReadsTest.scala
@@ -21,7 +21,7 @@ class SubReadsTest extends Specification {
 
     "Discard discount rate plans when reading JSON" in {
 
-      val plans = Resource.getJson("rest/plans/Promo.json").validate[List[SubscriptionZuoraPlan]].get
+      val plans = Resource.getJson("rest/plans/Promo.json").validate[List[SubscriptionZuoraPlan]](subZuoraPlanListReads).get
       plans mustEqual List(
         SubscriptionZuoraPlan(
           id = RatePlanId("2c92c0f957220b5d01573252b3bb7c71"),

--- a/membership-common/src/test/scala/com/gu/memsub/subsv2/services/SubscriptionServiceTest.scala
+++ b/membership-common/src/test/scala/com/gu/memsub/subsv2/services/SubscriptionServiceTest.scala
@@ -148,8 +148,8 @@ class SubscriptionServiceTest extends Specification {
 
   "Current Plan" should {
 
-    def contributorPlan(startDate: LocalDate, endDate: LocalDate, lastChangeType: Option[String] = None): SubscriptionPlan =
-      SubscriptionPlan(
+    def contributorPlan(startDate: LocalDate, endDate: LocalDate, lastChangeType: Option[String] = None): RatePlan =
+      RatePlan(
         RatePlanId("idContributor"),
         ProductRatePlanId("prpi"),
         "Contributor",
@@ -159,7 +159,7 @@ class SubscriptionServiceTest extends Specification {
         "Contribution",
         Product.Contribution,
         List.empty,
-        SingleCharge(
+        RatePlanCharge(
           Contributor,
           BillingPeriod.Month,
           PricingSummary(Map(GBP -> Price(5.0f, GBP))),
@@ -170,8 +170,8 @@ class SubscriptionServiceTest extends Specification {
         startDate,
         endDate,
       )
-    def partnerPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan =
-      SubscriptionPlan(
+    def partnerPlan(startDate: LocalDate, endDate: LocalDate): RatePlan =
+      RatePlan(
         RatePlanId("idPartner"),
         ProductRatePlanId("prpi"),
         "Partner",
@@ -181,7 +181,7 @@ class SubscriptionServiceTest extends Specification {
         "Membership",
         Product.Membership,
         List.empty,
-        SingleCharge(
+        RatePlanCharge(
           Partner,
           BillingPeriod.Year,
           PricingSummary(Map(GBP -> Price(149.0f, GBP))),
@@ -192,8 +192,8 @@ class SubscriptionServiceTest extends Specification {
         startDate,
         endDate,
       )
-    def supporterPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan =
-      SubscriptionPlan(
+    def supporterPlan(startDate: LocalDate, endDate: LocalDate): RatePlan =
+      RatePlan(
         RatePlanId("idSupporter"),
         ProductRatePlanId("prpi"),
         "Supporter",
@@ -203,7 +203,7 @@ class SubscriptionServiceTest extends Specification {
         "Membership",
         Product.Membership,
         List.empty,
-        SingleCharge(
+        RatePlanCharge(
           Supporter,
           BillingPeriod.Year,
           PricingSummary(Map(GBP -> Price(49.0f, GBP))),
@@ -214,8 +214,8 @@ class SubscriptionServiceTest extends Specification {
         startDate,
         endDate,
       )
-    def digipackPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan =
-      SubscriptionPlan(
+    def digipackPlan(startDate: LocalDate, endDate: LocalDate): RatePlan =
+      RatePlan(
         RatePlanId("idDigipack"),
         ProductRatePlanId("prpi"),
         "Digipack",
@@ -225,7 +225,7 @@ class SubscriptionServiceTest extends Specification {
         "Digital Pack",
         Product.Digipack,
         List.empty,
-        SingleCharge(
+        RatePlanCharge(
           Digipack,
           BillingPeriod.Year,
           PricingSummary(Map(GBP -> Price(119.90f, GBP))),
@@ -237,8 +237,8 @@ class SubscriptionServiceTest extends Specification {
         endDate,
       )
 
-    def switchedSupporterPlusPlan(startDate: LocalDate, endDate: LocalDate): SubscriptionPlan =
-      SubscriptionPlan(
+    def switchedSupporterPlusPlan(startDate: LocalDate, endDate: LocalDate): RatePlan =
+      RatePlan(
         id = RatePlanId("idSupporterPlus"),
         productRatePlanId = ProductRatePlanId("prpi"),
         name = "SupporterPlus",
@@ -248,7 +248,7 @@ class SubscriptionServiceTest extends Specification {
         productType = "Supporter Plus",
         product = Product.SupporterPlus,
         features = List.empty,
-        charges = SingleCharge(
+        charges = RatePlanCharge(
           SupporterPlus,
           BillingPeriod.Year,
           PricingSummary(Map(GBP -> Price(119.90f, GBP))),
@@ -260,7 +260,7 @@ class SubscriptionServiceTest extends Specification {
         end = endDate,
       )
 
-    def toSubscription(isCancelled: Boolean)(plans: NonEmptyList[SubscriptionPlan]): Subscription = {
+    def toSubscription(isCancelled: Boolean)(plans: NonEmptyList[RatePlan]): Subscription = {
       import com.gu.memsub.Subscription._
       Subscription(
         id = Id(plans.head.id.get),
@@ -347,7 +347,7 @@ class SubscriptionServiceTest extends Specification {
     "Be able to fetch a supporter plus subscription" in {
       val sub = service.get(memsub.Subscription.Name("1234"))
       sub.map(_.plan) must beSome(
-        SubscriptionPlan(
+        RatePlan(
           RatePlanId("8ad08ae28f9570f0018f958813ed10ca"),
           supporterPlusPrpId,
           "Supporter Plus",

--- a/membership-common/src/test/scala/com/gu/memsub/subsv2/services/SubscriptionTransformTest.scala
+++ b/membership-common/src/test/scala/com/gu/memsub/subsv2/services/SubscriptionTransformTest.scala
@@ -82,7 +82,7 @@ class SubscriptionTransformTest extends AnyFlatSpec {
         promoCode = None,
         isCancelled = false,
         plans = CovariantNonEmptyList(
-          SubscriptionPlan(
+          RatePlan(
             id = RatePlanId("2c92c0f85bae511e015bcead96a569e5"),
             productRatePlanId = ProductRatePlanId("2c92c0f9585841e7015862c9128e153b"),
             name = "foo",
@@ -92,7 +92,7 @@ class SubscriptionTransformTest extends AnyFlatSpec {
             productType = "Guardian Weekly",
             product = WeeklyZoneB,
             features = List(),
-            charges = SingleCharge(
+            charges = RatePlanCharge(
               Benefit.Weekly,
               OneYear,
               PricingSummary(Map(GBP -> Price(152.0f, GBP))),
@@ -132,7 +132,7 @@ class SubscriptionTransformTest extends AnyFlatSpec {
         promoCode = None,
         isCancelled = false,
         plans = CovariantNonEmptyList(
-          SubscriptionPlan(
+          RatePlan(
             id = RatePlanId("2c92c0f95bae6218015bceaf24520fa9"),
             productRatePlanId = ProductRatePlanId("2c92c0f85a4b3a23015a5be3fc2271ad"),
             name = "foo",
@@ -142,7 +142,7 @@ class SubscriptionTransformTest extends AnyFlatSpec {
             productType = "Guardian Weekly",
             product = WeeklyZoneB,
             features = List(),
-            charges = SingleCharge(
+            charges = RatePlanCharge(
               Benefit.Weekly,
               SixMonths,
               PricingSummary(Map(GBP -> Price(76.0f, GBP))),
@@ -182,7 +182,7 @@ class SubscriptionTransformTest extends AnyFlatSpec {
         promoCode = None,
         isCancelled = false,
         plans = CovariantNonEmptyList(
-          SubscriptionPlan(
+          RatePlan(
             id = RatePlanId("2c92c0f85be67835015be8f3743a7f8e"),
             productRatePlanId = ProductRatePlanId("2c92c0f95a4b48b8015a5be1205d042b"),
             name = "foo",
@@ -192,7 +192,7 @@ class SubscriptionTransformTest extends AnyFlatSpec {
             productType = "Guardian Weekly",
             product = WeeklyZoneB,
             features = List(),
-            charges = SingleCharge(
+            charges = RatePlanCharge(
               Benefit.Weekly,
               SixMonthsRecurring,
               PricingSummary(Map(GBP -> Price(76.0f, GBP))),


### PR DESCRIPTION
separate PR for the naming strategy suggested by @rupertbates in  https://github.com/guardian/members-data-api/pull/1073#discussion_r1607302410

renames as follows
```
SubscriptionPlan -> RatePlan
SingleCharge -> RatePlanCharge
ChargeList -> RatePlanChargeList
CatalogPlan -> ProductRatePlan
```