### PR TITLE
don't apply grace period to cancelled subscriptions

### DIFF
--- a/membership-common/src/main/scala/com/gu/memsub/subsv2/Subscription.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/subsv2/Subscription.scala
@@ -76,7 +76,10 @@ object GetCurrentPlans {
       else if (product == Product.Digipack && plan.billingPeriod.toOption.contains(OneTimeChargeBillingPeriod))
         digipackGiftEnded(_ => sub.termEndDate >= dateToCheck)
       else
-        paidPlanEnded(_ => plan.effectiveEndDate >= dateToCheck)
+        paidPlanEnded(_ => {
+          val inGracePeriodAndNotCancelled = plan.effectiveEndDate == dateToCheck && !sub.isCancelled
+          plan.effectiveEndDate > dateToCheck || inGracePeriodAndNotCancelled
+        })
     }
 
     Sequence(

--- a/membership-common/src/test/scala/com/gu/memsub/subsv2/services/SubscriptionServiceTest.scala
+++ b/membership-common/src/test/scala/com/gu/memsub/subsv2/services/SubscriptionServiceTest.scala
@@ -8,6 +8,8 @@ import com.gu.memsub
 import com.gu.memsub.Subscription.{Id => _, _}
 import com.gu.memsub.subsv2._
 import com.gu.memsub.subsv2.reads.PlanWithCreditsTestData
+import com.gu.memsub.subsv2.reads.SubJsonReads.subscriptionReads
+import com.gu.memsub.subsv2.services.SubscriptionServiceTest.adLiteCancelledInTrial
 import com.gu.memsub.{Subscription => _, _}
 import com.gu.monitoring.SafeLogger
 import com.gu.okhttp.RequestRunners.HttpClient
@@ -18,6 +20,7 @@ import io.lemonlabs.uri.typesafe.dsl._
 import okhttp3._
 import org.joda.time.LocalDate
 import org.specs2.mutable.Specification
+import play.api.libs.json.Json
 import scalaz.Id._
 import scalaz.{-\/, NonEmptyList, \/, \/-}
 import utils.Resource
@@ -262,6 +265,13 @@ class SubscriptionServiceTest extends Specification {
       GetCurrentPlans.currentPlans(digipackSub, referenceDate, catalog).map(_.head.id.get) mustEqual \/-("idDigipack")
     }
 
+    "if you cancel an Ad-Lite in the trial period, tell you you're not a subscriber" in {
+      val now = new LocalDate(2025, 2, 13) // still in trial
+      val adLite = subscriptionReads.reads(Json.parse(adLiteCancelledInTrial)).get
+      val actual = GetCurrentPlans.currentPlans(adLite, now, catalog)
+      actual mustEqual (-\/("Discarded 71a1e04469b94df9a384f4b1d2e15d71 because it has a paid plan which has ended"))
+    }
+
   }
 
   "Subscription service" should {
@@ -375,4 +385,263 @@ class SubscriptionServiceTest extends Specification {
       )
     }
   }
+}
+
+object SubscriptionServiceTest {
+  val adLiteCancelledInTrial =
+    """{
+      |    "success": true,
+      |    "id": "71a1e04469b94df9a384f4b1d2d75d6f",
+      |    "accountId": "8ad083f094df87910194f4ab34952c25",
+      |    "accountNumber": "A00975920",
+      |    "accountName": "001UD00000EU61XYAT",
+      |    "invoiceOwnerAccountId": "8ad083f094df87910194f4ab34952c25",
+      |    "invoiceOwnerAccountNumber": "A00975920",
+      |    "invoiceOwnerAccountName": "001UD00000EU61XYAT",
+      |    "subscriptionNumber": "A-S00959362",
+      |    "version": 2,
+      |    "revision": "2.0",
+      |    "termType": "TERMED",
+      |    "invoiceSeparately": false,
+      |    "contractEffectiveDate": "2025-02-11",
+      |    "serviceActivationDate": "2025-02-11",
+      |    "customerAcceptanceDate": "2025-02-26",
+      |    "subscriptionStartDate": "2025-02-11",
+      |    "subscriptionEndDate": "2025-02-11",
+      |    "lastBookingDate": "2025-02-11",
+      |    "termStartDate": "2025-02-11",
+      |    "termEndDate": "2025-02-11",
+      |    "initialTerm": 12,
+      |    "initialTermPeriodType": "Month",
+      |    "currentTerm": 12,
+      |    "currentTermPeriodType": "Month",
+      |    "autoRenew": true,
+      |    "renewalSetting": "RENEW_WITH_SPECIFIC_TERM",
+      |    "renewalTerm": 12,
+      |    "renewalTermPeriodType": "Month",
+      |    "currency": "GBP",
+      |    "contractedMrr": 5.00,
+      |    "totalContractedValue": 0.00,
+      |    "notes": null,
+      |    "status": "Cancelled",
+      |    "TrialPeriodPrice__c": null,
+      |    "CanadaHandDelivery__c": null,
+      |    "AcquisitionMetadata__c": null,
+      |    "QuoteNumber__QT": null,
+      |    "GifteeIdentityId__c": null,
+      |    "OpportunityName__QT": null,
+      |    "LastQSSPaymentDate__c": null,
+      |    "GiftNotificationEmailDate__c": null,
+      |    "Gift_Subscription__c": "No",
+      |    "TrialPeriodDays__c": null,
+      |    "CreatedRequestId__c": "dcf9af0a-415d-ff99-0000-000000003881",
+      |    "ActivationDate3__c": null,
+      |    "AcquisitionSource__c": null,
+      |    "CreatedByCSR__c": null,
+      |    "CASSubscriberID__c": null,
+      |    "LastPriceChangeDate__c": null,
+      |    "InitialPromotionCode__c": null,
+      |    "Suspended__c": "false",
+      |    "CpqBundleJsonId__QT": null,
+      |    "RedemptionCode__c": null,
+      |    "QuoteType__QT": null,
+      |    "GiftRedemptionDate__c": null,
+      |    "QuoteBusinessType__QT": null,
+      |    "SupplierCode__c": null,
+      |    "legacy_cat__c": null,
+      |    "DeliveryAgent__c": null,
+      |    "AcquisitionCase__c": null,
+      |    "ReaderType__c": "Direct",
+      |    "ActivationDate__c": null,
+      |    "UserCancellationReason__c": "mma_support_another_way",
+      |    "SuspensionStatus__c": "Active",
+      |    "CardCountry__c": null,
+      |    "OpportunityCloseDate__QT": null,
+      |    "IPaddress__c": null,
+      |    "IPCountry__c": null,
+      |    "CancelledBy__c": null,
+      |    "dummy__c": null,
+      |    "PromotionCode__c": null,
+      |    "OriginalSubscriptionStartDate__c": null,
+      |    "LegacyContractStartDate__c": null,
+      |    "CancellationReason__c": "Customer",
+      |    "billToContact": {
+      |        "id": "8ad083f094df87910194f4ab34d62c28",
+      |        "address1": null,
+      |        "address2": null,
+      |        "city": null,
+      |        "country": "United Kingdom",
+      |        "county": null,
+      |        "fax": null,
+      |        "state": null,
+      |        "postalCode": null,
+      |        "firstName": "pp9trpqdowsgqlz2hsa",
+      |        "lastName": "pp9trpqdowsgqlz2hsa",
+      |        "nickname": null,
+      |        "workEmail": "john.duffell+pp9trpqdowsgqlz2hsa@guardian.co.uk",
+      |        "personalEmail": null,
+      |        "homePhone": null,
+      |        "mobilePhone": null,
+      |        "otherPhone": null,
+      |        "otherPhoneType": null,
+      |        "taxRegion": null,
+      |        "workPhone": null,
+      |        "contactDescription": null,
+      |        "Company_Name__c": null,
+      |        "SpecialDeliveryInstructions__c": null,
+      |        "Title__c": null,
+      |        "zipCode": null,
+      |        "accountId": "8ad083f094df87910194f4ab34952c25",
+      |        "accountNumber": "A00975920"
+      |    },
+      |    "paymentTerm": null,
+      |    "invoiceTemplateId": null,
+      |    "invoiceTemplateName": null,
+      |    "sequenceSetId": null,
+      |    "sequenceSetName": null,
+      |    "soldToContact": {
+      |        "id": "8ad083f094df87910194f4ab34d62c28",
+      |        "address1": null,
+      |        "address2": null,
+      |        "city": null,
+      |        "country": "United Kingdom",
+      |        "county": null,
+      |        "fax": null,
+      |        "state": null,
+      |        "postalCode": null,
+      |        "firstName": "pp9trpqdowsgqlz2hsa",
+      |        "lastName": "pp9trpqdowsgqlz2hsa",
+      |        "nickname": null,
+      |        "workEmail": "john.duffell+pp9trpqdowsgqlz2hsa@guardian.co.uk",
+      |        "personalEmail": null,
+      |        "homePhone": null,
+      |        "mobilePhone": null,
+      |        "otherPhone": null,
+      |        "otherPhoneType": null,
+      |        "taxRegion": null,
+      |        "workPhone": null,
+      |        "contactDescription": null,
+      |        "Company_Name__c": null,
+      |        "SpecialDeliveryInstructions__c": null,
+      |        "Title__c": null,
+      |        "zipCode": null,
+      |        "accountId": "8ad083f094df87910194f4ab34952c25",
+      |        "accountNumber": "A00975920"
+      |    },
+      |    "isLatestVersion": true,
+      |    "cancelReason": null,
+      |    "ratePlans": [
+      |        {
+      |            "id": "71a1e04469b94df9a384f4b1d2e15d71",
+      |            "productId": "8ad0869c9444afc7019446c5eaf33503",
+      |            "productName": "Guardian Ad-Lite",
+      |            "productSku": "SKU-00000082",
+      |            "productRatePlanId": "71a1bebf6be9444afad446c5ebaf0019",
+      |            "productRatePlanNumber": null,
+      |            "ratePlanName": "Guardian Ad-Lite Monthly",
+      |            "subscriptionProductFeatures": [],
+      |            "externallyManagedPlanId": null,
+      |            "subscriptionRatePlanNumber": "SRP-01634051",
+      |            "isFromExternalCatalog": false,
+      |            "ratePlanCharges": [
+      |                {
+      |                    "id": "71a1e04469b94df9a384f4b1d2e75d73",
+      |                    "originalChargeId": "71a1b9d74f794df87704f4ab35539cf4",
+      |                    "productRatePlanChargeId": "71a1bebf6be9444afad446c5ec26001a",
+      |                    "number": "C-01675716",
+      |                    "name": "Guardian Ad-Lite",
+      |                    "productRatePlanChargeNumber": null,
+      |                    "type": "Recurring",
+      |                    "model": "FlatFee",
+      |                    "originalListPrice": null,
+      |                    "uom": null,
+      |                    "version": 2,
+      |                    "subscriptionChargeDeliverySchedule": null,
+      |                    "numberOfDeliveries": null,
+      |                    "priceChangeOption": "NoChange",
+      |                    "priceIncreasePercentage": null,
+      |                    "currency": "GBP",
+      |                    "chargeModelConfiguration": null,
+      |                    "inputArgumentId": null,
+      |                    "includedUnits": null,
+      |                    "overagePrice": null,
+      |                    "applyDiscountTo": null,
+      |                    "discountLevel": null,
+      |                    "discountClass": null,
+      |                    "applyToBillingPeriodPartially": false,
+      |                    "billingDay": "ChargeTriggerDay",
+      |                    "listPriceBase": "Per_Billing_Period",
+      |                    "specificListPriceBase": null,
+      |                    "billingPeriod": "Month",
+      |                    "specificBillingPeriod": null,
+      |                    "billingTiming": "IN_ADVANCE",
+      |                    "ratingGroup": null,
+      |                    "billingPeriodAlignment": "AlignToCharge",
+      |                    "quantity": 1.000000000,
+      |                    "prorationOption": null,
+      |                    "isStackedDiscount": false,
+      |                    "reflectDiscountInNetAmount": false,
+      |                    "smoothingModel": null,
+      |                    "numberOfPeriods": null,
+      |                    "overageCalculationOption": null,
+      |                    "overageUnusedUnitsCreditOption": null,
+      |                    "unusedUnitsCreditRates": null,
+      |                    "usageRecordRatingOption": null,
+      |                    "segment": 1,
+      |                    "effectiveStartDate": "2025-02-26",
+      |                    "effectiveEndDate": "2025-02-26",
+      |                    "processedThroughDate": null,
+      |                    "chargedThroughDate": null,
+      |                    "done": false,
+      |                    "triggerDate": null,
+      |                    "triggerEvent": "CustomerAcceptance",
+      |                    "endDateCondition": "Subscription_End",
+      |                    "upToPeriodsType": null,
+      |                    "upToPeriods": null,
+      |                    "specificEndDate": null,
+      |                    "mrr": 5.000000000,
+      |                    "dmrc": 0.000000000,
+      |                    "tcv": 0.000000000,
+      |                    "dtcv": -57.580645160,
+      |                    "originalOrderDate": "2025-02-11",
+      |                    "amendedByOrderOn": "2025-02-11",
+      |                    "description": "",
+      |                    "HolidayStart__c": null,
+      |                    "HolidayEnd__c": null,
+      |                    "ForceSync__c": null,
+      |                    "salesPrice": 5.000000000,
+      |                    "taxable": null,
+      |                    "taxCode": null,
+      |                    "taxMode": null,
+      |                    "tiers": null,
+      |                    "discountApplyDetails": null,
+      |                    "pricingSummary": "GBP5",
+      |                    "price": 5.000000000,
+      |                    "discountAmount": null,
+      |                    "discountPercentage": null
+      |                }
+      |            ]
+      |        }
+      |    ],
+      |    "orderNumber": "O-00994630",
+      |    "externallyManagedBy": null,
+      |    "statusHistory": [
+      |        {
+      |            "startDate": "2025-02-11",
+      |            "endDate": "2025-02-11",
+      |            "status": "Active"
+      |        },
+      |        {
+      |            "startDate": "2025-02-11",
+      |            "endDate": null,
+      |            "status": "Cancelled"
+      |        }
+      |    ],
+      |    "invoiceGroupNumber": null,
+      |    "createTime": "2025-02-11 11:08:02",
+      |    "updateTime": "2025-02-11 11:08:02",
+      |    "scheduledCancelDate": null,
+      |    "scheduledSuspendDate": null,
+      |    "scheduledResumeDate": null
+      |}""".stripMargin
 }

--- a/membership-common/src/test/scala/com/gu/memsub/subsv2/services/TestCatalog.scala
+++ b/membership-common/src/test/scala/com/gu/memsub/subsv2/services/TestCatalog.scala
@@ -27,7 +27,7 @@ object TestCatalog {
   val contributorPrpId = ProductRatePlanId("asdfasdf")
   val supporterPlusPrpId = ProductRatePlanId("8ad08cbd8586721c01858804e3275376")
   val tierThreePrpId = ProductRatePlanId("8ad097b48ff26452019001cebac92376")
-  val guardianAdLitePrpId = ProductRatePlanId("8a1285e294443da501944b04cb692c9e")
+  val guardianAdLitePrpId = ProductRatePlanId("71a1bebf6be9444afad446c5ebaf0019")
   val digipackPrpId = ProductRatePlanId("2c92c0f94f2acf73014f2c908f671591")
   val gw6for6PrpId = ProductRatePlanId("2c92c0f965f212210165f69b94c92d66")
   val homeDeliveryPrpId = ProductRatePlanId("homedelPRPid")
@@ -130,6 +130,13 @@ object TestCatalog {
       idForProduct(Product.Contribution),
       Map(contributorChargeId -> Contributor),
       Some(ProductType("type")),
+    ),
+    guardianAdLitePrpId -> ProductRatePlan(
+      guardianAdLitePrpId,
+      "Guardian Ad Lite",
+      idForProduct(Product.AdLite),
+      Map(guardianAdLiteChargeId -> GuardianAdLite),
+      Some(ProductType("typeAdLite")),
     ),
     discountPrpId -> ProductRatePlan(
       discountPrpId,


### PR DESCRIPTION
There is a but that will affect digi sub and ad lite trials, plus possibly other deferred start subs that are cancelled.

Basically if you're in a free trial/before paid period, the customer acceptance date indicates the first paid day, but the contract effective date represents the date you agreed to the subscription.

In MDAPI you only get benefits based on the active/paid plans.  So to handle free trials we fast forward to the first day of the paid period to decide what benefits you will get.

However, for cancelled subscriptions, the paid trial is reduced to start and end at midnight at the point of first payment.
As a final issue, we actually give people an extra 1 day grace period after a rate plan ends.  This is to allow zuora’s auto renewal process to kick in which happens soon after the previous one goes out of term.

This means that when checking the subscription, in the trial period of a cancelled subscription, it fast forwards to the paid period (of zero length) adds one day grace period, and then returns the subscription as an active one.

This PR changes the code to notice a subscription in cancelled state, and doesn’t apply the 1 day grace period.
