### PR TITLE
use alternative tier for observer only delivery

### DIFF
--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -211,13 +211,11 @@ object AccountDetails {
   }
 
   def getTier(catalog: Catalog, plan: RatePlan): Json.JsValueWrapper =
-    if (
-      plan.product(catalog) == Product.Delivery &&
-      plan.name(catalog) == "Sunday"
-    )
-      "Newspaper Delivery - Observer"
-    else
-      plan.productName
+    plan.product(catalog) match {
+      case Product.Delivery if plan.name(catalog) == "Sunday" => "Newspaper Delivery - Observer"
+      case Product.DigitalVoucher if plan.name(catalog) == "Sunday" => "Newspaper Digital Voucher - Observer"
+      case _ => plan.productName
+    }
 
 }
 

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -214,6 +214,7 @@ object AccountDetails {
     plan.product(catalog) match {
       case Product.Delivery if plan.name(catalog) == "Sunday" => "Newspaper Delivery - Observer"
       case Product.DigitalVoucher if plan.name(catalog) == "Sunday" => "Newspaper Digital Voucher - Observer"
+      case Product.Voucher if plan.name(catalog) == "Sunday" => "Newspaper Voucher - Observer"
       case _ => plan.productName
     }
 

--- a/membership-attribute-service/app/services/GuardianPatronService.scala
+++ b/membership-attribute-service/app/services/GuardianPatronService.scala
@@ -83,7 +83,7 @@ class GuardianPatronService(
           RatePlan(
             id = RatePlanId("guardian_patron_unused"), // only used for contribution amount change
             productRatePlanId = Catalog.guardianPatronProductRatePlanId,
-            productName = "Guardian Patron",
+            productName = "guardianpatron",
             lastChangeType = None,
             features = Nil,
             ratePlanCharges = NonEmptyList(

--- a/membership-attribute-service/test/models/ProductsResponseSpec.scala
+++ b/membership-attribute-service/test/models/ProductsResponseSpec.scala
@@ -111,7 +111,6 @@ class ProductsResponseSpec extends Specification with SafeLogging {
         |    "email" : "test@thegulocal.com"
         |  },
         |  "products" : [ {
-        |    "mmaCategory" : "recurringSupport",
         |    "tier" : "Supporter Plus",
         |    "isPaidTier" : true,
         |    "selfServiceCancellation" : {
@@ -309,7 +308,6 @@ class ProductsResponseSpec extends Specification with SafeLogging {
         |  },
         |  "products": [
         |    {
-        |      "mmaCategory": "subscriptions",
         |      "tier": "$productName",
         |      "isPaidTier": true,
         |      "selfServiceCancellation": {


### PR DESCRIPTION
This PR updates the "tier" property for home delivery sunday only to be "tier": "Newspaper Delivery - Observer" and likewise for other observer only subs

This means that manage can correctly display the branding and options for these subscribers.

Sunday+ is NOT classed as observer only (as they are giving a portion of their money for digital access)

Changes are also being made in Manage and will be shipped in advance of this PR (to avoid breaking MMA for observer people)

Tested OK in DEV with various subs:
```
"tier": "Newspaper Delivery",
"tier": "Newspaper Delivery - Observer",
"tier": "Guardian Ad-Lite",
"tier": "Guardian Weekly - Domestic",
"tier": "Supporter Plus",
```