### PR TITLE
fix test users to use email rather than first name

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,7 @@ import scala.util.Try
 
 val appVersion = "1.0-SNAPSHOT"
 name := "members-data-api"
+ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("releases") // libraries that haven't yet synced to maven central
 
 def commitId(): String =
   try { "git rev-parse HEAD".!!.trim }

--- a/membership-attribute-service/app/filters/TestUserChecker.scala
+++ b/membership-attribute-service/app/filters/TestUserChecker.scala
@@ -6,18 +6,11 @@ import com.gu.monitoring.SafeLogging
 
 class TestUserChecker(testUsernames: TestUsernames) extends SafeLogging {
   def isTestUser(primaryEmailAddress: String)(implicit logPrefix: LogPrefix): Boolean = {
-    val maybeValidTestUser = for {
-      localPart <- primaryEmailAddress.split('@').headOption
-      possibleTestUsername <- localPart.split('+').toList match {
-        case _ :: subAddress :: _ => Some(subAddress)
-        case noPlus :: Nil => Some(noPlus)
-        case _ => None // invalid email address - no @ sign
-      }
-    } yield testUsernames.isValid(possibleTestUsername)
-    if (maybeValidTestUser.contains(true)) {
+    val isTestUser = testUsernames.isValidEmail(primaryEmailAddress)
+    if (isTestUser) {
       logger.info(primaryEmailAddress + " is a test user")
     }
-    maybeValidTestUser.getOrElse(false)
+    isTestUser
   }
 
 }

--- a/membership-attribute-service/test/filters/AddGuIdentityHeadersTest.scala
+++ b/membership-attribute-service/test/filters/AddGuIdentityHeadersTest.scala
@@ -63,7 +63,7 @@ class AddGuIdentityHeadersTest extends Specification with IdiomaticMockito {
 
     "add headers for test user " in {
       val (_, addGuIdentityHeaders) = setup
-      val testUsername = testUsernames.generateEmail("test.user@thegulocal.com")
+      val testUsername = testUsernames.generateEmail(Some("test.user@thegulocal.com"))
       val testUser = user.copy(primaryEmailAddress = testUsername.email)
       val actualResult = addGuIdentityHeaders.fromUser(resultWithoutIdentityHeaders, testUser)
       assertHeadersSet(actualResult, testUser = true)
@@ -78,7 +78,7 @@ class AddGuIdentityHeadersTest extends Specification with IdiomaticMockito {
     }
 
     "detect test users" in {
-      val testUsername = testUsernames.generateEmail("test.user@thegulocal.com")
+      val testUsername = testUsernames.generateEmail(Some("test.user@thegulocal.com"))
       val isTestUser = new TestUserChecker(testUsernames)
       isTestUser.isTestUser(testUsername.email) should beTrue
     }

--- a/membership-attribute-service/test/filters/AddGuIdentityHeadersTest.scala
+++ b/membership-attribute-service/test/filters/AddGuIdentityHeadersTest.scala
@@ -63,8 +63,8 @@ class AddGuIdentityHeadersTest extends Specification with IdiomaticMockito {
 
     "add headers for test user " in {
       val (_, addGuIdentityHeaders) = setup
-      val testUsername = testUsernames.generate()
-      val testUser = user.copy(primaryEmailAddress = testUsername + "@thegulocal.com")
+      val testUsername = testUsernames.generateEmail("test.user@thegulocal.com")
+      val testUser = user.copy(primaryEmailAddress = testUsername.email)
       val actualResult = addGuIdentityHeaders.fromUser(resultWithoutIdentityHeaders, testUser)
       assertHeadersSet(actualResult, testUser = true)
     }
@@ -78,14 +78,9 @@ class AddGuIdentityHeadersTest extends Specification with IdiomaticMockito {
     }
 
     "detect test users" in {
-      val testUsername = testUsernames.generate() + "@thegulocal.com"
+      val testUsername = testUsernames.generateEmail("test.user@thegulocal.com")
       val isTestUser = new TestUserChecker(testUsernames)
-      isTestUser.isTestUser(testUsername) should beTrue
-    }
-    "detect test users with subaddresses" in {
-      val testUsername = "test.user+" + testUsernames.generate() + "@thegulocal.com"
-      val isTestUser = new TestUserChecker(testUsernames)
-      isTestUser.isTestUser(testUsername) should beTrue
+      isTestUser.isTestUser(testUsername.email) should beTrue
     }
     "detect non test users" in {
       testUserChecker.isTestUser("not_a_test_user@thegulocal.com") should beFalse

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
 
   val sentryLogback = "io.sentry" % "sentry-logback" % "7.2.0"
   val identityAuth = "com.gu.identity" %% "identity-auth-play" % "4.15"
-  val identityTestUsers = "com.gu" %% "identity-test-users" % "0.9"
+  val identityTestUsers = "com.gu" %% "identity-test-users" % "0.10.2-SNAPSHOT"
   val postgres = "org.postgresql" % "postgresql" % "42.7.2"
   val jdbc = PlayImport.jdbc
   val playWS = PlayImport.ws

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
 
   val sentryLogback = "io.sentry" % "sentry-logback" % "7.2.0"
   val identityAuth = "com.gu.identity" %% "identity-auth-play" % "4.15"
-  val identityTestUsers = "com.gu" %% "identity-test-users" % "0.10.2-SNAPSHOT"
+  val identityTestUsers = "com.gu" %% "identity-test-users" % "0.10.2"
   val postgres = "org.postgresql" % "postgresql" % "42.7.2"
   val jdbc = PlayImport.jdbc
   val playWS = PlayImport.ws


### PR DESCRIPTION
following on from #1088 which didn't work
This PR pulls in the updated test user library that will only use lower case tokens - https://github.com/guardian/identity-test-users/pull/10

I have tested locally using the browser direct to MDAPI and the X-Gu-Membership-Test-User header is correctly set to true or false depending on whether it's a test user.

If I try to get manage running locally, the /me/mma response is now correct (however I seem to have a setup issue causing an Oops error)

Testing:

If I hit MDAPI I can see the test users line only appears in the logs when I'm a test user 
`2024-07-09 12:55:12,291 TestUserChecker.scala:11 [INFO]: 123456: redacted.user+oudfhj53j323@guardian.co.uk is a test user`
(in DEV, the normal and test environments are the same so it's harder to test)