### PR TITLE
infra: EC2 instances should use Instance Metadata Service Version 2 (IMDSv2)

### DIFF
--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -12,6 +12,8 @@ Parameters:
     AllowedValues:
     - t4g.small
     ConstraintDescription: must be a valid EC2 instance type.
+  MetadataOptions:
+    HttpTokens: required
   VpcId:
     Description: ID of the VPC onto which to launch the application
     Type: AWS::EC2::VPC::Id

--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -12,8 +12,6 @@ Parameters:
     AllowedValues:
     - t4g.small
     ConstraintDescription: must be a valid EC2 instance type.
-  MetadataOptions:
-    HttpTokens: required
   VpcId:
     Description: ID of the VPC onto which to launch the application
     Type: AWS::EC2::VPC::Id
@@ -228,6 +226,8 @@ Resources:
       - Ref: SecurityGroupForPostgres
       InstanceType:
         Ref: InstanceType
+      MetadataOptions:
+        HttpTokens: required
       AssociatePublicIpAddress: 'False'
       IamInstanceProfile:
         Ref: InstanceProfile


### PR DESCRIPTION
## What does this change?

[Trello](https://trello.com/c/te6kPgNR/346-aws-fsbp-high-vulnerabilities-auto-scaling-group-launch-configurations-should-configure-ec2-instances-to-require-instance-metada)

EC2 instances should use Instance Metadata Service Version 2 (IMDSv2).

## Why are you making this change?

This is part of new obligations for fixing AWS vulnerabilities.

See [document](https://docs.google.com/document/d/1Q_ts5mbRvASCGo3UfsPHwUVvSXc3f2fkK2Fwp6N9Pxc/edit?tab=t.0#heading=h.64oh0k2bzslf) for more details.

## How to test

Before:
<img width="443" alt="Screenshot 2024-11-04 at 12 14 12" src="https://github.com/user-attachments/assets/b8bda57a-59a7-49a0-b33c-19eda5c9e502">

After deploying the branch to CODE:
<img width="140" alt="Screenshot 2024-11-04 at 12 14 29" src="https://github.com/user-attachments/assets/b5fccda3-cb98-4d5f-a610-0fb404180a3d">