### PR TITLE
don't error an unsupported plan for staff membership

### DIFF
--- a/membership-attribute-service/app/services/SupporterRatePlanToAttributesMapper.scala
+++ b/membership-attribute-service/app/services/SupporterRatePlanToAttributesMapper.scala
@@ -34,7 +34,10 @@ class SupporterRatePlanToAttributesMapper(stage: Stage) extends SafeLogging {
       .map(transformer => transformer.transform(_, ratePlanItem))
 
   private def logUnsupportedRatePlanId(ratePlanItem: DynamoSupporterRatePlanItem)(implicit logPrefix: LogPrefix): Option[Nothing] = {
-    logger.error(scrub"Unsupported product rate plan id: ${ratePlanItem.productRatePlanId}")
+    // this staff check is needed to tidy up the logs because we have not yet cancelled the staff in zuora
+    val staffPROD = "2c92a0f949efde7c0149f1f18162178e"
+    if (ratePlanItem.productRatePlanId != staffPROD)
+      logger.error(scrub"Unsupported product rate plan id: ${ratePlanItem.productRatePlanId}")
     None
   }
 


### PR DESCRIPTION
Back in this PR: https://github.com/guardian/members-data-api/pull/1072
i removed staff membership recognition from the whole of MDAPI.

However all the staff subscriptions in zuora still exist (for now - they need cancelling really)

However, there is a bit of logic that logs if a rate plan's product isn't in the catalog mappings that are in the code.

Since I deleted the mapping for staff, every time a staff member hits /me endpoint, we get an error logged:
`2024-07-30 08:47:09,031 SupporterRatePlanToAttributesMapper.scala:37 [ERROR]: redacted: Unsupported product rate plan id: 2c92a0f949efde7c0149f1f18162178e`

This PR specifically doesn't log this exact sitatuion, purely to clean up the logs.