### PR TITLE
Give Feast access to supporter members

### DIFF
--- a/membership-attribute-service/app/models/FeastApp.scala
+++ b/membership-attribute-service/app/models/FeastApp.scala
@@ -5,8 +5,6 @@ import org.joda.time.LocalDate
 
 object FeastApp {
 
-  val FeastFullLaunchDate = LocalDate.parse("2024-07-10")
-
   object IosSubscriptionGroupIds {
     // Subscription group ids are used by the app to tell the app store which subscription option to show to the user
     val IntroductoryOffer = "21396030"
@@ -17,11 +15,10 @@ object FeastApp {
     val IntroductoryOffer = "initial_supporter_launch_offer"
   }
 
-  private def isBeforeFeastLaunch(dt: LocalDate): Boolean = dt.isBefore(FeastFullLaunchDate)
-
   def shouldGetFeastAccess(attributes: Attributes): Boolean =
     attributes.isPartnerTier ||
       attributes.isPatronTier ||
+      attributes.isSupporterTier ||
       attributes.isGuardianPatron ||
       attributes.digitalSubscriberHasActivePlan ||
       attributes.isSupporterPlus ||

--- a/membership-attribute-service/test/controllers/AttributeControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AttributeControllerTest.scala
@@ -32,7 +32,7 @@ class AttributeControllerTest extends Specification with AfterAll with Idiomatic
   implicit val as: ActorSystem = ActorSystem("test")
 
   private val dateTimeInTheFuture = DateTime.now().plusDays(1)
-  private val dateBeforeFeastLaunch = FeastApp.FeastFullLaunchDate.minusDays(1)
+  private val dateBeforeFeastLaunch = LocalDate.parse("2024-07-10")
   private val validUserId = "1"
   private val userWithoutAttributesUserId = "2"
   private val userWithRecurringContributionUserId = "3"


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
This PR gives access to Feast for supporter members
