### PR TITLE
don't apply 1 day grace on charges on removed plans

### DIFF
--- a/membership-common/src/main/scala/com/gu/memsub/subsv2/Subscription.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/subsv2/Subscription.scala
@@ -81,7 +81,7 @@ object GetCurrentPlans {
         digipackGiftEnded(_ => sub.termEndDate >= dateToCheck)
       else
         paidPlanEnded(_ => {
-          val inGracePeriodAndNotCancelled = plan.effectiveEndDate == dateToCheck && !sub.isCancelled
+          val inGracePeriodAndNotCancelled = plan.effectiveEndDate == dateToCheck && !sub.isCancelled && !plan.lastChangeType.contains("Remove")
           plan.effectiveEndDate > dateToCheck || inGracePeriodAndNotCancelled
         })
     }


### PR DESCRIPTION
Normally we allow a one day grace period on charges after the end date.  This is because most subscriptions auto renew which extends the charges, but the renewal process doesn't happen until after midnight.  Therefore the grace period allows continuity of service.

However there are situations where the charge will not be extended, and we need to not allow the grace period.  These situations include cancellation of the subscription, or switching (removal of the plan).

This PR updates the rules for grace period application to stop applying it when a switch has happened.