### PR TITLE
fix test users to use email rather than first name

### DIFF
--- a/membership-attribute-service/app/actions/AuthAndBackendViaAuthLibAction.scala
+++ b/membership-attribute-service/app/actions/AuthAndBackendViaAuthLibAction.scala
@@ -2,7 +2,7 @@ package actions
 
 import com.gu.identity.auth.AccessScope
 import components.TouchpointBackends
-import filters.IsTestUser
+import filters.TestUserChecker
 import play.api.mvc.{ActionRefiner, Request, Result, Results}
 import services.AuthenticationFailure
 
@@ -11,7 +11,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class AuthAndBackendViaAuthLibAction(
     touchpointBackends: TouchpointBackends,
     requiredScopes: List[AccessScope],
-    isTestUser: IsTestUser,
+    testUserChecker: TestUserChecker,
 )(implicit
     ex: ExecutionContext,
 ) extends ActionRefiner[Request, AuthenticatedUserAndBackendRequest] {
@@ -22,7 +22,7 @@ class AuthAndBackendViaAuthLibAction(
       case Left(AuthenticationFailure.Unauthorised) => Left(Results.Unauthorized)
       case Left(AuthenticationFailure.Forbidden) => Left(Results.Forbidden)
       case Right(authenticatedUser) =>
-        val backendConf = if (isTestUser(authenticatedUser.username)) {
+        val backendConf = if (testUserChecker.isTestUser(authenticatedUser.primaryEmailAddress)(authenticatedUser.logPrefix)) {
           touchpointBackends.test
         } else {
           touchpointBackends.normal

--- a/membership-attribute-service/app/actions/AuthAndBackendViaIdapiAction.scala
+++ b/membership-attribute-service/app/actions/AuthAndBackendViaIdapiAction.scala
@@ -4,7 +4,7 @@ import com.gu.identity.auth.{AccessScope, IdapiUserCredentials, OktaUserCredenti
 import com.gu.identity.{IdapiService, RedirectAdviceResponse, SignedInRecently}
 import com.gu.monitoring.SafeLogger.LogPrefix
 import components.{TouchpointBackends, TouchpointComponents}
-import filters.IsTestUser
+import filters.TestUserChecker
 import models.{ApiError, UserFromToken}
 import play.api.mvc.{ActionRefiner, Request, Result, Results}
 import services.UserAndCredentials
@@ -14,7 +14,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class AuthAndBackendViaIdapiAction(
     touchpointBackends: TouchpointBackends,
     howToHandleRecencyOfSignedIn: HowToHandleRecencyOfSignedIn,
-    isTestUser: IsTestUser,
+    testUserChecker: TestUserChecker,
     requiredScopes: List[AccessScope],
 )(implicit
     ex: ExecutionContext,
@@ -29,12 +29,12 @@ class AuthAndBackendViaIdapiAction(
       case Right(UserAndCredentials(user, _: OktaUserCredentials)) => Future.successful(Right(oktaRefine(request, user)))
       case Right(UserAndCredentials(user, _: IdapiUserCredentials)) =>
         implicit val logPrefix: LogPrefix = user.logPrefix
-        idapiRefine(request)
+        idapiRefine(request, user.primaryEmailAddress)
     }
   }
 
-  private def backend(displayName: Option[String]): TouchpointComponents =
-    if (isTestUser(displayName)) {
+  private def backend(primaryEmailAddress: String)(implicit logPrefix: LogPrefix): TouchpointComponents =
+    if (testUserChecker.isTestUser(primaryEmailAddress)) {
       touchpointBackends.test
     } else {
       touchpointBackends.normal
@@ -50,11 +50,13 @@ class AuthAndBackendViaIdapiAction(
         // Okta reauthentication redirect will be managed by the API client
         redirect = None,
       ),
-      touchpoint = backend(user.username),
+      touchpoint = backend(user.primaryEmailAddress)(user.logPrefix),
       request,
     )
 
-  private def idapiRefine[A](request: Request[A])(implicit logPrefix: LogPrefix): Future[Either[Result, AuthAndBackendRequest[A]]] =
+  private def idapiRefine[A](request: Request[A], primaryEmailAddress: String)(implicit
+      logPrefix: LogPrefix,
+  ): Future[Either[Result, AuthAndBackendRequest[A]]] =
     touchpointBackends.normal.idapiService.RedirectAdvice
       .getRedirectAdvice(
         request.headers.get(IdapiService.HeaderNameCookie).getOrElse(""),
@@ -65,7 +67,7 @@ class AuthAndBackendViaIdapiAction(
           case Return401IfNotSignedInRecently if redirectAdvice.signInStatus != SignedInRecently =>
             Left(Results.Unauthorized.withHeaders(("X-GU-IDAPI-Redirect", redirectAdvice.redirect.map(_.url).getOrElse(""))))
           case _ =>
-            val backendConf = backend(redirectAdvice.displayName)
+            val backendConf = backend(primaryEmailAddress)
             Right(new AuthAndBackendRequest[A](redirectAdvice, backendConf, request))
         },
       )

--- a/membership-attribute-service/app/filters/AddGuIdentityHeaders.scala
+++ b/membership-attribute-service/app/filters/AddGuIdentityHeaders.scala
@@ -20,11 +20,11 @@ class AddGuIdentityHeadersFilter(addGuIdentityHeaders: AddGuIdentityHeaders)(imp
   }
 }
 
-class AddGuIdentityHeaders(identityAuthService: IdentityAuthService, isTestUser: IsTestUser) {
+class AddGuIdentityHeaders(identityAuthService: IdentityAuthService, testUserChecker: TestUserChecker) {
 
   def fromUser(result: Result, user: UserFromToken): Result = result.withHeaders(
     xGuIdentityIdHeaderName -> user.identityId,
-    xGuMembershipTestUserHeaderName -> isTestUser(user.username).toString,
+    xGuMembershipTestUserHeaderName -> testUserChecker.isTestUser(user.primaryEmailAddress)(user.logPrefix).toString,
   )
 
   def fromIdapiIfMissing(request: RequestHeader, result: Result)(implicit ex: ExecutionContext): Future[Result] = {

--- a/membership-attribute-service/app/filters/IsTestUser.scala
+++ b/membership-attribute-service/app/filters/IsTestUser.scala
@@ -1,9 +1,0 @@
-package filters
-
-import com.gu.identity.testing.usernames.TestUsernames
-
-class IsTestUser(testUsernames: TestUsernames) {
-  def apply(displayName: Option[String]): Boolean =
-    displayName.flatMap(_.split(' ').headOption).exists(testUsernames.isValid)
-
-}

--- a/membership-attribute-service/app/filters/TestUserChecker.scala
+++ b/membership-attribute-service/app/filters/TestUserChecker.scala
@@ -1,0 +1,23 @@
+package filters
+
+import com.gu.identity.testing.usernames.TestUsernames
+import com.gu.monitoring.SafeLogger.LogPrefix
+import com.gu.monitoring.SafeLogging
+
+class TestUserChecker(testUsernames: TestUsernames) extends SafeLogging {
+  def isTestUser(primaryEmailAddress: String)(implicit logPrefix: LogPrefix): Boolean = {
+    val maybeValidTestUser = for {
+      localPart <- primaryEmailAddress.split('@').headOption
+      possibleTestUsername <- localPart.split('+').toList match {
+        case _ :: subAddress :: _ => Some(subAddress)
+        case noPlus :: Nil => Some(noPlus)
+        case _ => None // invalid email address - no @ sign
+      }
+    } yield testUsernames.isValid(possibleTestUsername)
+    if (maybeValidTestUser.contains(true)) {
+      logger.info(primaryEmailAddress + " is a test user")
+    }
+    maybeValidTestUser.getOrElse(false)
+  }
+
+}

--- a/membership-attribute-service/app/wiring/AppLoader.scala
+++ b/membership-attribute-service/app/wiring/AppLoader.scala
@@ -85,9 +85,9 @@ class MyComponents(context: Context)
     patronsStripeServiceOverride,
     chooseStripeOverride,
   )
-  private val isTestUser = new IsTestUser(CreateTestUsernames.from(config))
-  private val addGuIdentityHeaders = new AddGuIdentityHeaders(touchPointBackends.normal.identityAuthService, isTestUser)
-  lazy val commonActions = new CommonActions(touchPointBackends, defaultBodyParser, isTestUser)
+  private val testUserChecker = new TestUserChecker(CreateTestUsernames.from(config))
+  private val addGuIdentityHeaders = new AddGuIdentityHeaders(touchPointBackends.normal.identityAuthService, testUserChecker)
+  lazy val commonActions = new CommonActions(touchPointBackends, defaultBodyParser, testUserChecker)
   override lazy val httpErrorHandler: ErrorHandler =
     new ErrorHandler(
       environment,

--- a/membership-attribute-service/test/actions/AuthAndBackendViaIdapiActionTest.scala
+++ b/membership-attribute-service/test/actions/AuthAndBackendViaIdapiActionTest.scala
@@ -2,7 +2,7 @@ package actions
 
 import com.gu.identity.auth.OktaUserCredentials
 import components.{TouchpointBackends, TouchpointComponents}
-import filters.IsTestUser
+import filters.TestUserChecker
 import models.AccessScope.readSelf
 import models.{ApiErrors, UserFromToken}
 import org.mockito.IdiomaticMockito
@@ -34,7 +34,7 @@ class AuthAndBackendViaIdapiActionTest extends Specification with IdiomaticMocki
       when(user.username).thenReturn(None)
       when(user.authTime).thenReturn(Some(authenticatedTime))
 
-      val isTestUser = mock[IsTestUser]
+      val isTestUser = mock[TestUserChecker]
 
       val authService = mock[IdentityAuthService]
       when(authService.userAndCredentials(request, requiredScopes))
@@ -65,7 +65,7 @@ class AuthAndBackendViaIdapiActionTest extends Specification with IdiomaticMocki
     "fail with a 401 when call to identityAuthService fails with a 401" in {
       val request = FakeRequest()
 
-      val isTestUser = mock[IsTestUser]
+      val isTestUser = mock[TestUserChecker]
 
       val authService = mock[IdentityAuthService]
       when(authService.userAndCredentials(request, requiredScopes))
@@ -87,7 +87,7 @@ class AuthAndBackendViaIdapiActionTest extends Specification with IdiomaticMocki
     "fail with a 403 when call to identityAuthService fails with a 403" in {
       val request = FakeRequest()
 
-      val isTestUser = mock[IsTestUser]
+      val isTestUser = mock[TestUserChecker]
 
       val authService = mock[IdentityAuthService]
       when(authService.userAndCredentials(request, requiredScopes))

--- a/membership-attribute-service/test/filters/AddGuIdentityHeadersTest.scala
+++ b/membership-attribute-service/test/filters/AddGuIdentityHeadersTest.scala
@@ -10,6 +10,7 @@ import play.api.mvc.Results.Ok
 import play.api.mvc.{RequestHeader, Result}
 import services.AuthenticationFailure.Unauthorised
 import services.IdentityAuthService
+import testdata.TestLogPrefix.testLogPrefix
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
@@ -27,14 +28,17 @@ class AddGuIdentityHeadersTest extends Specification with IdiomaticMockito {
     authTime = None,
   )
 
-  val identityService = mock[IdentityAuthService]
   val request = mock[RequestHeader]
-  when(identityService.user(requiredScopes = Nil)(request)).thenReturn(Future.successful(Right(user)))
   val config = ConfigFactory.load()
   val testUsernames = CreateTestUsernames.from(config)
-  val isTestUser = new IsTestUser(testUsernames)
+  val testUserChecker = new TestUserChecker(testUsernames)
 
-  val addGuIdentityHeaders = new AddGuIdentityHeaders(identityService, isTestUser)
+  def setup = {
+    val identityService = mock[IdentityAuthService]
+    when(identityService.user(requiredScopes = Nil)(request)).thenReturn(Future.successful(Right(user)))
+    val addGuIdentityHeaders = new AddGuIdentityHeaders(identityService, testUserChecker)
+    (identityService, addGuIdentityHeaders)
+  }
 
   val resultWithoutIdentityHeaders = Ok("testResult").withHeaders("previousHeader" -> "previousHeaderValue")
   val resultWithXGuIdentity = resultWithoutIdentityHeaders.withHeaders(XGuIdentityId -> "testUserId")
@@ -52,18 +56,21 @@ class AddGuIdentityHeadersTest extends Specification with IdiomaticMockito {
   "AddGuIdentityHeaders" should {
 
     "add headers for user " in {
+      val (_, addGuIdentityHeaders) = setup
       val actualResult = addGuIdentityHeaders.fromUser(resultWithoutIdentityHeaders, user)
       assertHeadersSet(actualResult)
     }
 
     "add headers for test user " in {
+      val (_, addGuIdentityHeaders) = setup
       val testUsername = testUsernames.generate()
-      val testUser = user.copy(username = Some(testUsername))
+      val testUser = user.copy(primaryEmailAddress = testUsername + "@thegulocal.com")
       val actualResult = addGuIdentityHeaders.fromUser(resultWithoutIdentityHeaders, testUser)
       assertHeadersSet(actualResult, testUser = true)
     }
 
     "detect if result has identity headers" in {
+      val (_, addGuIdentityHeaders) = setup
       addGuIdentityHeaders.hasIdentityHeaders(resultWithoutIdentityHeaders) should beEqualTo(false)
       addGuIdentityHeaders.hasIdentityHeaders(resultWithXGuIdentity) should beEqualTo(false)
       addGuIdentityHeaders.hasIdentityHeaders(resultWithXGuMembershipTestUser) should beEqualTo(false)
@@ -71,19 +78,28 @@ class AddGuIdentityHeadersTest extends Specification with IdiomaticMockito {
     }
 
     "detect test users" in {
-      val testUsername = testUsernames.generate()
-      val isTestUser = new IsTestUser(testUsernames)
-      isTestUser(Some(testUsername)) should beTrue
+      val testUsername = testUsernames.generate() + "@thegulocal.com"
+      val isTestUser = new TestUserChecker(testUsernames)
+      isTestUser.isTestUser(testUsername) should beTrue
+    }
+    "detect test users with subaddresses" in {
+      val testUsername = "test.user+" + testUsernames.generate() + "@thegulocal.com"
+      val isTestUser = new TestUserChecker(testUsernames)
+      isTestUser.isTestUser(testUsername) should beTrue
     }
     "detect non test users" in {
-      isTestUser(Some("not_a_test_user")) should beFalse
+      testUserChecker.isTestUser("not_a_test_user@thegulocal.com") should beFalse
     }
-    "consider empty username as non test user" in {
-      isTestUser(None) should beFalse
+    "detect non test users with subaddresses" in {
+      testUserChecker.isTestUser("not_a_test_user+blahblah@thegulocal.com") should beFalse
+    }
+    "not choke on an empty email address" in {
+      testUserChecker.isTestUser("") should beFalse
     }
   }
 
   "fromIdapiIfMissing should not change the headers or call idapi if the result already has identity headers" in {
+    val (identityService, addGuIdentityHeaders) = setup
     val futureActualResult = addGuIdentityHeaders.fromIdapiIfMissing(request, resultWithAllIdentityHeaders)
     val actualResult = Await.result(futureActualResult, 5.seconds)
     verifyNoInteractions(identityService)
@@ -91,6 +107,7 @@ class AddGuIdentityHeadersTest extends Specification with IdiomaticMockito {
   }
 
   "fromIdapiIfMissing should call idapi and set the headers if the result doesn't already have identity headers" in {
+    val (identityService, addGuIdentityHeaders) = setup
     val futureActualResult = addGuIdentityHeaders.fromIdapiIfMissing(request, resultWithoutIdentityHeaders)
     val actualResult = Await.result(futureActualResult, 5.seconds)
     verify(identityService, times(1)).user(requiredScopes = Nil)(request)
@@ -101,7 +118,7 @@ class AddGuIdentityHeadersTest extends Specification with IdiomaticMockito {
     val notFoundIdentityService = mock[IdentityAuthService]
     when(notFoundIdentityService.user(requiredScopes = Nil)(request)).thenReturn(Future.successful(Left(Unauthorised)))
 
-    val guIdentityHeaders = new AddGuIdentityHeaders(notFoundIdentityService, isTestUser)
+    val guIdentityHeaders = new AddGuIdentityHeaders(notFoundIdentityService, testUserChecker)
     val futureActualResult = guIdentityHeaders.fromIdapiIfMissing(request, resultWithoutIdentityHeaders)
     val actualResult = Await.result(futureActualResult, 5.seconds)
     verify(notFoundIdentityService, times(1)).user(requiredScopes = Nil)(request)


### PR DESCRIPTION
Apparently test users has been broken for a few years in manage.

Traditiainlly we have expected test users to put the special key in the first name field.  This should come through to the display name (along with the last name field separated by a space)

However since 2020 the display name has been populated by "user" by default, meaning that test users stopped working https://github.com/guardian/identity/pull/1701

This PR switches it to look in the email address instead.
The recommended format is `something+KEY@blah` or `KEY@blah` and it should handle both