### PR TITLE
Guardian Light - Update tests to match what is currently in main

### DIFF
--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -411,24 +411,24 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
       val jsonBody = contentAsJson(result)
       jsonBody shouldEqual
         Json.parse(s"""
-                     |{
-                     |  "userId": "$userWithoutAttributesUserId",
-                     |  "showSupportMessaging": true,
-                     |  "feastIosSubscriptionGroup": "${FeastApp.IosSubscriptionGroupIds.IntroductoryOffer}",
-                     |  "feastAndroidOfferTags": ["${FeastApp.AndroidOfferTags.IntroductoryOffer}"],
-                     |  "contentAccess": {
-                     |    "member": false,
-                     |    "paidMember": false,
-                     |    "recurringContributor": false,
-                     |    "supporterPlus" : false,
-                     |    "feast": false,
-                     |    "digitalPack": false,
-                     |    "paperSubscriber": false,
-                     |    "guardianWeeklySubscriber": false,
-                     |    "guardianPatron": false,
-                     |    "guardianLight":false
-                     |  }
-                     |}""".stripMargin)
+                       |{
+                       |  "userId": "$userWithoutAttributesUserId",
+                       |  "showSupportMessaging": true,
+                       |  "feastIosSubscriptionGroup": "${FeastApp.IosSubscriptionGroupIds.IntroductoryOffer}",
+                       |  "feastAndroidOfferTags": ["${FeastApp.AndroidOfferTags.IntroductoryOffer}"],
+                       |  "contentAccess": {
+                       |    "member": false,
+                       |    "paidMember": false,
+                       |    "recurringContributor": false,
+                       |    "supporterPlus" : false,
+                       |    "feast": false,
+                       |    "digitalPack": false,
+                       |    "paperSubscriber": false,
+                       |    "guardianWeeklySubscriber": false,
+                       |    "guardianPatron": false,
+                       |    "guardianLight":false
+                       |  }
+                       |}""".stripMargin)
       verifyIdentityHeadersSet(result, userWithoutAttributesUserId)
 
     }
@@ -440,26 +440,26 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
       val jsonBody = contentAsJson(result)
       jsonBody shouldEqual
         Json.parse(s"""
-             |{
-             |  "userId": "$userWithRecurringContributionUserId",
-             |  "showSupportMessaging": false,
-             |  "feastIosSubscriptionGroup": "${FeastApp.IosSubscriptionGroupIds.IntroductoryOffer}",
-             |  "feastAndroidOfferTags": ["${FeastApp.AndroidOfferTags.IntroductoryOffer}"],
-             |  "recurringContributionPaymentPlan":"Monthly Contribution",
-             |  "recurringContributionAcquisitionDate":"$dateBeforeFeastLaunch",
-             |  "contentAccess": {
-             |    "member": false,
-             |    "paidMember": false,
-             |    "recurringContributor": true,
-             |    "supporterPlus" : false,
-             |    "feast": false,
-             |    "digitalPack": false,
-             |    "paperSubscriber": false,
-             |    "guardianWeeklySubscriber": false,
-             |    "guardianPatron": false,
-             |    "guardianLight": false
-             |  }
-             |}""".stripMargin)
+               |{
+               |  "userId": "$userWithRecurringContributionUserId",
+               |  "showSupportMessaging": false,
+               |  "feastIosSubscriptionGroup": "${FeastApp.IosSubscriptionGroupIds.IntroductoryOffer}",
+               |  "feastAndroidOfferTags": ["${FeastApp.AndroidOfferTags.IntroductoryOffer}"],
+               |  "recurringContributionPaymentPlan":"Monthly Contribution",
+               |  "recurringContributionAcquisitionDate":"$dateBeforeFeastLaunch",
+               |  "contentAccess": {
+               |    "member": false,
+               |    "paidMember": false,
+               |    "recurringContributor": true,
+               |    "supporterPlus" : false,
+               |    "feast": false,
+               |    "digitalPack": false,
+               |    "paperSubscriber": false,
+               |    "guardianWeeklySubscriber": false,
+               |    "guardianPatron": false,
+               |    "guardianLight": false
+               |  }
+               |}""".stripMargin)
       verifyIdentityHeadersSet(result, userWithRecurringContributionUserId)
 
     }
@@ -472,25 +472,25 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
       val jsonBody = contentAsJson(result)
       jsonBody shouldEqual
         Json.parse(s"""
-             |{
-             |  "userId": "$userWithLiveAppUserId",
-             |  "liveAppSubscriptionExpiryDate":"${dateTimeInTheFuture.toLocalDate}",
-             |  "showSupportMessaging": false,
-             |  "feastIosSubscriptionGroup": "${FeastApp.IosSubscriptionGroupIds.IntroductoryOffer}",
-             |  "feastAndroidOfferTags": ["${FeastApp.AndroidOfferTags.IntroductoryOffer}"],
-             |  "contentAccess": {
-             |    "member": false,
-             |    "paidMember": false,
-             |    "recurringContributor": false,
-             |    "supporterPlus" : false,
-             |    "feast": false,
-             |    "digitalPack": false,
-             |    "paperSubscriber": false,
-             |    "guardianWeeklySubscriber": false,
-             |    "guardianPatron": false,
-             |    "guardianLight": false
-             |  }
-             |}""".stripMargin)
+               |{
+               |  "userId": "$userWithLiveAppUserId",
+               |  "liveAppSubscriptionExpiryDate":"${dateTimeInTheFuture.toLocalDate}",
+               |  "showSupportMessaging": false,
+               |  "feastIosSubscriptionGroup": "${FeastApp.IosSubscriptionGroupIds.IntroductoryOffer}",
+               |  "feastAndroidOfferTags": ["${FeastApp.AndroidOfferTags.IntroductoryOffer}"],
+               |  "contentAccess": {
+               |    "member": false,
+               |    "paidMember": false,
+               |    "recurringContributor": false,
+               |    "supporterPlus" : false,
+               |    "feast": false,
+               |    "digitalPack": false,
+               |    "paperSubscriber": false,
+               |    "guardianWeeklySubscriber": false,
+               |    "guardianPatron": false,
+               |    "guardianLight": false
+               |  }
+               |}""".stripMargin)
       verifyIdentityHeadersSet(result, userWithLiveAppUserId)
 
     }
@@ -504,23 +504,23 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
       println(Json.prettyPrint(jsonBody))
       jsonBody shouldEqual
         Json.parse(s"""
-             |{
-             |  "userId": "$userWithNewspaperUserId",
-             |  "paperSubscriptionExpiryDate":"${dateTimeInTheFuture.toLocalDate}",
-             |  "showSupportMessaging": false,
-             |  "contentAccess": {
-             |    "member": false,
-             |    "paidMember": false,
-             |    "recurringContributor": false,
-             |    "supporterPlus" : false,
-             |    "feast": true,
-             |    "digitalPack": true,
-             |    "paperSubscriber": true,
-             |    "guardianWeeklySubscriber": false,
-             |    "guardianPatron": false,
-             |    "guardianLight":false
-             |  }
-             |}""".stripMargin)
+               |{
+               |  "userId": "$userWithNewspaperUserId",
+               |  "paperSubscriptionExpiryDate":"${dateTimeInTheFuture.toLocalDate}",
+               |  "showSupportMessaging": false,
+               |  "contentAccess": {
+               |    "member": false,
+               |    "paidMember": false,
+               |    "recurringContributor": false,
+               |    "supporterPlus" : false,
+               |    "feast": true,
+               |    "digitalPack": true,
+               |    "paperSubscriber": true,
+               |    "guardianWeeklySubscriber": false,
+               |    "guardianPatron": false,
+               |    "guardianLight":false
+               |  }
+               |}""".stripMargin)
       verifyIdentityHeadersSet(result, userWithNewspaperUserId)
 
     }
@@ -534,24 +534,24 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
       println(Json.prettyPrint(jsonBody))
       jsonBody shouldEqual
         Json.parse(s"""
-                      |{
-                      |  "userId": "$userWithNewspaperPlusUserId",
-                      |  "digitalSubscriptionExpiryDate":"${dateTimeInTheFuture.toLocalDate}",
-                      |  "paperSubscriptionExpiryDate":"${dateTimeInTheFuture.toLocalDate}",
-                      |  "showSupportMessaging": false,
-                      |  "contentAccess": {
-                      |    "member": false,
-                      |    "paidMember": false,
-                      |    "recurringContributor": false,
-                      |    "supporterPlus" : false,
-                      |    "feast": true,
-                      |    "digitalPack": true,
-                      |    "paperSubscriber": true,
-                      |    "guardianWeeklySubscriber": false,
-                      |    "guardianPatron": false,
-                      |    "guardianLight":false
-                      |  }
-                      |}""".stripMargin)
+                        |{
+                        |  "userId": "$userWithNewspaperPlusUserId",
+                        |  "digitalSubscriptionExpiryDate":"${dateTimeInTheFuture.toLocalDate}",
+                        |  "paperSubscriptionExpiryDate":"${dateTimeInTheFuture.toLocalDate}",
+                        |  "showSupportMessaging": false,
+                        |  "contentAccess": {
+                        |    "member": false,
+                        |    "paidMember": false,
+                        |    "recurringContributor": false,
+                        |    "supporterPlus" : false,
+                        |    "feast": true,
+                        |    "digitalPack": true,
+                        |    "paperSubscriber": true,
+                        |    "guardianWeeklySubscriber": false,
+                        |    "guardianPatron": false,
+                        |    "guardianLight":false
+                        |  }
+                        |}""".stripMargin)
       verifyIdentityHeadersSet(result, userWithNewspaperPlusUserId)
 
     }
@@ -565,25 +565,25 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
       println(Json.prettyPrint(jsonBody))
       jsonBody shouldEqual
         Json.parse(s"""
-             |{
-             |  "userId": "$userWithGuardianWeeklyUserId",
-             |  "guardianWeeklyExpiryDate":"${dateTimeInTheFuture.toLocalDate}",
-             |  "showSupportMessaging": false,
-             |  "feastIosSubscriptionGroup": "${FeastApp.IosSubscriptionGroupIds.IntroductoryOffer}",
-             |  "feastAndroidOfferTags": ["${FeastApp.AndroidOfferTags.IntroductoryOffer}"],
-             |  "contentAccess": {
-             |    "member": false,
-             |    "paidMember": false,
-             |    "recurringContributor": false,
-             |    "supporterPlus" : false,
-             |    "feast": false,
-             |    "digitalPack": false,
-             |    "paperSubscriber": false,
-             |    "guardianWeeklySubscriber": true,
-             |    "guardianPatron": false,
-             |    "guardianLight":false
-             |  }
-             |}""".stripMargin)
+               |{
+               |  "userId": "$userWithGuardianWeeklyUserId",
+               |  "guardianWeeklyExpiryDate":"${dateTimeInTheFuture.toLocalDate}",
+               |  "showSupportMessaging": false,
+               |  "feastIosSubscriptionGroup": "${FeastApp.IosSubscriptionGroupIds.IntroductoryOffer}",
+               |  "feastAndroidOfferTags": ["${FeastApp.AndroidOfferTags.IntroductoryOffer}"],
+               |  "contentAccess": {
+               |    "member": false,
+               |    "paidMember": false,
+               |    "recurringContributor": false,
+               |    "supporterPlus" : false,
+               |    "feast": false,
+               |    "digitalPack": false,
+               |    "paperSubscriber": false,
+               |    "guardianWeeklySubscriber": true,
+               |    "guardianPatron": false,
+               |    "guardianLight":false
+               |  }
+               |}""".stripMargin)
       verifyIdentityHeadersSet(result, userWithGuardianWeeklyUserId)
 
     }
@@ -630,7 +630,8 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
              |  "userId": "$userWithGuardianLightUserId",
              |  "guardianLightExpiryDate":"${dateTimeInTheFuture.toLocalDate}",
              |  "showSupportMessaging": true,
-             |  "feastIosSubscriptionGroup": "${FeastApp.IosSubscriptionGroupIds.RegularSubscription}",
+             |  "feastIosSubscriptionGroup": "${FeastApp.IosSubscriptionGroupIds.IntroductoryOffer}",
+             |  "feastAndroidOfferTags": ["${FeastApp.AndroidOfferTags.IntroductoryOffer}"],
              |  "contentAccess": {
              |    "member": false,
              |    "paidMember": false,

--- a/membership-attribute-service/test/models/ProductsResponseSpec.scala
+++ b/membership-attribute-service/test/models/ProductsResponseSpec.scala
@@ -227,14 +227,11 @@ class ProductsResponseSpec extends Specification with SafeLogging {
 
       val subscription = Subscription(
         id = Id(subId),
-        name = Name(subNumber),
+        subscriptionNumber = SubscriptionNumber(subNumber),
         accountId = AccountId(accountId),
-        startDate = LocalDate.parse(startDate),
-        acceptanceDate = LocalDate.parse(startDate),
-        termStartDate = LocalDate.parse(startDate),
+        contractEffectiveDate = LocalDate.parse(startDate),
+        customerAcceptanceDate = LocalDate.parse(startDate),
         termEndDate = LocalDate.parse(endDate),
-        casActivationDate = None,
-        promoCode = None,
         isCancelled = false,
         ratePlans = List(
           RatePlan(
@@ -243,7 +240,6 @@ class ProductsResponseSpec extends Specification with SafeLogging {
             productName,
             lastChangeType = None,
             features = List(),
-            chargedThroughDate = Some(LocalDate.parse(nextInvoiceDate)),
             ratePlanCharges = NonEmptyList(
               RatePlanCharge(
                 SubscriptionRatePlanChargeId("lklklk"),
@@ -254,14 +250,14 @@ class ProductsResponseSpec extends Specification with SafeLogging {
                 SubscriptionEnd,
                 None,
                 None,
+                Some(LocalDate.parse(nextInvoiceDate)),
+                LocalDate.parse(startDate),
+                LocalDate.parse(endDate),
               ),
             ),
-            start = LocalDate.parse(startDate),
-            end = LocalDate.parse(endDate),
           ),
         ),
         readerType = Direct,
-        gifteeIdentityId = None,
         autoRenew = true,
       )
 


### PR DESCRIPTION
### Why do we need this?

Deployment of [Add Guardian Light to members-data-api #1105](https://github.com/guardian/members-data-api/pull/1105) failed because the branch wasn't up to date with main. 

This branch contains fixes to update object references to match the object definitions in main, so deployment should succeed