### PR TITLE
log catalog fetch failures together with identity id

### DIFF
--- a/membership-attribute-service/app/services/PaymentDetailsForSubscription.scala
+++ b/membership-attribute-service/app/services/PaymentDetailsForSubscription.scala
@@ -12,14 +12,14 @@ import services.zuora.payment.PaymentService
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class PaymentDetailsForSubscription(paymentService: PaymentService, futureCatalog: Future[Catalog]) extends SafeLogging {
+class PaymentDetailsForSubscription(paymentService: PaymentService, futureCatalog: LogPrefix => Future[Catalog]) extends SafeLogging {
 
   def getPaymentDetails(
       contactAndSubscription: ContactAndSubscription,
   )(implicit ec: ExecutionContext, logPrefix: LogPrefix): Future[PaymentDetails] = {
     val subscription = contactAndSubscription.subscription
     for {
-      catalog <- futureCatalog
+      catalog <- futureCatalog(logPrefix)
       paymentDetails <-
         if (contactAndSubscription.isGiftRedemption)
           Future.successful(giftPaymentDetailsFor(subscription, catalog))

--- a/membership-attribute-service/test/services/PaymentDetailsForSubscriptionTest.scala
+++ b/membership-attribute-service/test/services/PaymentDetailsForSubscriptionTest.scala
@@ -27,7 +27,7 @@ class PaymentDetailsForSubscriptionTest(implicit ee: ExecutionEnv) extends Speci
   "PaymentDetailMapper" should {
     "recognise a giftee's gift subscription" in {
       val contact = TestContact(randomId("identityId"))
-      val paymentDetailsForSubscription = new PaymentDetailsForSubscription(mock[PaymentService], Future.successful(catalog))
+      val paymentDetailsForSubscription = new PaymentDetailsForSubscription(mock[PaymentService], _ => Future.successful(catalog))
 
       paymentDetailsForSubscription
         .getPaymentDetails(ContactAndSubscription(contact, digipackGift, true))
@@ -57,7 +57,7 @@ class PaymentDetailsForSubscriptionTest(implicit ee: ExecutionEnv) extends Speci
     "recognise a gifter's gift subscription" in {
       val contact = TestContact(randomId("identityId"))
       val paymentService = mock[PaymentService]
-      val paymentDetailsForSubscription = new PaymentDetailsForSubscription(paymentService, Future.successful(catalog))
+      val paymentDetailsForSubscription = new PaymentDetailsForSubscription(paymentService, _ => Future.successful(catalog))
       val expectedPaymentDetails = PaymentDetails.fromSubAndPaymentData(digipackGift, None, None, None, None, catalog)
 
       paymentService.paymentDetails(
@@ -74,7 +74,7 @@ class PaymentDetailsForSubscriptionTest(implicit ee: ExecutionEnv) extends Speci
     "recognise a regular digital subscription" in {
       val contact = TestContact(randomId("identityId"))
       val paymentService = mock[PaymentService]
-      val paymentDetailsForSubscription = new PaymentDetailsForSubscription(paymentService, Future.successful(catalog))
+      val paymentDetailsForSubscription = new PaymentDetailsForSubscription(paymentService, _ => Future.successful(catalog))
       val expectedPaymentDetails = PaymentDetails.fromSubAndPaymentData(digipack, None, None, None, None, catalog)
 
       paymentService.paymentDetails(

--- a/membership-common/src/test/scala/com/gu/memsub/subsv2/services/CatalogServiceTest.scala
+++ b/membership-common/src/test/scala/com/gu/memsub/subsv2/services/CatalogServiceTest.scala
@@ -20,7 +20,7 @@ class CatalogServiceTest extends Specification {
     "Read a catalog in CODE with the config product IDs" in {
       val dev = ConfigFactory.parseResources("touchpoint.CODE.conf")
       val ids = SubsV2ProductIds.load(dev.getConfig("touchpoint.backend.environments.CODE.zuora.productIds"))
-      val cats = CatalogService.read(FetchCatalog.fromZuoraApi(CatalogServiceTest.client("rest/Catalog.json")), ids)
+      val cats = CatalogService.read(FetchCatalog.fromZuoraApi(CatalogServiceTest.client("rest/Catalog.json")), ids).toOption.get
       val supporterPlus = cats.productRatePlans(ProductRatePlanId("8ad08e1a8586721801858805663f6fab"))
       val supporterPlusMonth = cats.productRatePlans(ProductRatePlanId("8ad08cbd8586721c01858804e3275376"))
       supporterPlus.productType.productTypeString must beEqualTo("Supporter Plus")

--- a/membership-common/src/test/scala/com/gu/memsub/subsv2/services/SubscriptionServiceTest.scala
+++ b/membership-common/src/test/scala/com/gu/memsub/subsv2/services/SubscriptionServiceTest.scala
@@ -63,7 +63,7 @@ class SubscriptionServiceTest extends Specification {
   }
 
   val rc = new SimpleClient[Id](ZuoraRestConfig("TESTS", "https://localhost", "foo", "bar"), subscriptions)
-  private val service = new SubscriptionService[Id](catalog, rc, soapClient)
+  private val service = new SubscriptionService[Id](_ => catalog, rc, soapClient)
 
   "Current Plan" should {
 

--- a/membership-common/src/test/scala/com/gu/memsub/subsv2/services/TestCatalog.scala
+++ b/membership-common/src/test/scala/com/gu/memsub/subsv2/services/TestCatalog.scala
@@ -18,7 +18,7 @@ object TestCatalog {
     val ids = SubsV2ProductIds.load(dev.getConfig("touchpoint.backend.environments.PROD.zuora.productIds"))
     val cats = CatalogService.read(FetchCatalog.fromZuoraApi(CatalogServiceTest.client("rest/CatalogProd.json")), ids)
 
-    cats
+    cats.toOption.get
   }
 
   val digipackAnnualPrpId = ProductRatePlanId("2c92c0f94bbffaaa014bc6a4212e205b")


### PR DESCRIPTION
Zuora sandbox is throwing 500 errors, however strangely if the catalog fetch fails, it seemed to populate the catalog with an empty map.  This meant that when trying to read a subscription it can't look up the product rate plan id, which is confusing, as the real error is buried somewhere way up the log file (when the first request happened)

This PR makes it so that the error is thrown from the catalog fetch, and further changes to make it log it against the identity id of the current request, so if you're filtering the logs you will still see it.

After, you can see that searching for this test user's identity id (200275381) would pick up the error clearly 
```
2025-01-16 15:06:05,494 AccountController.scala:198 [INFO]: 200275381: Attempting to retrieve payment details for identity user: 200275381
2025-01-16 15:06:05,494 TouchpointComponents.scala:143 [ERROR]: 200275381: Failed to load the product catalog from Zuora due to: java.lang.RuntimeException: List((,List(JsonValidationError(List(No product array found, got JsUndefined('products' is undefined on object. Available keys are 'success', 'processId', 'reasons', 'requestId')),List()))))
2025-01-16 15:06:05,495 HttpErrorHandler.scala:305 [ERROR]: 

! @8870e91k4 - Internal server error, for (GET) [/user-attributes/me/mma] ->
 
play.api.http.HttpErrorHandlerExceptions$$anon$1: Execution exception[[RuntimeException: List((,List(JsonValidationError(List(No product array found, got JsUndefined('products' is undefined on object. Available keys are 'success', 'processId', 'reasons', 'requestId')),List()))))]]
	at play.api.http.HttpErrorHandlerExceptions$.$anonfun$convertToPlayException$2(HttpErrorHandler.scala:400)
	at scala.Option.map(Option.scala:242)
	at play.api.http.HttpErrorHandlerExceptions$.convertToPlayException(HttpErrorHandler.scala:398)

....
```
Note that the whole stack trace (reported by play framework ErrorHandler) would not be visible without viewing the original log.  I could get around that by wrapping the original exception in another one that contains the ID, but I think what I've done is less invasive and will be good enough.