### PR TITLE
Change tier three to be a separate product in user-attributes/me

### DIFF
--- a/membership-attribute-service/app/services/SupporterRatePlanToAttributesMapper.scala
+++ b/membership-attribute-service/app/services/SupporterRatePlanToAttributesMapper.scala
@@ -53,7 +53,7 @@ object SupporterRatePlanToAttributesMapper {
       SupporterPlusExpiryDate = Some(supporterRatePlanItem.termEndDate),
     )
   val supporterPlusV2Transformer: AttributeTransformer = supporterPlusTransformer
-  val supporterPlusWithGuardianWeeklyTransformer: AttributeTransformer =
+  val tierThreeTransformer: AttributeTransformer =
     (attributes: Attributes, supporterRatePlanItem: DynamoSupporterRatePlanItem) =>
       attributes.copy(
         SupporterPlusExpiryDate = Some(supporterRatePlanItem.termEndDate),
@@ -99,11 +99,11 @@ object SupporterRatePlanToAttributesMapper {
       "8a128ed885fc6ded01860228f77e3d5a",
     ) -> supporterPlusV2Transformer,
     List(
-      "8a1292628f51a923018f52a324e45710", // Supporter Plus V2 & Guardian Weekly ROW - Annual
-      "8a1281f38f518d11018f52a599806a65", // Supporter Plus V2 & Guardian Weekly ROW - Monthly
-      "8a1282048f518d08018f529ead0f3d91", // Supporter Plus V2 & Guardian Weekly Domestic - Annual
-      "8a1288a38f518d01018f529a04443172", // Supporter Plus V2 & Guardian Weekly Domestic - Monthly
-    ) -> supporterPlusWithGuardianWeeklyTransformer,
+      "8a1299788ff2ec100190025fccc32bb1",
+      "8a1288a38ff2af980190025b32591ccc",
+      "8a128ab18ff2af9301900255d77979ac",
+      "8a1299788ff2ec100190024d1e3b1a09",
+    ) -> tierThreeTransformer,
     List(
       "2c92a0fb4edd70c8014edeaa4eae220a",
       "2c92a0fb4edd70c8014edeaa4e972204",
@@ -224,11 +224,11 @@ object SupporterRatePlanToAttributesMapper {
       "8ad08e1a8586721801858805663f6fab",
     ) -> supporterPlusV2Transformer,
     List(
-      "8ad097b48f006681018f05a0496e01f4", // Supporter Plus V2 & Guardian Weekly ROW - Annual
-      "8ad097b48f006681018f05a2c0fb0227", // Supporter Plus V2 & Guardian Weekly ROW - Monthly
-      "8ad097b48f006681018f059b755e0140", // Supporter Plus V2 & Guardian Weekly Domestic - Annual
-      "8ad081dd8ef57784018ef6e159224bfa", // Supporter Plus V2 & Guardian Weekly Domestic - Monthly
-    ) -> supporterPlusWithGuardianWeeklyTransformer,
+      "8ad097b48ff26452019001cebac92376",
+      "8ad081dd8ff24a9a019001d95e4e3574",
+      "8ad081dd8ff24a9a019001df2ce83657",
+      "8ad097b48ff26452019001e65bbf2ca8",
+    ) -> tierThreeTransformer,
     List(
       "2c92c0f84bbfec8b014bc655f4852d9d",
       "2c92c0f94bbffaaa014bc6a4212e205b",

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -41,7 +41,7 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
   private val userWithNewspaperPlusUserId = "6"
   private val userWithGuardianWeeklyUserId = "7"
   private val unvalidatedEmailUserId = "8"
-  private val userWithSupporterPlusWithGuardianWeeklyId = "9"
+  private val userWithTierThreeId = "9"
 
   private val testAttributes = Attributes(
     UserId = validUserId,
@@ -74,8 +74,8 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
     GuardianWeeklySubscriptionExpiryDate = Some(dateTimeInTheFuture.toLocalDate),
   )
 
-  private val supporterPlusWithGuardianWeeklyAttributes = Attributes(
-    UserId = userWithSupporterPlusWithGuardianWeeklyId,
+  private val tierThreeAttributes = Attributes(
+    UserId = userWithTierThreeId,
     SupporterPlusExpiryDate = Some(dateTimeInTheFuture.toLocalDate),
     GuardianWeeklySubscriptionExpiryDate = Some(dateTimeInTheFuture.toLocalDate),
   )
@@ -88,7 +88,7 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
   private val newspaperCookie = Cookie("newspaper", "true")
   private val newspaperPlusCookie = Cookie("newspaperPlus", "true")
   private val guardianWeeklyCookie = Cookie("guardianWeekly", "true")
-  private val supporterPlusWithGuardianWeeklyCookie = Cookie("supporterPlusWithGuardianWeekly", "true")
+  private val tierThreeCookie = Cookie("tierThree", "true")
   private val validUser = UserFromToken(
     primaryEmailAddress = "test@thegulocal.com",
     identityId = validUserId,
@@ -134,9 +134,9 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
     authTime = None,
   )
 
-  private val userWithSupporterPlusWithGuardianWeekly = UserFromToken(
-    primaryEmailAddress = "SupporterPlusWithGuardianWeekly@thegulocal.com",
-    identityId = userWithSupporterPlusWithGuardianWeeklyId,
+  private val userWithTierThree = UserFromToken(
+    primaryEmailAddress = "TierThree@thegulocal.com",
+    identityId = userWithTierThreeId,
     authTime = None,
   )
 
@@ -175,7 +175,7 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
         case Some(c) if c == newspaperCookie => Future.successful(Right(userWithNewspaper))
         case Some(c) if c == newspaperPlusCookie => Future.successful(Right(userWithNewspaperPlus))
         case Some(c) if c == guardianWeeklyCookie => Future.successful(Right(userWithGuardianWeekly))
-        case Some(c) if c == supporterPlusWithGuardianWeeklyCookie => Future.successful(Right(userWithSupporterPlusWithGuardianWeekly))
+        case Some(c) if c == tierThreeCookie => Future.successful(Right(userWithTierThree))
         case Some(c) if c == guardianEmployeeCookie => Future.successful(Right(guardianEmployeeUser))
         case Some(c) if c == guardianEmployeeCookieTheguardian => Future.successful(Right(guardianEmployeeUserTheguardian))
         case Some(c) if c == validEmployeeUserCookie => Future.successful(Right(validEmployeeUser))
@@ -263,8 +263,8 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
           ("Zuora", Some(newspaperPlusAttributes))
         } else if (identityId == userWithGuardianWeeklyUserId) {
           ("Zuora", Some(guardianWeeklyOnlyAttributes))
-        } else if (identityId == userWithSupporterPlusWithGuardianWeeklyId) {
-          ("Zuora", Some(supporterPlusWithGuardianWeeklyAttributes))
+        } else if (identityId == userWithTierThreeId) {
+          ("Zuora", Some(tierThreeAttributes))
         } else
           ("Zuora", None)
       }
@@ -564,8 +564,8 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
 
     }
 
-    "return the correct attributes for Supporter Plus With Guardian Weekly subscribers" in {
-      val req = FakeRequest().withCookies(supporterPlusWithGuardianWeeklyCookie)
+    "return the correct attributes for Tier Three subscribers" in {
+      val req = FakeRequest().withCookies(tierThreeCookie)
       val result = controller.attributes(req)
 
       status(result) shouldEqual OK
@@ -574,7 +574,7 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
       jsonBody shouldEqual
         Json.parse(s"""
              |{
-             |  "userId": "$userWithSupporterPlusWithGuardianWeeklyId",
+             |  "userId": "$userWithTierThreeId",
              |  "guardianWeeklyExpiryDate":"${dateTimeInTheFuture.toLocalDate}",
              |  "showSupportMessaging": false,
              |  "contentAccess": {
@@ -589,7 +589,7 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
              |    "guardianPatron": false
              |  }
              |}""".stripMargin)
-      verifyIdentityHeadersSet(result, userWithSupporterPlusWithGuardianWeeklyId)
+      verifyIdentityHeadersSet(result, userWithTierThreeId)
 
     }
 

--- a/membership-attribute-service/test/services/SupporterRatePlanToAttributesMapperTest.scala
+++ b/membership-attribute-service/test/services/SupporterRatePlanToAttributesMapperTest.scala
@@ -113,20 +113,20 @@ class SupporterRatePlanToAttributesMapperTest extends Specification {
       )
     }
 
-    "handle a SupporterPlusWithGuardianWeekly subscription" in {
+    "handle a Tier Three subscription" in {
       testMapper(
         Map(
           "PROD" -> List(
-            ratePlanItem("8a1292628f51a923018f52a324e45710"), // Supporter Plus V2 & Guardian Weekly ROW - Annual
-            ratePlanItem("8a1281f38f518d11018f52a599806a65"), // Supporter Plus V2 & Guardian Weekly ROW - Monthly
-            ratePlanItem("8a1282048f518d08018f529ead0f3d91"), // Supporter Plus V2 & Guardian Weekly Domestic - Annual
-            ratePlanItem("8a1288a38f518d01018f529a04443172"), // Supporter Plus V2 & Guardian Weekly Domestic - Monthly
+            ratePlanItem("8a1299788ff2ec100190025fccc32bb1"),
+            ratePlanItem("8a1288a38ff2af980190025b32591ccc"),
+            ratePlanItem("8a128ab18ff2af9301900255d77979ac"),
+            ratePlanItem("8a1299788ff2ec100190024d1e3b1a09"),
           ),
           "CODE" -> List(
-            ratePlanItem("8ad097b48f006681018f05a0496e01f4"), // Supporter Plus V2 & Guardian Weekly ROW - Annual
-            ratePlanItem("8ad097b48f006681018f05a2c0fb0227"), // Supporter Plus V2 & Guardian Weekly ROW - Monthly
-            ratePlanItem("8ad097b48f006681018f059b755e0140"), // Supporter Plus V2 & Guardian Weekly Domestic - Annual
-            ratePlanItem("8ad081dd8ef57784018ef6e159224bfa"), // Supporter Plus V2 & Guardian Weekly Domestic - Monthly
+            ratePlanItem("8ad097b48ff26452019001cebac92376"),
+            ratePlanItem("8ad081dd8ff24a9a019001d95e4e3574"),
+            ratePlanItem("8ad081dd8ff24a9a019001df2ce83657"),
+            ratePlanItem("8ad097b48ff26452019001e65bbf2ca8"),
           ),
         ),
         _ should beSome.which { attributes: Attributes =>


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
This PR makes some changes to support the new Tier Three product, following on from [this PR](https://github.com/guardian/members-data-api/pull/1065), now that Tier Three is a separate product in Zuora and not just a new rate plan in Supporter Plus.