### PR TITLE
Give Feast access to newspaper subscribers

### DIFF
--- a/membership-attribute-service/app/models/FeastApp.scala
+++ b/membership-attribute-service/app/models/FeastApp.scala
@@ -26,7 +26,8 @@ object FeastApp {
       attributes.isPatronTier ||
       attributes.isGuardianPatron ||
       attributes.digitalSubscriberHasActivePlan ||
-      attributes.isSupporterPlus
+      attributes.isSupporterPlus ||
+      attributes.isPaperSubscriber
 
   private def isRecurringContributorWhoSubscribedBeforeFeastLaunch(attributes: Attributes) =
     attributes.isRecurringContributor && attributes.RecurringContributionAcquisitionDate.exists(isBeforeFeastLaunch)
@@ -35,8 +36,7 @@ object FeastApp {
     isRecurringContributorWhoSubscribedBeforeFeastLaunch(attributes) ||
       attributes.isPremiumLiveAppSubscriber ||
       attributes.isGuardianWeeklySubscriber ||
-      attributes.isSupporterTier ||
-      attributes.isPaperSubscriber
+      attributes.isSupporterTier
 
   private def shouldShowSubscriptionOptions(attributes: Attributes) = !shouldGetFeastAccess(attributes)
 

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -484,15 +484,13 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
              |{
              |  "userId": "$userWithNewspaperUserId",
              |  "paperSubscriptionExpiryDate":"${dateTimeInTheFuture.toLocalDate}",
-             |  "feastIosSubscriptionGroup": "${FeastApp.IosSubscriptionGroupIds.ExtendedTrial}",
-             |  "feastAndroidOfferTags": ["${FeastApp.AndroidOfferTags.ExtendedTrial}"],
              |  "showSupportMessaging": false,
              |  "contentAccess": {
              |    "member": false,
              |    "paidMember": false,
              |    "recurringContributor": false,
              |    "supporterPlus" : false,
-             |    "feast": false,
+             |    "feast": true,
              |    "digitalPack": true,
              |    "paperSubscriber": true,
              |    "guardianWeeklySubscriber": false,


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
We have made the decision to give Newspaper subscribers full digital benefits moving forward. They already receive most of these but were excluded from Feast access. This PR removes that exclusion.