### PR TITLE
build: update okta-jwt-verifier-impl to fix com.squareup.okio:okio-jvm vulnerability

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,7 +30,7 @@ object Dependencies {
   val jacksonVersion = "2.15.0"
   val jacksonDatabindVersion = "2.15.0"
   val akkaHttpCore = "com.typesafe.akka" %% "akka-http-core" % "10.2.9"
-  val oktaJwtVerifierVersion = "0.5.7"
+  val oktaJwtVerifierVersion = "0.5.8"
   val jackson = Seq(
     "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
     "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,


### PR DESCRIPTION
## What does this change?

[Trello](https://trello.com/c/nGl3ZcFF/377-upgrade-amazonawssdkdynamodb-to-fix-vulnerability-in-contributions-platform)

Update `okta-jwt-verifier-impl` to fix `com.squareup.okio:okio-jvm` vulnerability.

https://app.snyk.io/org/guardian-portfolio-and-platform/project/f3cf5e53-df63-4df1-b825-0282abe5f604

<img width="980" alt="Screenshot 2024-11-21 at 16 02 32" src="https://github.com/user-attachments/assets/994f3e70-ede5-4642-ba3e-24b3316ae48b">
