### PR TITLE
Allow self-service cancellation of Tier Three in UK

### DIFF
--- a/membership-attribute-service/app/models/SelfServiceCancellation.scala
+++ b/membership-attribute-service/app/models/SelfServiceCancellation.scala
@@ -23,13 +23,13 @@ object SelfServiceCancellation {
 
   def apply(product: Product, billingCountry: Option[Country]): SelfServiceCancellation = {
 
-    if (isOneOf(product, Membership, Contribution, SupporterPlus, Digipack)) {
+    if (isOneOf(product, Membership, Contribution, SupporterPlus, Digipack, TierThree)) {
       SelfServiceCancellation(
         isAllowed = true,
         shouldDisplayEmail = true,
         phoneRegionsToDisplay = allPhones,
       )
-    } else if (billingCountry == Some(UK)) {
+    } else if (billingCountry.contains(UK)) {
       SelfServiceCancellation(
         isAllowed = false,
         shouldDisplayEmail = false,

--- a/membership-attribute-service/test/models/SelfServiceCancellationTest.scala
+++ b/membership-attribute-service/test/models/SelfServiceCancellationTest.scala
@@ -10,6 +10,7 @@ class SelfServiceCancellationTest extends Specification {
     Membership,
     Contribution,
     SupporterPlus,
+    TierThree,
     Voucher,
     Delivery,
     DigitalVoucher,
@@ -36,9 +37,15 @@ class SelfServiceCancellationTest extends Specification {
       }.toList
     }
 
-    "disallow cancellation for all products except Membership, Contribution, Digipack and Supporter Plus in the UK" in {
+    "allow cancellation for Tier Three in all countries" in {
+      allCountries.map { country =>
+        SelfServiceCancellation(TierThree, Some(country)).isAllowed shouldEqual true
+      }.toList
+    }
+
+    "disallow cancellation for all products except Membership, Contribution, Digipack, Tier Three and Supporter Plus in the UK" in {
       allProducts
-        .diff(Set(Membership, Contribution, SupporterPlus, Digipack))
+        .diff(Set(Membership, Contribution, SupporterPlus, Digipack, TierThree))
         .map { product =>
           SelfServiceCancellation(product, Some(UK)).isAllowed shouldEqual false
         }


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
The new Tier Three product should allow self service cancellation globally. See [this doc](https://docs.google.com/document/d/1exq06PZVjPwJ88o2vV8yeU9Fd-C0ey6DBGQYxGkGOB0/edit) for more details