### PR TITLE
Tortoise Media Stripe Account

### DIFF
--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -174,7 +174,7 @@ class TouchpointComponents(
     )
 
   lazy val chooseStripe: ChooseStripe = chooseStripeOverride.getOrElse(
-    ChooseStripe.createFor(backendConfig.stripeUKMembership, backendConfig.stripeAUMembership),
+    ChooseStripe.createFor(backendConfig.stripeUKMembership, backendConfig.stripeAUMembership, backendConfig.stripeTortoiseMediaMembership),
   )
 
   lazy val paymentDetailsForSubscription: PaymentDetailsForSubscription = new PaymentDetailsForSubscription(paymentService, futureCatalog(_))

--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -177,7 +177,7 @@ class TouchpointComponents(
     ChooseStripe.createFor(
       backendConfig.stripeUKMembership,
       backendConfig.stripeAUMembership,
-      backendConfig.stripeTortoiseMediaMembership,
+      backendConfig.stripeTortoiseMedia,
     ),
   )
 

--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -174,7 +174,11 @@ class TouchpointComponents(
     )
 
   lazy val chooseStripe: ChooseStripe = chooseStripeOverride.getOrElse(
-    ChooseStripe.createFor(backendConfig.stripeUKMembership, backendConfig.stripeAUMembership, backendConfig.stripeTortoiseMediaMembership),
+    ChooseStripe.createFor(
+      backendConfig.stripeUKMembership,
+      backendConfig.stripeAUMembership,
+      backendConfig.stripeTortoiseMediaMembership,
+    ),
   )
 
   lazy val paymentDetailsForSubscription: PaymentDetailsForSubscription = new PaymentDetailsForSubscription(paymentService, futureCatalog(_))

--- a/membership-attribute-service/app/services/stripe/ChooseStripe.scala
+++ b/membership-attribute-service/app/services/stripe/ChooseStripe.scala
@@ -10,8 +10,8 @@ import scala.concurrent.ExecutionContext
 case class StripePublicKey(key: String)
 
 object ChooseStripe {
-  def createFor(ukStripeConfig: StripeServiceConfig, auServiceConfig: StripeServiceConfig, tortoiseMediaStripeServiceConfig: StripeServiceConfig)(implicit
-      ec: ExecutionContext,
+  def createFor(ukStripeConfig: StripeServiceConfig, auServiceConfig: StripeServiceConfig, tortoiseMediaStripeServiceConfig: StripeServiceConfig)(
+      implicit ec: ExecutionContext,
   ): ChooseStripe = {
     val ukStripePublicKey: StripePublicKey = StripePublicKey(ukStripeConfig.credentials.publicKey)
     val auStripePublicKey: StripePublicKey = StripePublicKey(auServiceConfig.credentials.publicKey)

--- a/membership-attribute-service/app/services/stripe/ChooseStripe.scala
+++ b/membership-attribute-service/app/services/stripe/ChooseStripe.scala
@@ -10,14 +10,16 @@ import scala.concurrent.ExecutionContext
 case class StripePublicKey(key: String)
 
 object ChooseStripe {
-  def createFor(ukStripeConfig: StripeServiceConfig, auServiceConfig: StripeServiceConfig)(implicit
+  def createFor(ukStripeConfig: StripeServiceConfig, auServiceConfig: StripeServiceConfig, tortoiseMediaStripeServiceConfig: StripeServiceConfig)(implicit
       ec: ExecutionContext,
   ): ChooseStripe = {
     val ukStripePublicKey: StripePublicKey = StripePublicKey(ukStripeConfig.credentials.publicKey)
     val auStripePublicKey: StripePublicKey = StripePublicKey(auServiceConfig.credentials.publicKey)
+    val tortoiseMediaStripePublicKey: StripePublicKey = StripePublicKey(tortoiseMediaStripeServiceConfig.credentials.publicKey)
 
     val ukStripeService: StripeService = createStripeServiceFor(ukStripeConfig)
     val auStripeService: StripeService = createStripeServiceFor(auServiceConfig)
+    val tortoiseMediaStripeService: StripeService = createStripeServiceFor(tortoiseMediaStripeServiceConfig)
 
     val stripePublicKeyByCountry: Map[Country, StripePublicKey] = Map(
       Country.UK -> ukStripePublicKey,
@@ -26,6 +28,7 @@ object ChooseStripe {
     val stripeServicesByPublicKey: Map[StripePublicKey, StripeService] = Map(
       ukStripePublicKey -> ukStripeService,
       auStripePublicKey -> auStripeService,
+      tortoiseMediaStripePublicKey -> tortoiseMediaStripeService,
     )
     new ChooseStripe(stripePublicKeyByCountry, ukStripePublicKey, stripeServicesByPublicKey)
   }

--- a/membership-common/conf/touchpoint.CODE.conf
+++ b/membership-common/conf/touchpoint.CODE.conf
@@ -42,7 +42,7 @@ touchpoint.backend.environments {
                 secret = ""
                 public = "pk_test_BOYT4zGHkJvq3sPZjxnL0pbx"
             }
-            tortoise-media-membership.key {
+            tortoise-media.key {
                 secret = ""
                 public = "pk_test_51R2EwSFNFWz7WMIhlRO95hCjJy6frZdqdOshm7L9ZPt8Pwgw9izuf6QV7VMSHiX2qOpKafDlzvnQPM4enjWxJlLM001gwbmifF"
             }

--- a/membership-common/conf/touchpoint.CODE.conf
+++ b/membership-common/conf/touchpoint.CODE.conf
@@ -42,6 +42,10 @@ touchpoint.backend.environments {
                 secret = ""
                 public = "pk_test_BOYT4zGHkJvq3sPZjxnL0pbx"
             }
+            tortoise-media-membership.key {
+                secret = ""
+                public = "pk_test_51R2EwSFNFWz7WMIhlRO95hCjJy6frZdqdOshm7L9ZPt8Pwgw9izuf6QV7VMSHiX2qOpKafDlzvnQPM4enjWxJlLM001gwbmifF"
+            }
         }
 
         salesforce {

--- a/membership-common/conf/touchpoint.PROD.conf
+++ b/membership-common/conf/touchpoint.PROD.conf
@@ -27,6 +27,10 @@ touchpoint.backend.environments {
                 secret = ""
                 public = "pk_live_yc7a7N3P0Z8r63PkGow0tOOt"
             }
+            tortoise-media-membership.key {
+                secret = ""
+                public = "to-be-defined"
+            }
         }
 
         salesforce {

--- a/membership-common/conf/touchpoint.PROD.conf
+++ b/membership-common/conf/touchpoint.PROD.conf
@@ -29,7 +29,7 @@ touchpoint.backend.environments {
             }
             tortoise-media-membership.key {
                 secret = ""
-                public = "to-be-defined"
+                public = "pk_live_51R2EwSFNFWz7WMIhi8Xp3xQ9xMjGlaTQPrwrk0PikCdR4wLla5Y2tc6qIdTF5zgWW4oykETepTwCtN7iHQl0beDL00N8KPa4Jp"
             }
         }
 

--- a/membership-common/conf/touchpoint.PROD.conf
+++ b/membership-common/conf/touchpoint.PROD.conf
@@ -27,7 +27,7 @@ touchpoint.backend.environments {
                 secret = ""
                 public = "pk_live_yc7a7N3P0Z8r63PkGow0tOOt"
             }
-            tortoise-media-membership.key {
+            tortoise-media.key {
                 secret = ""
                 public = "pk_live_51R2EwSFNFWz7WMIhi8Xp3xQ9xMjGlaTQPrwrk0PikCdR4wLla5Y2tc6qIdTF5zgWW4oykETepTwCtN7iHQl0beDL00N8KPa4Jp"
             }

--- a/membership-common/src/main/scala/com/gu/touchpoint/TouchpointBackendConfig.scala
+++ b/membership-common/src/main/scala/com/gu/touchpoint/TouchpointBackendConfig.scala
@@ -13,6 +13,7 @@ case class TouchpointBackendConfig(
     stripePatrons: BasicStripeServiceConfig,
     stripeUKMembership: StripeServiceConfig,
     stripeAUMembership: StripeServiceConfig,
+    stripeTortoiseMediaMembership: StripeServiceConfig,
     zuoraSoap: ZuoraSoapConfig,
     zuoraRest: ZuoraRestConfig,
     idapi: IdapiConfig,
@@ -29,6 +30,7 @@ object TouchpointBackendConfig extends SafeLogging {
       BasicStripeServiceConfig.from(envBackendConf, "patrons"),
       StripeServiceConfig.from(envBackendConf, environmentName, Country.UK), // uk-membership
       StripeServiceConfig.from(envBackendConf, environmentName, Country.Australia, variant = "au-membership"),
+      StripeServiceConfig.from(envBackendConf, environmentName, Country.UK, variant = "tortoise-media-membership"), // tortoise-media-membership
       ZuoraApiConfig.soap(envBackendConf, environmentName),
       ZuoraApiConfig.rest(envBackendConf, environmentName),
       IdapiConfig.from(envBackendConf, environmentName),

--- a/membership-common/src/main/scala/com/gu/touchpoint/TouchpointBackendConfig.scala
+++ b/membership-common/src/main/scala/com/gu/touchpoint/TouchpointBackendConfig.scala
@@ -13,7 +13,7 @@ case class TouchpointBackendConfig(
     stripePatrons: BasicStripeServiceConfig,
     stripeUKMembership: StripeServiceConfig,
     stripeAUMembership: StripeServiceConfig,
-    stripeTortoiseMediaMembership: StripeServiceConfig,
+    stripeTortoiseMedia: StripeServiceConfig,
     zuoraSoap: ZuoraSoapConfig,
     zuoraRest: ZuoraRestConfig,
     idapi: IdapiConfig,
@@ -30,7 +30,7 @@ object TouchpointBackendConfig extends SafeLogging {
       BasicStripeServiceConfig.from(envBackendConf, "patrons"),
       StripeServiceConfig.from(envBackendConf, environmentName, Country.UK), // uk-membership
       StripeServiceConfig.from(envBackendConf, environmentName, Country.Australia, variant = "au-membership"),
-      StripeServiceConfig.from(envBackendConf, environmentName, Country.UK, variant = "tortoise-media-membership"), // tortoise-media-membership
+      StripeServiceConfig.from(envBackendConf, environmentName, Country.UK, variant = "tortoise-media"), // tortoise-media
       ZuoraApiConfig.soap(envBackendConf, environmentName),
       ZuoraApiConfig.rest(envBackendConf, environmentName),
       IdapiConfig.from(envBackendConf, environmentName),


### PR DESCRIPTION
<!-- 
The text you're about to write will advocate why the change is needed.
Think about OKRs and wider purpose!
-->
### Why do we need this? <!-- how will closing this PR damage the guardian/KRs? -->
Currently, the manage-frontend project uses Stripe Elements for updating payment methods. This involves users entering their payment details directly on the site, which are then processed using Stripe's API. The existing implementation includes various flows for updating payment methods, such as credit cards and direct debits, and handles different scenarios like payment failures and reCAPTCHA verification.

Our goal here is to remove GNM from the Observer-only payment flow (“Home delivery” and “Subscription Card”). By taking Observer-only funds on behalf of TM, and later settling them to TM, GNM is acting as a “Payment Facilitator”. To avoid this, we are implementing a specific flow for this product, which consists of using the “Stripe” payment solution in its self-hosted format (Stripe Checkout) with the usage of a service account belonging to Tortoise Media.

Because of this, we must add the Tortoise Media Stripe Public/Private API Keys mapping to make sure that the system works and accepts credit cards on this new account.

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->

• Added support for a new Stripe configuration for Tortoise Media Membership:
  - Modified `TouchpointComponents.scala` to include a third Stripe configuration parameter in the `chooseStripe` method
  - Updated `ChooseStripe.scala` to handle the new Tortoise Media Stripe service configuration
  - Added a new method parameter `tortoiseMediaStripeServiceConfig` to `createFor` method

• Updated configuration files:
  - Added Tortoise Media Membership Stripe keys in both `touchpoint.CODE.conf` and `touchpoint.PROD.conf`
    - Added test public key in CODE environment
    - Added live public key in PROD environment

• Modified `TouchpointBackendConfig.scala`:
  - Added a new field `stripeTortoiseMediaMembership` to the case class
  - Updated the configuration loading method to include the new Tortoise Media Membership Stripe configuration
  - Used the UK country configuration for the new Tortoise Media Membership variant

• Implemented additional mapping for the new Stripe service:
  - Added a new Stripe service to `stripeServicesByPublicKey` map in `ChooseStripe` object

These changes were implemented to prepare the system to support a new Stripe membership type for Tortoise Media.

### Trello card/screenshot/json/related PRs etc

#### Recorded Demo
https://github.com/user-attachments/assets/c5a2e9f1-08f5-433b-ab0e-8991d948b72a

#### Sequence Diagram
![Update Payment Method - Credit Card for Sunday Only The Observer Subscription](https://github.com/user-attachments/assets/ff560a3b-a234-4ec5-89d5-24369e04b92c)


#### Linked Trello Cards
https://trello.com/c/7pqmbEKX/743-tortoise-stripe-api-key-on-members-data-api
https://trello.com/c/uAwOrl8b/725-estimate-migrating-mma-to-use-stripe-checkout
https://trello.com/c/GDkXwLUz/731-poc-stripe-checkout-implementation-on-mma
https://trello.com/c/H9gGqX0x/737-stripe-checkout-implementation-on-mma
