### PR TITLE
add tier property to currentPlans/futurePlans

### DIFF
--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -117,6 +117,7 @@ object AccountDetails {
       }
 
       def jsonifyPlan(plan: RatePlan) = Json.obj(
+        "tier" -> getTier(catalog, plan),
         "name" -> externalisePlanName(plan),
         "start" -> plan.effectiveStartDate,
         "end" -> plan.effectiveEndDate,

--- a/membership-attribute-service/test/models/ProductsResponseSpec.scala
+++ b/membership-attribute-service/test/models/ProductsResponseSpec.scala
@@ -163,6 +163,7 @@ class ProductsResponseSpec extends Specification with SafeLogging {
         |        "billingPeriod" : "month"
         |      },
         |      "currentPlans" : [ {
+        |        "tier": "Supporter Plus",
         |        "name" : null,
         |        "start" : "2024-05-15",
         |        "end" : "2025-05-15",
@@ -364,6 +365,7 @@ class ProductsResponseSpec extends Specification with SafeLogging {
         |          "billingPeriod": "$month"
         |        },
         |        "currentPlans" : [ {
+        |          "tier": "$productName",
         |          "name" : null,
         |          "start" : "$startDate",
         |          "end" : "$endDate",


### PR DESCRIPTION
At the moment you can switch from supporter membership to contribution.

Because you pay in advance, the switch happens at the end of your term which could be almost a year ahead.

This means that after the switch, you are displayed in manage as still a supporter but your next payment will be calculated for your contribution.

This is not ideal because there's no clue that you have switched, and there is not enough information in the MDAPI response to make it possible to display that on screen.

This PR changes the MDAPI response so it also contains a tier property in each current and future plan.  The one at the top level still remains the "best" plan's tier.

TODO
- test in CODE if needed
- add a unit test for a pending switch sub (this would be a good idea in general, not something specific to this PR)