### PR TITLE
Switch which GoCardless Zuora gateway is used when user updates Direct Debit details in MMA

### DIFF
--- a/membership-attribute-service/app/controllers/PaymentUpdateController.scala
+++ b/membership-attribute-service/app/controllers/PaymentUpdateController.scala
@@ -7,7 +7,7 @@ import com.gu.memsub.{CardUpdateFailure, CardUpdateSuccess, GoCardless, PaymentM
 import com.gu.monitoring.SafeLogger.LogPrefix
 import com.gu.monitoring.SafeLogging
 import com.gu.salesforce.Contact
-import com.gu.zuora.api.GoCardlessZuoraInstance
+import com.gu.zuora.api.GoCardless
 import com.gu.zuora.soap.models.Commands.{BankTransfer, CreatePaymentMethod}
 import json.PaymentCardUpdateResultWriters._
 import models.AccessScope.{readSelf, updateSelf}
@@ -169,7 +169,7 @@ class PaymentUpdateController(
           createPaymentMethod = CreatePaymentMethod(
             accountId = subscription.accountId,
             paymentMethod = bankTransferPaymentMethod,
-            paymentGateway = GoCardlessZuoraInstance,
+            paymentGateway = GoCardless,
             billtoContact = billToContact,
             invoiceTemplateOverride = None,
           )

--- a/membership-attribute-service/test/acceptance/PaymentUpdateControllerAcceptanceTest.scala
+++ b/membership-attribute-service/test/acceptance/PaymentUpdateControllerAcceptanceTest.scala
@@ -9,7 +9,7 @@ import com.gu.memsub.subsv2.services.SubscriptionService.CatalogMap
 import com.gu.memsub.subsv2.services.{CatalogService, SubscriptionService}
 import com.gu.memsub.subsv2.{CovariantNonEmptyList, RatePlan}
 import com.gu.zuora.ZuoraSoapService
-import com.gu.zuora.api.{GoCardlessZuoraInstance, PaymentGateway}
+import com.gu.zuora.api.{GoCardless, PaymentGateway}
 import com.gu.zuora.soap.models.Commands.{BankTransfer, CreatePaymentMethod}
 import com.gu.zuora.soap.models.Queries
 import com.gu.zuora.soap.models.Results.UpdateResult
@@ -178,7 +178,7 @@ class PaymentUpdateControllerAcceptanceTest extends AcceptanceTest {
       val createPaymentMethod = CreatePaymentMethod(
         accountId = subscription.accountId,
         paymentMethod = bankTransferPaymentMethod,
-        paymentGateway = GoCardlessZuoraInstance,
+        paymentGateway = GoCardless,
         billtoContact = queriesContact,
         invoiceTemplateOverride = None,
       )

--- a/membership-common/src/main/scala/com/gu/zuora/api/PaymentGateway.scala
+++ b/membership-common/src/main/scala/com/gu/zuora/api/PaymentGateway.scala
@@ -26,6 +26,7 @@ case object StripeAUPaymentIntentsMembershipGateway extends PaymentGateway {
 case object GoCardless extends PaymentGateway {
   val gatewayName = "GoCardless"
 }
+// Temporarily here to enable deseerialisation until it's fully deprovisioned.
 case object GoCardlessZuoraInstance extends PaymentGateway {
   val gatewayName = "GoCardless - Zuora Instance"
 }


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
Currently the GoCardless reconciliation batch job (https://knowledgecenter.zuora.com/Zuora_Payments/Payment_gateway_integrations/Batch_Gateway_Reconciliation) happens twice because we have 2 GoCardless payment gateways configured in Production Zuora. I'd like to reduce down to having 1, this change is a prerequisite to ensure no new payment methods are created referencing this gateway. Salesforce HPP may also need to be updated.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
Setting the gateway to `GoCardless` for Direct Debits rather than `GoCardless - Zuora Gateway` so the latter one (with far fewer accounts using it) can be deprovisioned.

### trello card/screenshot/json/related PRs etc
https://trello.com/c/uaCj9MdG