### PR TITLE
feat: make MDAPI aware of new Stripe Membership USA account

### DIFF
--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -164,7 +164,7 @@ class TouchpointComponents(
     )
 
   lazy val chooseStripe: ChooseStripe = chooseStripeOverride.getOrElse(
-    ChooseStripe.createFor(backendConfig.stripeUKMembership, backendConfig.stripeAUMembership),
+    ChooseStripe.createFor(backendConfig.stripeUKMembership, backendConfig.stripeAUMembership, backendConfig.stripeUSMembership),
   )
 
   lazy val paymentDetailsForSubscription: PaymentDetailsForSubscription = new PaymentDetailsForSubscription(paymentService, futureCatalog)

--- a/membership-attribute-service/app/services/PaymentFailureAlerter.scala
+++ b/membership-attribute-service/app/services/PaymentFailureAlerter.scala
@@ -6,7 +6,7 @@ import com.gu.memsub.Subscription.AccountId
 import com.gu.memsub.subsv2.{Catalog, Subscription}
 import com.gu.monitoring.SafeLogger.LogPrefix
 import com.gu.monitoring.SafeLogging
-import com.gu.zuora.api.{RegionalStripeGateways, StripeAUMembershipGateway, StripeUKMembershipGateway}
+import com.gu.zuora.api.{RegionalStripeGateways, StripeAUMembershipGateway, StripeUKMembershipGateway, StripeUSMembershipGateway}
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
 import scalaz.syntax.std.boolean._
@@ -96,7 +96,8 @@ object PaymentFailureAlerter extends SafeLogging {
 
     val stillFreshInDays = 27
     def recentEnough(lastInvoiceDateTime: DateTime) = lastInvoiceDateTime.plusDays(stillFreshInDays).isAfterNow
-    val isActionablePaymentGateway = account.PaymentGateway.exists(gw => gw == StripeUKMembershipGateway || gw == StripeAUMembershipGateway)
+    val isActionablePaymentGateway =
+      account.PaymentGateway.exists(gw => gw == StripeUKMembershipGateway || gw == StripeAUMembershipGateway || gw == StripeUSMembershipGateway)
 
     def hasFailureForCreditCardPaymentMethod(paymentMethodId: PaymentMethodId): Future[Either[String, Boolean]] = {
       val eventualPaymentMethod: Future[Either[String, PaymentMethodResponse]] = paymentMethodGetter(paymentMethodId)

--- a/membership-attribute-service/app/services/stripe/ChooseStripe.scala
+++ b/membership-attribute-service/app/services/stripe/ChooseStripe.scala
@@ -10,22 +10,26 @@ import scala.concurrent.ExecutionContext
 case class StripePublicKey(key: String)
 
 object ChooseStripe {
-  def createFor(ukStripeConfig: StripeServiceConfig, auServiceConfig: StripeServiceConfig)(implicit
+  def createFor(ukStripeConfig: StripeServiceConfig, auServiceConfig: StripeServiceConfig, usServiceConfig: StripeServiceConfig)(implicit
       ec: ExecutionContext,
   ): ChooseStripe = {
     val ukStripePublicKey: StripePublicKey = StripePublicKey(ukStripeConfig.credentials.publicKey)
     val auStripePublicKey: StripePublicKey = StripePublicKey(auServiceConfig.credentials.publicKey)
+    val usStripePublicKey: StripePublicKey = StripePublicKey(usServiceConfig.credentials.publicKey)
 
     val ukStripeService: StripeService = createStripeServiceFor(ukStripeConfig)
     val auStripeService: StripeService = createStripeServiceFor(auServiceConfig)
+    val usStripeService: StripeService = createStripeServiceFor(usServiceConfig)
 
     val stripePublicKeyByCountry: Map[Country, StripePublicKey] = Map(
       Country.UK -> ukStripePublicKey,
       Country.Australia -> auStripePublicKey,
+      Country.US -> usStripePublicKey,
     )
     val stripeServicesByPublicKey: Map[StripePublicKey, StripeService] = Map(
       ukStripePublicKey -> ukStripeService,
       auStripePublicKey -> auStripeService,
+      usStripePublicKey -> usStripeService,
     )
     new ChooseStripe(stripePublicKeyByCountry, ukStripePublicKey, stripeServicesByPublicKey)
   }

--- a/membership-common/conf/touchpoint.CODE.conf
+++ b/membership-common/conf/touchpoint.CODE.conf
@@ -34,6 +34,10 @@ touchpoint.backend.environments {
                 secret = ""
                 public = "pk_test_m0sjR1tGM22fpaz48csa49us"
             },
+            us-membership.key {
+                secret = ""
+                public = "pk_test_51PRElqIBwJUYhy0IWUNDmaka3qeQJzTed3vHKURsqtIYFI4DwEQWVjFDA94yseRUjMkR1TL1WpjIAq3wycXrIeZ400Ptp1gY2r"
+            },
             au-contributions.key {
                 secret = ""
                 public = "pk_test_I1ts3iShWrjssTavL0b7QXQ6"

--- a/membership-common/conf/touchpoint.PROD.conf
+++ b/membership-common/conf/touchpoint.PROD.conf
@@ -19,6 +19,10 @@ touchpoint.backend.environments {
                 secret = ""
                 public = "pk_live_57xV50eFjPIA990PEGWJwoHp"
             },
+            us-membership.key {
+                secret = ""
+                public = "pk_live_51PRElqIBwJUYhy0IEHvAAmdxqho5H6nOpzlJ8bkbiVJ7VHjx1TKXKI0tZa7HVP6WUPSZLJJKewUUl0At9p5ilJds00Mu4WKBgS"
+            },
             au-contributions.key {
                 secret = ""
                 public = "pk_live_HRYGcMzpbqY7ehLuUkdqvIDE"

--- a/membership-common/src/main/scala/com/gu/touchpoint/TouchpointBackendConfig.scala
+++ b/membership-common/src/main/scala/com/gu/touchpoint/TouchpointBackendConfig.scala
@@ -13,6 +13,7 @@ case class TouchpointBackendConfig(
     stripePatrons: BasicStripeServiceConfig,
     stripeUKMembership: StripeServiceConfig,
     stripeAUMembership: StripeServiceConfig,
+    stripeUSMembership: StripeServiceConfig,
     zuoraSoap: ZuoraSoapConfig,
     zuoraRest: ZuoraRestConfig,
     idapi: IdapiConfig,
@@ -29,6 +30,7 @@ object TouchpointBackendConfig extends SafeLogging {
       BasicStripeServiceConfig.from(envBackendConf, "patrons"),
       StripeServiceConfig.from(envBackendConf, environmentName, Country.UK), // uk-membership
       StripeServiceConfig.from(envBackendConf, environmentName, Country.Australia, variant = "au-membership"),
+      StripeServiceConfig.from(envBackendConf, environmentName, Country.US, variant = "us-membership"),
       ZuoraApiConfig.soap(envBackendConf, environmentName),
       ZuoraApiConfig.rest(envBackendConf, environmentName),
       IdapiConfig.from(envBackendConf, environmentName),

--- a/membership-common/src/main/scala/com/gu/zuora/api/PaymentGateway.scala
+++ b/membership-common/src/main/scala/com/gu/zuora/api/PaymentGateway.scala
@@ -23,6 +23,14 @@ case object StripeAUPaymentIntentsMembershipGateway extends PaymentGateway {
   val gatewayName = "Stripe PaymentIntents GNM Membership AUS"
   override val forCountry = Some(Country.Australia)
 }
+case object StripeUSMembershipGateway extends PaymentGateway {
+  val gatewayName = "Stripe Gateway GNM Membership USA"
+  override val forCountry = Some(Country.US)
+}
+case object StripeUSPaymentIntentsMembershipGateway extends PaymentGateway {
+  val gatewayName = "Stripe PaymentIntents GNM Membership USA"
+  override val forCountry = Some(Country.US)
+}
 case object GoCardlessGateway extends PaymentGateway {
   val gatewayName = "GoCardless"
 }
@@ -38,8 +46,10 @@ object PaymentGateway {
   private val gatewaysByName = Set(
     StripeUKMembershipGateway,
     StripeAUMembershipGateway,
+    StripeUSMembershipGateway,
     StripeUKPaymentIntentsMembershipGateway,
     StripeAUPaymentIntentsMembershipGateway,
+    StripeUSPaymentIntentsMembershipGateway,
     GoCardlessGateway,
     GoCardlessZuoraInstance,
     PayPal,
@@ -48,8 +58,14 @@ object PaymentGateway {
 }
 
 object RegionalStripeGateways {
-  def getGatewayForCountry(country: Country): PaymentGateway =
-    if (country == Country.Australia) StripeAUMembershipGateway else StripeUKMembershipGateway
-  def getPaymentIntentsGatewayForCountry(country: Country): PaymentGateway =
-    if (country == Country.Australia) StripeAUPaymentIntentsMembershipGateway else StripeUKPaymentIntentsMembershipGateway
+  def getGatewayForCountry(country: Country): PaymentGateway = country match {
+    case Country.Australia => StripeAUMembershipGateway
+    case Country.US => StripeUSMembershipGateway
+    case _ => StripeUKMembershipGateway
+  }
+  def getPaymentIntentsGatewayForCountry(country: Country): PaymentGateway = country match {
+    case Country.Australia => StripeAUPaymentIntentsMembershipGateway
+    case Country.US => StripeUSPaymentIntentsMembershipGateway
+    case _ => StripeUKPaymentIntentsMembershipGateway
+  }
 }


### PR DESCRIPTION
## What does this change?

[Trello](https://trello.com/c/z9jACK9Q/223-make-mdapi-aware-of-new-stripe-usa-account)

This adds the new Membership USA Stripe account gateway to MDAPI, to be used if country is United States.

## Other changes not in code

The following S3 files have been updated with the new Stripe Membership USA account keys (all environments):
- members-data-api.private.conf

## Why are you doing this?

As part of KD2 for optimising “interchange” (aka “over the Atlantic”) network charges with Stripe ([SR Platform - Q2 FY 2024/25 OKR Submission](https://docs.google.com/document/d/1Eo4ge2awFMBZL1H4dDqqfYrGTiVS5_H0lQ75KygUQgM/edit#heading=h.d6f3idk6a29j)).

## Notes

- PR to be merged after [related PR in manage-frontend](https://github.com/guardian/manage-frontend/pull/1371)