### PR TITLE
Add Support for Tortoise Media's Dedicated GoCardless Payment Gateway

### DIFF
--- a/membership-attribute-service/app/controllers/PaymentUpdateController.scala
+++ b/membership-attribute-service/app/controllers/PaymentUpdateController.scala
@@ -141,7 +141,7 @@ class PaymentUpdateController(
             "sortCode" -> nonEmptyText,
             "gatewayOwner" -> optional(text).transform[Option[GatewayOwner]](
               _.flatMap(GatewayOwner.fromString),
-              _.map(_.toString)
+              _.map(_.toString),
             ),
           )
         }

--- a/membership-attribute-service/app/controllers/PaymentUpdateController.scala
+++ b/membership-attribute-service/app/controllers/PaymentUpdateController.scala
@@ -171,7 +171,8 @@ class PaymentUpdateController(
             lastName = billToContact.lastName,
             countryCode = "GB",
           )
-          paymentGatewayToUse = if (paymentGatewayOwner.equals("tortoise-media")) {
+          paymentGatewayToUse =
+            if (paymentGatewayOwner.equals("tortoise-media")) {
               GoCardlessTortoiseMediaGateway
             } else {
               GoCardlessGateway

--- a/membership-attribute-service/app/controllers/PaymentUpdateController.scala
+++ b/membership-attribute-service/app/controllers/PaymentUpdateController.scala
@@ -179,7 +179,6 @@ class PaymentUpdateController(
             case GatewayOwner.TortoiseMedia => GoCardlessTortoiseMediaGateway
             case _ => GoCardlessGateway
           }
-          logger.info(s"Attempting to Update Direct Debit with Gateway: ${paymentGatewayToUse.gatewayName}")
           createPaymentMethod = CreatePaymentMethod(
             accountId = subscription.accountId,
             paymentMethod = bankTransferPaymentMethod,
@@ -187,7 +186,7 @@ class PaymentUpdateController(
             billtoContact = billToContact,
           )
           _ <- SimpleEitherT(
-            annotateFailableFuture(services.zuoraSoapService.createPaymentMethod(createPaymentMethod), "create direct debit payment method"),
+            annotateFailableFuture(services.zuoraSoapService.createPaymentMethod(createPaymentMethod), s"create direct debit payment method using ${paymentGatewayToUse.gatewayName}"),
           )
           freshAccount <- SimpleEitherT(
             annotateFailableFuture(

--- a/membership-attribute-service/app/controllers/PaymentUpdateController.scala
+++ b/membership-attribute-service/app/controllers/PaymentUpdateController.scala
@@ -186,7 +186,10 @@ class PaymentUpdateController(
             billtoContact = billToContact,
           )
           _ <- SimpleEitherT(
-            annotateFailableFuture(services.zuoraSoapService.createPaymentMethod(createPaymentMethod), s"create direct debit payment method using ${paymentGatewayToUse.gatewayName}"),
+            annotateFailableFuture(
+              services.zuoraSoapService.createPaymentMethod(createPaymentMethod),
+              s"create direct debit payment method using ${paymentGatewayToUse.gatewayName}",
+            ),
           )
           freshAccount <- SimpleEitherT(
             annotateFailableFuture(

--- a/membership-attribute-service/app/controllers/PaymentUpdateController.scala
+++ b/membership-attribute-service/app/controllers/PaymentUpdateController.scala
@@ -179,6 +179,7 @@ class PaymentUpdateController(
             case GatewayOwner.TortoiseMedia => GoCardlessTortoiseMediaGateway
             case _ => GoCardlessGateway
           }
+          logger.info(s"Attempting to Update Direct Debit with Gateway: ${paymentGatewayToUse.gatewayName}")
           createPaymentMethod = CreatePaymentMethod(
             accountId = subscription.accountId,
             paymentMethod = bankTransferPaymentMethod,

--- a/membership-attribute-service/app/models/GatewayOwner.scala
+++ b/membership-attribute-service/app/models/GatewayOwner.scala
@@ -1,0 +1,12 @@
+package models
+
+sealed trait GatewayOwner
+object GatewayOwner {
+  case object TortoiseMedia extends GatewayOwner
+  case object Default extends GatewayOwner
+
+  def fromString(value: String): Option[GatewayOwner] = value.toLowerCase match {
+    case "tortoise-media" => Some(TortoiseMedia)
+    case _ => Some(Default)
+  }
+}

--- a/membership-common/src/main/scala/com/gu/zuora/api/PaymentGateway.scala
+++ b/membership-common/src/main/scala/com/gu/zuora/api/PaymentGateway.scala
@@ -26,6 +26,9 @@ case object StripeAUPaymentIntentsMembershipGateway extends PaymentGateway {
 case object GoCardlessGateway extends PaymentGateway {
   val gatewayName = "GoCardless"
 }
+case object GoCardlessTortoiseMediaGateway extends PaymentGateway {
+  val gatewayName = "GoCardless - Observer - Tortoise Media"
+}
 // Temporarily here to enable deseerialisation until it's fully deprovisioned.
 case object GoCardlessZuoraInstance extends PaymentGateway {
   val gatewayName = "GoCardless - Zuora Instance"

--- a/membership-common/src/main/scala/com/gu/zuora/api/PaymentGateway.scala
+++ b/membership-common/src/main/scala/com/gu/zuora/api/PaymentGateway.scala
@@ -44,6 +44,7 @@ object PaymentGateway {
     StripeUKPaymentIntentsMembershipGateway,
     StripeAUPaymentIntentsMembershipGateway,
     GoCardlessGateway,
+    GoCardlessTortoiseMediaGateway,
     GoCardlessZuoraInstance,
     PayPal,
   ).map(g => (g.gatewayName, g)).toMap


### PR DESCRIPTION
### Why do we need this? 
This change enables directing direct debit payments from Tortoise Media customers through a dedicated GoCardless payment gateway. By adding support for a specific Tortoise Media gateway, we can properly route and track these transactions separately from our standard GoCardless payments, allowing for proper financial reconciliation and reporting.

### The changes

- Added a new payment gateway option `GoCardlessTortoiseMediaGateway` with the name "GoCardless - Observer - Tortoise Media"
- Modified the direct debit form to include an optional `gatewayOwner` field
- Updated the payment method creation logic to select the appropriate gateway based on the `gatewayOwner` value:
-- If `gatewayOwner` equals "tortoise-media", use the new Tortoise Media gateway
-- Otherwise, use the standard GoCardless gateway
- Registered the new gateway in the payment gateway map for proper serialization/deserialization

### trello card/screenshot/json/related PRs etc
[Trello Card](https://trello.com/c/8DeIOlkm/760-direct-debit-gocardless-on-tortoise-media-for-observer-only-subscriptions)
