### PR TITLE
Add feast android offer tags

### DIFF
--- a/membership-attribute-service/app/models/Attributes.scala
+++ b/membership-attribute-service/app/models/Attributes.scala
@@ -2,7 +2,7 @@ package models
 
 import com.github.nscala_time.time.OrderingImplicits._
 import json._
-import models.FeastApp.getFeastIosSubscriptionGroup
+import models.FeastApp.{getFeastAndroidOfferTags, getFeastIosSubscriptionGroup}
 import org.joda.time.LocalDate
 import org.joda.time.LocalDate.now
 import play.api.libs.functional.syntax._
@@ -107,6 +107,7 @@ object Attributes {
     .addNullableField("digitalSubscriptionExpiryDate", _.latestDigitalSubscriptionExpiryDate)
     .addField("showSupportMessaging", _.showSupportMessaging)
     .addNullableField("feastIosSubscriptionGroup", getFeastIosSubscriptionGroup)
+    .addNullableField("feastAndroidOfferTags", getFeastAndroidOfferTags)
     .addField("contentAccess", _.contentAccess)
 }
 

--- a/membership-attribute-service/app/models/FeastApp.scala
+++ b/membership-attribute-service/app/models/FeastApp.scala
@@ -16,7 +16,7 @@ object FeastApp {
 
   object AndroidOfferTags {
     // Offer tags are the Android equivalent of iOS subscription groups - used by the app to work out which offer to show to the user
-    val InitialSupporterLaunchOffer = "initial_supporter_launch_offer"
+    val ExtendedTrial = "initial_supporter_launch_offer"
   }
 
   private def isBeforeFeastLaunch(dt: LocalDate): Boolean = dt.isBefore(FeastIosLaunchDate)
@@ -49,6 +49,6 @@ object FeastApp {
     )
   def getFeastAndroidOfferTags(attributes: Attributes): Option[String] =
     if (shouldShowSubscriptionOptions(attributes) && shouldGetFreeTrial(attributes))
-      Some(AndroidOfferTags.InitialSupporterLaunchOffer)
+      Some(AndroidOfferTags.ExtendedTrial)
     else None
 }

--- a/membership-attribute-service/app/models/FeastApp.scala
+++ b/membership-attribute-service/app/models/FeastApp.scala
@@ -14,6 +14,11 @@ object FeastApp {
     val RegularSubscription = "21396030"
   }
 
+  object AndroidOfferTags {
+    // Offer tags are the Android equivalent of iOS subscription groups - used by the app to work out which offer to show to the user
+    val InitialSupporterLaunchOffer = "initial_supporter_launch_offer"
+  }
+
   private def isBeforeFeastLaunch(dt: LocalDate): Boolean = dt.isBefore(FeastIosLaunchDate)
 
   def shouldGetFeastAccess(attributes: Attributes): Boolean =
@@ -42,4 +47,8 @@ object FeastApp {
       else
         RegularSubscription,
     )
+  def getFeastAndroidOfferTags(attributes: Attributes): Option[String] =
+    if (shouldShowSubscriptionOptions(attributes) && shouldGetFreeTrial(attributes))
+      Some(AndroidOfferTags.InitialSupporterLaunchOffer)
+    else None
 }

--- a/membership-attribute-service/app/models/FeastApp.scala
+++ b/membership-attribute-service/app/models/FeastApp.scala
@@ -47,8 +47,8 @@ object FeastApp {
       else
         RegularSubscription,
     )
-  def getFeastAndroidOfferTags(attributes: Attributes): Option[String] =
+  def getFeastAndroidOfferTags(attributes: Attributes): Option[List[String]] =
     if (shouldShowSubscriptionOptions(attributes) && shouldGetFreeTrial(attributes))
-      Some(AndroidOfferTags.ExtendedTrial)
+      Some(List(AndroidOfferTags.ExtendedTrial))
     else None
 }

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -423,7 +423,7 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
              |  "userId": "$userWithRecurringContributionUserId",
              |  "showSupportMessaging": false,
              |  "feastIosSubscriptionGroup": "${FeastApp.IosSubscriptionGroupIds.ExtendedTrial}",
-             |  "feastAndroidOfferTags": "${FeastApp.AndroidOfferTags.ExtendedTrial}",
+             |  "feastAndroidOfferTags": ["${FeastApp.AndroidOfferTags.ExtendedTrial}"],
              |  "recurringContributionPaymentPlan":"Monthly Contribution",
              |  "recurringContributionAcquisitionDate":"$dateBeforeFeastLaunch",
              |  "contentAccess": {
@@ -455,7 +455,7 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
              |  "liveAppSubscriptionExpiryDate":"${dateTimeInTheFuture.toLocalDate}",
              |  "showSupportMessaging": false,
              |  "feastIosSubscriptionGroup": "${FeastApp.IosSubscriptionGroupIds.ExtendedTrial}",
-             |  "feastAndroidOfferTags": "${FeastApp.AndroidOfferTags.ExtendedTrial}",
+             |  "feastAndroidOfferTags": ["${FeastApp.AndroidOfferTags.ExtendedTrial}"],
              |  "contentAccess": {
              |    "member": false,
              |    "paidMember": false,
@@ -485,7 +485,7 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
              |  "userId": "$userWithNewspaperUserId",
              |  "paperSubscriptionExpiryDate":"${dateTimeInTheFuture.toLocalDate}",
              |  "feastIosSubscriptionGroup": "${FeastApp.IosSubscriptionGroupIds.ExtendedTrial}",
-             |  "feastAndroidOfferTags": "${FeastApp.AndroidOfferTags.ExtendedTrial}",
+             |  "feastAndroidOfferTags": ["${FeastApp.AndroidOfferTags.ExtendedTrial}"],
              |  "showSupportMessaging": false,
              |  "contentAccess": {
              |    "member": false,
@@ -547,7 +547,7 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
              |  "guardianWeeklyExpiryDate":"${dateTimeInTheFuture.toLocalDate}",
              |  "showSupportMessaging": false,
              |  "feastIosSubscriptionGroup": "${FeastApp.IosSubscriptionGroupIds.ExtendedTrial}",
-             |  "feastAndroidOfferTags": "${FeastApp.AndroidOfferTags.ExtendedTrial}",
+             |  "feastAndroidOfferTags": ["${FeastApp.AndroidOfferTags.ExtendedTrial}"],
              |  "contentAccess": {
              |    "member": false,
              |    "paidMember": false,

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -423,6 +423,7 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
              |  "userId": "$userWithRecurringContributionUserId",
              |  "showSupportMessaging": false,
              |  "feastIosSubscriptionGroup": "${FeastApp.IosSubscriptionGroupIds.ExtendedTrial}",
+             |  "feastAndroidOfferTags": "${FeastApp.AndroidOfferTags.ExtendedTrial}",
              |  "recurringContributionPaymentPlan":"Monthly Contribution",
              |  "recurringContributionAcquisitionDate":"$dateBeforeFeastLaunch",
              |  "contentAccess": {
@@ -454,6 +455,7 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
              |  "liveAppSubscriptionExpiryDate":"${dateTimeInTheFuture.toLocalDate}",
              |  "showSupportMessaging": false,
              |  "feastIosSubscriptionGroup": "${FeastApp.IosSubscriptionGroupIds.ExtendedTrial}",
+             |  "feastAndroidOfferTags": "${FeastApp.AndroidOfferTags.ExtendedTrial}",
              |  "contentAccess": {
              |    "member": false,
              |    "paidMember": false,
@@ -483,6 +485,7 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
              |  "userId": "$userWithNewspaperUserId",
              |  "paperSubscriptionExpiryDate":"${dateTimeInTheFuture.toLocalDate}",
              |  "feastIosSubscriptionGroup": "${FeastApp.IosSubscriptionGroupIds.ExtendedTrial}",
+             |  "feastAndroidOfferTags": "${FeastApp.AndroidOfferTags.ExtendedTrial}",
              |  "showSupportMessaging": false,
              |  "contentAccess": {
              |    "member": false,
@@ -544,6 +547,7 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
              |  "guardianWeeklyExpiryDate":"${dateTimeInTheFuture.toLocalDate}",
              |  "showSupportMessaging": false,
              |  "feastIosSubscriptionGroup": "${FeastApp.IosSubscriptionGroupIds.ExtendedTrial}",
+             |  "feastAndroidOfferTags": "${FeastApp.AndroidOfferTags.ExtendedTrial}",
              |  "contentAccess": {
              |    "member": false,
              |    "paidMember": false,


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
This PR adds 'offer tags' to the /user-attributes/me response to enable the Android Feast app to work out whether to offer users an extended free trial.

### Testing
To test this you can deploy this build to CODE and then sign in to 
https://manage.code.dev-theguardian.com/
with the username rupert.bates+supporter-plus-only@observer.co.uk and password rupert.bates+supporter-plus-only
and then check the members data api response at 
https://members-data-api.code.dev-theguardian.com/user-attributes/me
The `feast` boolean in the `contentAccess` object should be `true`

Next sign in with the username rupert.bates+paper-only@observer.co.uk and password rupert.bates+paper-only
and check the mdapi response
The `feast` boolean should be `false` and the response should have a `feastAndroidOfferTags` attribute at the top level with the value `initial_supporter_launch_offer`