### PR TITLE
get rid of the Optionality at the serialiser

### DIFF
--- a/membership-attribute-service/app/controllers/PaymentUpdateController.scala
+++ b/membership-attribute-service/app/controllers/PaymentUpdateController.scala
@@ -139,9 +139,9 @@ class PaymentUpdateController(
             "accountName" -> nonEmptyText,
             "accountNumber" -> nonEmptyText,
             "sortCode" -> nonEmptyText,
-            "gatewayOwner" -> optional(text).transform[Option[GatewayOwner]](
-              _.flatMap(GatewayOwner.fromString),
-              _.map(_.toString)
+            "gatewayOwner" -> optional(text).transform[GatewayOwner](
+              GatewayOwner.fromString,
+              _.value,
             ),
           )
         }
@@ -176,7 +176,7 @@ class PaymentUpdateController(
             countryCode = "GB",
           )
           paymentGatewayToUse = paymentGatewayOwner match {
-            case Some(GatewayOwner.TortoiseMedia) => GoCardlessTortoiseMediaGateway
+            case GatewayOwner.TortoiseMedia => GoCardlessTortoiseMediaGateway
             case _ => GoCardlessGateway
           }
           createPaymentMethod = CreatePaymentMethod(

--- a/membership-attribute-service/app/models/GatewayOwner.scala
+++ b/membership-attribute-service/app/models/GatewayOwner.scala
@@ -1,12 +1,14 @@
 package models
 
-sealed trait GatewayOwner
+sealed abstract class GatewayOwner(val value: Option[String])
 object GatewayOwner {
-  case object TortoiseMedia extends GatewayOwner
-  case object Default extends GatewayOwner
+  case object TortoiseMedia extends GatewayOwner(Some("tortoise-media"))
+  case object Default extends GatewayOwner(None)
 
-  def fromString(value: String): Option[GatewayOwner] = value.toLowerCase match {
-    case "tortoise-media" => Some(TortoiseMedia)
-    case _ => Some(Default)
+  def fromString(value: Option[String]): GatewayOwner = {
+    value.map(_.toLowerCase) match {
+      case Some("tortoise-media") => TortoiseMedia
+      case _ => Default
+    }
   }
 }


### PR DESCRIPTION
(GH can't do multi file suggestions so I have put them in a branch)

Basically since we are using GatewayOwner instead of Option[String] as our domain type,  we don't need Option[GatewayOwner] we can use GatewayOwner directly.

This is because the GatewayOwner class has it's own concept of None which is the `Default` value.  So I have made the "Form" do the full translation to the custom class, then we don't have to think about Options any more, this simplifying the business logic.