### PR TITLE
add inDiscountPeriod flag to /mma response

### DIFF
--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -165,6 +165,9 @@ object AccountDetails {
             "nextPaymentPrice" -> paymentDetails.nextPaymentPrice,
             "nextPaymentDate" -> paymentDetails.nextPaymentDate,
             "potentialCancellationDate" -> paymentDetails.nextInvoiceDate,
+            "inDiscountPeriod" -> JsBoolean(
+              !paymentDetails.nextPaymentDate.forall(paymentDetails.nextInvoiceDate.contains),
+            ), // temp field until we fetch the actual discount details
             "lastPaymentDate" -> paymentDetails.lastPaymentDate,
             "chargedThroughDate" -> paymentDetails.chargedThroughDate,
             "renewalDate" -> paymentDetails.termEndDate,

--- a/membership-attribute-service/test/models/ProductsResponseSpec.scala
+++ b/membership-attribute-service/test/models/ProductsResponseSpec.scala
@@ -133,6 +133,7 @@ class ProductsResponseSpec extends Specification with SafeLogging {
           |      "nextPaymentPrice" : 2500,
           |      "nextPaymentDate" : "2024-06-15",
           |      "potentialCancellationDate" : "2024-06-15",
+          |      "inDiscountPeriod": false,
           |      "lastPaymentDate" : "2024-05-15",
           |      "chargedThroughDate" : "2024-06-15",
           |      "renewalDate" : "2025-05-15",


### PR DESCRIPTION
The manage page needs to flag up to users whether their subscription is discounted or not.

This PR adds a flag so that it can be guessed whether it's in the "cancellation save" free period.

--

As future work, once the MDAPI refactor in another PR https://github.com/guardian/members-data-api/pull/1079 is finished, it will be easier to identify discounts in the code and return the name or other details in the API response.