### PR TITLE
add new endpoint to quickly check if someone is a test user

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -275,9 +275,11 @@ class AttributeController(
       maybeAttributes
   }
 
-  def isTestUser: Action[AnyContent] =
-    AuthorizeForScopes(List(readSelf)) {
+  def isTestUser: Action[AnyContent] = {
+    val scope = List(readSelf) // this doesn't end in .secure so we won't call through to okta
+    AuthorizeForScopes(scope) {
       NoContent
     }
+  }
 
 }

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -274,4 +274,10 @@ class AttributeController(
     else
       maybeAttributes
   }
+
+  def isTestUser: Action[AnyContent] =
+    AuthorizeForScopes(List(readSelf)) {
+      NoContent
+    }
+
 }

--- a/membership-attribute-service/conf/routes
+++ b/membership-attribute-service/conf/routes
@@ -23,6 +23,7 @@ GET         /user-attributes/me/one-off-contributions                           
 
 PUT         /user-attributes/me/delivery-address/:contactId                     controllers.ContactController.updateDeliveryAddress(contactId: String)
 
+GET         /user-attributes/me/is-test-user                                    controllers.AttributeController.isTestUser
 
 # OLD ENDPOINTS below will be phased out as traffic moves over to the new endpoints above
 GET         /user-attributes/me/membership                              controllers.AttributeController.membership


### PR DESCRIPTION
At the moment it is quite difficult to tell if someone is a test user in manage, without calling the main (slow) /user-attributes/me endpoint on MDAPI.  Although this is usually called, for deep links we don't always make that call (e.g. billing page)

This PR adds a new super lightweight call just to do the test user check without calling zuora etc.

Tested locally.