### PR TITLE
add switch to make observer only appear in CODE

### DIFF
--- a/membership-attribute-service/app/models/ProductsResponse.scala
+++ b/membership-attribute-service/app/models/ProductsResponse.scala
@@ -8,9 +8,11 @@ case class UserDetails(firstName: Option[String], lastName: Option[String], emai
 
 case class ProductsResponse(user: UserDetails, products: List[AccountDetails])
 
-class ProductsResponseWrites(catalog: Catalog) {
+class ProductsResponseWrites(catalog: Catalog, isProd: Boolean) {
   implicit val userDetailsWrites: OWrites[UserDetails] = Json.writes[UserDetails]
-  implicit def accountDetailsWrites(implicit logPrefix: LogPrefix): Writes[AccountDetails] = Writes[AccountDetails](_.toJson(catalog))
+  private val accountDetailsWriter = new AccountDetailsWriter(isProd)
+  implicit def accountDetailsWrites(implicit logPrefix: LogPrefix): Writes[AccountDetails] =
+    Writes[AccountDetails](accountDetails => new accountDetailsWriter.WithAccountDetails(accountDetails, catalog).toJson)
   implicit def writes(implicit logPrefix: LogPrefix): OWrites[ProductsResponse] = Json.writes[ProductsResponse]
 
   def from(user: UserFromToken, products: List[AccountDetails]) =

--- a/membership-attribute-service/app/wiring/AppLoader.scala
+++ b/membership-attribute-service/app/wiring/AppLoader.scala
@@ -113,7 +113,7 @@ class MyComponents(context: Context)
     new HealthCheckController(touchPointBackends, controllerComponents),
     new AttributeController(commonActions, controllerComponents, dbService, mobileSubscriptionService, addGuIdentityHeaders, createMetrics),
     new ExistingPaymentOptionsController(commonActions, controllerComponents, createMetrics),
-    new AccountController(commonActions, controllerComponents, dbService, sendEmail, createMetrics),
+    new AccountController(commonActions, controllerComponents, dbService, sendEmail, createMetrics, isProd),
     new PaymentUpdateController(commonActions, controllerComponents, sendEmail, createMetrics),
     new ContactController(commonActions, controllerComponents, createMetrics),
   )

--- a/membership-attribute-service/test/controllers/AccountControllerTest.scala
+++ b/membership-attribute-service/test/controllers/AccountControllerTest.scala
@@ -15,7 +15,8 @@ class AccountControllerTest extends Specification with IdiomaticMockito {
 
     val subName = "s1"
     val commonActions = mock[CommonActions]
-    val controller = new AccountController(commonActions, stubControllerComponents(), FakePostgresService("123"), mock[SendEmail], CreateNoopMetrics)
+    val controller =
+      new AccountController(commonActions, stubControllerComponents(), FakePostgresService("123"), mock[SendEmail], CreateNoopMetrics, isProd = false)
     val request = FakeRequest("POST", s"/api/update/amount/contributions/$subName")
 
     "succeed when given value is valid" in {

--- a/membership-attribute-service/test/integration/AccountDetailsFromZuoraIntegrationTest.scala
+++ b/membership-attribute-service/test/integration/AccountDetailsFromZuoraIntegrationTest.scala
@@ -6,6 +6,7 @@ import com.typesafe.config.ConfigFactory
 import components.TouchpointComponents
 import configuration.Stage
 import controllers.AccountHelpers
+import models.AccountDetailsWriter
 import monitoring.CreateNoopMetrics
 import org.specs2.mutable.Specification
 import play.api.libs.json.Json
@@ -33,7 +34,8 @@ class AccountDetailsFromZuoraIntegrationTest extends Specification {
             },
           Duration.Inf,
         )
-      result.map(_.foreach(accountDetails => println(Json.prettyPrint(accountDetails.toJson(catalog)))))
+      val accountDetailsWriter = new AccountDetailsWriter(isProd = false)
+      result.map(_.foreach(accountDetails => println(Json.prettyPrint(new accountDetailsWriter.WithAccountDetails(accountDetails, catalog).toJson))))
       result.isRight must_== true
     }
   }

--- a/membership-attribute-service/test/models/AnniversaryDateTest.scala
+++ b/membership-attribute-service/test/models/AnniversaryDateTest.scala
@@ -6,16 +6,16 @@ import org.specs2.mutable.Specification
 class AnniversaryDateTest extends Specification {
   "anniversaryDate" should {
     "if today is equal to subscription start, then anniversary is exactly in one year" in {
-      val actual = AccountDetails.anniversary(LocalDate.parse("2019-05-01"), LocalDate.parse("2019-05-01"))
+      val actual = AccountDetailsWriter.anniversary(LocalDate.parse("2019-05-01"), LocalDate.parse("2019-05-01"))
       actual should_=== LocalDate.parse("2020-05-01")
     }
     "if today is before next anniversary, then stop searching and return next anniversary date" in {
-      val actual = AccountDetails.anniversary(LocalDate.parse("2019-05-01"), LocalDate.parse("2020-04-28"))
+      val actual = AccountDetailsWriter.anniversary(LocalDate.parse("2019-05-01"), LocalDate.parse("2020-04-28"))
       actual should_=== LocalDate.parse("2020-05-01")
     }
 
     "if next anniversary is many years from the subscription start, then keep moving year by year until today is just before next anniversary date" in {
-      val actual = AccountDetails.anniversary(LocalDate.parse("2019-05-01"), LocalDate.parse("2025-05-01"))
+      val actual = AccountDetailsWriter.anniversary(LocalDate.parse("2019-05-01"), LocalDate.parse("2025-05-01"))
       actual should_=== LocalDate.parse("2026-05-01")
     }
   }

--- a/membership-attribute-service/test/models/ProductsResponseSpec.scala
+++ b/membership-attribute-service/test/models/ProductsResponseSpec.scala
@@ -182,7 +182,7 @@ class ProductsResponseSpec extends Specification with SafeLogging {
         |  } ]
         }""".stripMargin)
       val user = UserFromToken("test@thegulocal.com", "12345", None, None, None, None, None)
-      val productsResponseWrites = new ProductsResponseWrites(catalog)
+      val productsResponseWrites = new ProductsResponseWrites(catalog, isProd = false)
       import productsResponseWrites.writes
       val productsResponseJson = Json.toJson(productsResponseWrites.from(user, List(accountDetails)))
       productsResponseJson mustEqual expectedResponse
@@ -385,7 +385,7 @@ class ProductsResponseSpec extends Specification with SafeLogging {
         }""".stripMargin)
 
       val user = UserFromToken(email, identityId, None, None, None, None, None)
-      val productsResponseWrites = new ProductsResponseWrites(catalog)
+      val productsResponseWrites = new ProductsResponseWrites(catalog, isProd = false)
       import productsResponseWrites.writes
       val productsResponseJson = Json.toJson(productsResponseWrites.from(user, List(accountDetails)))
       productsResponseJson mustEqual expectedResponse


### PR DESCRIPTION
This PR sits on top of https://github.com/guardian/members-data-api/pull/1123

It adds a switch so we can ship it to main and only see the behaviour in CODE.

It seemed like a nice idea to avoid conflicts, but now I'm wondering with the extent of the changes, whether it's actually worse overall.  Hence the separate branch/PR so we can decide separately.