### PR TITLE
don't run `sbt test` explicitly as riffRaffUpload (re)runs them

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,4 +19,4 @@ jobs:
         run: |
           LAST_TEAMCITY_BUILD=11657
           export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
-          sbt "project membership-common" scalafmtCheckAll test "project membership-attribute-service" clean scalafmtCheckAll scalafmtSbtCheck test riffRaffUpload
+          sbt "project membership-common" scalafmtCheckAll test "project membership-attribute-service" clean scalafmtCheckAll scalafmtSbtCheck riffRaffUpload


### PR DESCRIPTION
I noticed the tests were running twice, this is because riffRaffUpload runs them (again)

In future, to improve security, we should probably switch over to the riff raff upload GHA action https://github.com/guardian/actions-riff-raff rather than using the SBT one