### PR TITLE
Correct the feast launch date 

### DIFF
--- a/membership-attribute-service/app/models/FeastApp.scala
+++ b/membership-attribute-service/app/models/FeastApp.scala
@@ -6,7 +6,7 @@ import scalaz.Scalaz.ToBooleanOpsFromBoolean
 
 object FeastApp {
 
-  val FeastIosLaunchDate = LocalDate.parse("2024-04-01")
+  val FeastFullLaunchDate = LocalDate.parse("2024-07-10")
 
   object IosSubscriptionGroupIds {
     // Subscription group ids are used by the app to tell the app store which subscription option to show to the user
@@ -19,7 +19,7 @@ object FeastApp {
     val ExtendedTrial = "initial_supporter_launch_offer"
   }
 
-  private def isBeforeFeastLaunch(dt: LocalDate): Boolean = dt.isBefore(FeastIosLaunchDate)
+  private def isBeforeFeastLaunch(dt: LocalDate): Boolean = dt.isBefore(FeastFullLaunchDate)
 
   def shouldGetFeastAccess(attributes: Attributes): Boolean =
     attributes.isPartnerTier ||

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -32,7 +32,7 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
   implicit val as: ActorSystem = ActorSystem("test")
 
   private val dateTimeInTheFuture = DateTime.now().plusDays(1)
-  private val dateBeforeFeastLaunch = FeastApp.FeastIosLaunchDate.minusDays(1)
+  private val dateBeforeFeastLaunch = FeastApp.FeastFullLaunchDate.minusDays(1)
   private val validUserId = "1"
   private val userWithoutAttributesUserId = "2"
   private val userWithRecurringContributionUserId = "3"


### PR DESCRIPTION
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
Recurring contributors are eligible for an extended trial for Feast, but only if they signed up as supporters before the Feast launch date. Previously the launch date we worked this out from was the iOS launch date, but this should have been updated to the Android launch date when that was released.
