### PR TITLE
filter out subscriptions with unknown products e.g. staff memberships

### DIFF
--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -200,18 +200,17 @@ class AccountController(
         for {
           catalog <- request.touchpoint.futureCatalog
           result <- paymentDetails(userId, filter, request.touchpoint).toEither
-            .map {
-              case Right(subscriptionList) =>
-                logger.info(s"Successfully retrieved payment details result for identity user: $userId")
-                val productsResponseWrites = new ProductsResponseWrites(catalog)
-                val response = productsResponseWrites.from(user, subscriptionList)
-                import productsResponseWrites.writes
-                Ok(Json.toJson(response))
-              case Left(message) =>
-                logger.warn(s"Unable to retrieve payment details result for identity user $userId due to $message")
-                InternalServerError("Failed to retrieve payment details due to an internal error")
-            }
-        } yield result
+        } yield result match {
+          case Right(subscriptionList) =>
+            logger.info(s"Successfully retrieved payment details result for identity user: $userId")
+            val productsResponseWrites = new ProductsResponseWrites(catalog)
+            val response = productsResponseWrites.from(user, subscriptionList)
+            import productsResponseWrites.writes
+            Ok(Json.toJson(response))
+          case Left(message) =>
+            logger.warn(s"Unable to retrieve payment details result for identity user $userId due to $message")
+            InternalServerError("Failed to retrieve payment details due to an internal error")
+        }
 
       }
     }

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -214,13 +214,13 @@ object AccountDetails {
   }
   def mmaCategoryFrom(product: Product): String = product match {
     case _: Product.Paper => "subscriptions" // Paper includes GW 🤦‍
-    case _: Product.ZDigipack => "subscriptions"
-    case _: Product.SupporterPlus => "recurringSupport"
-    case _: Product.TierThree => "recurringSupport"
-    case _: Product.GuardianPatron => "subscriptions"
-    case _: Product.Contribution => "recurringSupport"
-    case _: Product.Membership => "membership"
-    case _ => product.name // fallback
+    case Product.Digipack => "subscriptions"
+    case Product.SupporterPlus => "recurringSupport"
+    case Product.TierThree => "recurringSupport"
+    case Product.GuardianPatron => "subscriptions"
+    case Product.Contribution => "recurringSupport"
+    case Product.Membership => "membership"
+    case _ => "subscriptions" // fallback - passing undefined value breaks manage
   }
 }
 

--- a/membership-attribute-service/app/models/ExistingPaymentOption.scala
+++ b/membership-attribute-service/app/models/ExistingPaymentOption.scala
@@ -22,8 +22,8 @@ object ExistingPaymentOption {
 
     private def getSubscriptionFriendlyName(plan: RatePlan, catalog: Catalog): String = plan.product(catalog) match {
       case _: Product.Weekly => "Guardian Weekly"
-      case _: Product.Membership => plan.productName + " Membership"
-      case _: Product.Contribution => plan.name(catalog)
+      case Product.Membership => plan.productName + " Membership"
+      case Product.Contribution => plan.name(catalog)
       case _ => plan.productName // Newspaper & Digipack
     }
 

--- a/membership-common/src/main/scala/com/gu/memsub/ProductFamily.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/ProductFamily.scala
@@ -87,21 +87,6 @@ object Product {
     case _ => None
   }
 
-  type Membership = Membership.type
-  type GuardianPatron = GuardianPatron.type
-  type ZDigipack = Digipack.type
-  type SupporterPlus = SupporterPlus.type
-  type TierThree = TierThree.type
-  type Delivery = Delivery.type
-  type NationalDelivery = NationalDelivery.type
-  type Voucher = Voucher.type
-  type DigitalVoucher = DigitalVoucher.type
-  type WeeklyZoneA = WeeklyZoneA.type
-  type WeeklyZoneB = WeeklyZoneB.type
-  type WeeklyZoneC = WeeklyZoneC.type
-  type WeeklyDomestic = WeeklyDomestic.type
-  type WeeklyRestOfWorld = WeeklyRestOfWorld.type
-  type Contribution = Contribution.type
 }
 
 // Benefit is the catalog charge level ProductType__c


### PR DESCRIPTION
This PR follows on from the recent refactor PRs.

Staff membership is no longer defined or understood by MDAPI.

Previously this meant it was ignored.

However since the high level model was removed, all subscriptions are deserialised and retutned to the business logic, and the business logic is supposed to ignore what it doesn't like.  However in this case, the defunct staff membership was being returned to manage, with an `"mmaCategory": "UNKNOWN_PRODUCT"`. This broke the whole page!

This PR updates it to filter out all subscriptions that only have discounts and/or unknown products added.

Tested in CODE and seems to be working ok and displays the manage frontend.