### PR TITLE
use recommended SSL policy

### DIFF
--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -166,7 +166,8 @@ Resources:
       - LoadBalancerPort: '443'
         InstancePort: '9000'
         Protocol: HTTPS
-        SslPolicy: ELBSecurityPolicy-TLS13-1-2-2021-06
+        PolicyNames: 
+        - ELBSecurityPolicy-TLS13-1-2-2021-06
         SSLCertificateId: !Ref ELBSSLCertificate
       ConnectionDrainingPolicy:
         Enabled: 'true'

--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -167,7 +167,7 @@ Resources:
         InstancePort: '9000'
         Protocol: HTTPS
         PolicyNames: 
-        - ELBSecurityPolicy-TLS13-1-2-2021-06
+        - MDAPI-Security-Policy
         SSLCertificateId: !Ref ELBSSLCertificate
       ConnectionDrainingPolicy:
         Enabled: 'true'
@@ -183,6 +183,12 @@ Resources:
         Ref: PublicVpcSubnets
       SecurityGroups:
       - Ref: LoadBalancerSecurityGroup
+      Policies:
+      - PolicyName: MDAPI-Security-Policy
+        PolicyType: SSLNegotiationPolicyType
+        Attributes:
+        - Name: Reference-Security-Policy
+          Value: ELBSecurityPolicy-TLS13-1-2-2021-06
   AutoscalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:

--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -166,6 +166,7 @@ Resources:
       - LoadBalancerPort: '443'
         InstancePort: '9000'
         Protocol: HTTPS
+        SslPolicy: ELBSecurityPolicy-TLS13-1-2-2021-06
         SSLCertificateId: !Ref ELBSSLCertificate
       ConnectionDrainingPolicy:
         Enabled: 'true'


### PR DESCRIPTION
Currently we are using the default ELBSecurityPolicy-2016-08
but we should be using ELBSecurityPolicy-TLS13-1-2-2021-06

This enforces TLS 1.3 or 1.2

This is also the default for gucdk
https://github.com/guardian/cdk/pull/2306 and
https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_elasticloadbalancingv2/SslPolicy.html#aws_cdk.aws_elasticloadbalancingv2.SslPolicy.RECOMMENDED_TLS

more info https://docs.aws.amazon.com/elasticloadbalancing/latest/application/describe-ssl-policies.html