### PR TITLE
Remove extended Feast free trial period for existing subscribers

### DIFF
--- a/membership-attribute-service/app/models/FeastApp.scala
+++ b/membership-attribute-service/app/models/FeastApp.scala
@@ -1,8 +1,7 @@
 package models
 
-import models.FeastApp.IosSubscriptionGroupIds.{ExtendedTrial, RegularSubscription}
+import models.FeastApp.IosSubscriptionGroupIds.IntroductoryOffer
 import org.joda.time.LocalDate
-import scalaz.Scalaz.ToBooleanOpsFromBoolean
 
 object FeastApp {
 
@@ -10,13 +9,12 @@ object FeastApp {
 
   object IosSubscriptionGroupIds {
     // Subscription group ids are used by the app to tell the app store which subscription option to show to the user
-    val ExtendedTrial = "21445388"
-    val RegularSubscription = "21396030"
+    val IntroductoryOffer = "21396030"
   }
 
   object AndroidOfferTags {
     // Offer tags are the Android equivalent of iOS subscription groups - used by the app to work out which offer to show to the user
-    val ExtendedTrial = "initial_supporter_launch_offer"
+    val IntroductoryOffer = "initial_supporter_launch_offer"
   }
 
   private def isBeforeFeastLaunch(dt: LocalDate): Boolean = dt.isBefore(FeastFullLaunchDate)
@@ -29,26 +27,15 @@ object FeastApp {
       attributes.isSupporterPlus ||
       attributes.isPaperSubscriber
 
-  private def isRecurringContributorWhoSubscribedBeforeFeastLaunch(attributes: Attributes) =
-    attributes.isRecurringContributor && attributes.RecurringContributionAcquisitionDate.exists(isBeforeFeastLaunch)
-
-  private def shouldGetFreeTrial(attributes: Attributes) =
-    isRecurringContributorWhoSubscribedBeforeFeastLaunch(attributes) ||
-      attributes.isPremiumLiveAppSubscriber ||
-      attributes.isGuardianWeeklySubscriber ||
-      attributes.isSupporterTier
-
   private def shouldShowSubscriptionOptions(attributes: Attributes) = !shouldGetFeastAccess(attributes)
 
   def getFeastIosSubscriptionGroup(attributes: Attributes): Option[String] =
-    shouldShowSubscriptionOptions(attributes).option(
-      if (shouldGetFreeTrial(attributes))
-        ExtendedTrial
-      else
-        RegularSubscription,
-    )
+    if (shouldShowSubscriptionOptions(attributes))
+      Some(IntroductoryOffer)
+    else None
+
   def getFeastAndroidOfferTags(attributes: Attributes): Option[List[String]] =
-    if (shouldShowSubscriptionOptions(attributes) && shouldGetFreeTrial(attributes))
-      Some(List(AndroidOfferTags.ExtendedTrial))
+    if (shouldShowSubscriptionOptions(attributes))
+      Some(List(AndroidOfferTags.IntroductoryOffer))
     else None
 }

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -395,7 +395,8 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
                      |{
                      |  "userId": "$userWithoutAttributesUserId",
                      |  "showSupportMessaging": true,
-                     |  "feastIosSubscriptionGroup": "${FeastApp.IosSubscriptionGroupIds.RegularSubscription}",
+                     |  "feastIosSubscriptionGroup": "${FeastApp.IosSubscriptionGroupIds.IntroductoryOffer}",
+                     |  "feastAndroidOfferTags": ["${FeastApp.AndroidOfferTags.IntroductoryOffer}"],
                      |  "contentAccess": {
                      |    "member": false,
                      |    "paidMember": false,
@@ -422,8 +423,8 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
              |{
              |  "userId": "$userWithRecurringContributionUserId",
              |  "showSupportMessaging": false,
-             |  "feastIosSubscriptionGroup": "${FeastApp.IosSubscriptionGroupIds.ExtendedTrial}",
-             |  "feastAndroidOfferTags": ["${FeastApp.AndroidOfferTags.ExtendedTrial}"],
+             |  "feastIosSubscriptionGroup": "${FeastApp.IosSubscriptionGroupIds.IntroductoryOffer}",
+             |  "feastAndroidOfferTags": ["${FeastApp.AndroidOfferTags.IntroductoryOffer}"],
              |  "recurringContributionPaymentPlan":"Monthly Contribution",
              |  "recurringContributionAcquisitionDate":"$dateBeforeFeastLaunch",
              |  "contentAccess": {
@@ -454,8 +455,8 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
              |  "userId": "$userWithLiveAppUserId",
              |  "liveAppSubscriptionExpiryDate":"${dateTimeInTheFuture.toLocalDate}",
              |  "showSupportMessaging": false,
-             |  "feastIosSubscriptionGroup": "${FeastApp.IosSubscriptionGroupIds.ExtendedTrial}",
-             |  "feastAndroidOfferTags": ["${FeastApp.AndroidOfferTags.ExtendedTrial}"],
+             |  "feastIosSubscriptionGroup": "${FeastApp.IosSubscriptionGroupIds.IntroductoryOffer}",
+             |  "feastAndroidOfferTags": ["${FeastApp.AndroidOfferTags.IntroductoryOffer}"],
              |  "contentAccess": {
              |    "member": false,
              |    "paidMember": false,
@@ -544,8 +545,8 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
              |  "userId": "$userWithGuardianWeeklyUserId",
              |  "guardianWeeklyExpiryDate":"${dateTimeInTheFuture.toLocalDate}",
              |  "showSupportMessaging": false,
-             |  "feastIosSubscriptionGroup": "${FeastApp.IosSubscriptionGroupIds.ExtendedTrial}",
-             |  "feastAndroidOfferTags": ["${FeastApp.AndroidOfferTags.ExtendedTrial}"],
+             |  "feastIosSubscriptionGroup": "${FeastApp.IosSubscriptionGroupIds.IntroductoryOffer}",
+             |  "feastAndroidOfferTags": ["${FeastApp.AndroidOfferTags.IntroductoryOffer}"],
              |  "contentAccess": {
              |    "member": false,
              |    "paidMember": false,


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
When we initially launched the Feast app, we gave an extended free trial period to users who have a subscription to some of our other products. 

This is now being reduced to the 14 day free trial offered to all new users, because we could only offer an extended trial as a one-off 'gift' to this cohort (from a legal and tax perspective), rather than an ongoing benefit.

This PR removes the extended free trial from the /user-attributes/me response and tidies up.