### PR TITLE
use parameterised date to serialise /mma response

### DIFF
--- a/membership-attribute-service/app/controllers/AccountController.scala
+++ b/membership-attribute-service/app/controllers/AccountController.scala
@@ -196,7 +196,7 @@ class AccountController(
         } yield result match {
           case Right(subscriptionList) =>
             logger.info(s"Successfully retrieved payment details result for identity user: $userId")
-            val productsResponseWrites = new ProductsResponseWrites(catalog)
+            val productsResponseWrites = new ProductsResponseWrites(catalog, LocalDate.now)
             val response = productsResponseWrites.from(user, subscriptionList)
             import productsResponseWrites.writes
             Ok(Json.toJson(response))

--- a/membership-attribute-service/app/models/ProductsResponse.scala
+++ b/membership-attribute-service/app/models/ProductsResponse.scala
@@ -2,15 +2,16 @@ package models
 
 import com.gu.memsub.subsv2.Catalog
 import com.gu.monitoring.SafeLogger.LogPrefix
+import org.joda.time.LocalDate
 import play.api.libs.json._
 
 case class UserDetails(firstName: Option[String], lastName: Option[String], email: String)
 
 case class ProductsResponse(user: UserDetails, products: List[AccountDetails])
 
-class ProductsResponseWrites(catalog: Catalog) {
+class ProductsResponseWrites(catalog: Catalog, today: LocalDate) {
   implicit val userDetailsWrites: OWrites[UserDetails] = Json.writes[UserDetails]
-  implicit def accountDetailsWrites(implicit logPrefix: LogPrefix): Writes[AccountDetails] = Writes[AccountDetails](_.toJson(catalog))
+  implicit def accountDetailsWrites(implicit logPrefix: LogPrefix): Writes[AccountDetails] = Writes[AccountDetails](_.toJson(catalog, today))
   implicit def writes(implicit logPrefix: LogPrefix): OWrites[ProductsResponse] = Json.writes[ProductsResponse]
 
   def from(user: UserFromToken, products: List[AccountDetails]) =

--- a/membership-attribute-service/test/integration/AccountDetailsFromZuoraIntegrationTest.scala
+++ b/membership-attribute-service/test/integration/AccountDetailsFromZuoraIntegrationTest.scala
@@ -7,6 +7,7 @@ import components.TouchpointComponents
 import configuration.Stage
 import controllers.AccountHelpers
 import monitoring.CreateNoopMetrics
+import org.joda.time.LocalDate
 import org.specs2.mutable.Specification
 import play.api.libs.json.Json
 
@@ -33,7 +34,7 @@ class AccountDetailsFromZuoraIntegrationTest extends Specification {
             },
           Duration.Inf,
         )
-      result.map(_.foreach(accountDetails => println(Json.prettyPrint(accountDetails.toJson(catalog)))))
+      result.map(_.foreach(accountDetails => println(Json.prettyPrint(accountDetails.toJson(catalog, LocalDate.now)))))
       result.isRight must_== true
     }
   }

--- a/membership-attribute-service/test/models/FilterPlansSpec.scala
+++ b/membership-attribute-service/test/models/FilterPlansSpec.scala
@@ -5,6 +5,7 @@ import com.gu.memsub.subsv2.reads.FixedDiscountRecurringTestData
 import com.gu.memsub.subsv2.reads.SubJsonReads.subscriptionReads
 import com.gu.memsub.subsv2.services.TestCatalog
 import com.gu.monitoring.SafeLogging
+import org.joda.time.LocalDate
 import org.specs2.mutable.Specification
 import utils.Resource
 import utils.TestLogPrefix.testLogPrefix
@@ -17,7 +18,7 @@ class FilterPlansSpec extends Specification with SafeLogging {
 
       val expected = FixedDiscountRecurringTestData.mainPlan
 
-      val actual = new FilterPlans(actualSubscription, TestCatalog.catalogProd)
+      val actual = new FilterPlans(actualSubscription, TestCatalog.catalogProd, LocalDate.parse("2099-01-01"))
 
       actual.currentPlans must containTheSameElementsAs(List(expected))
     }

--- a/membership-attribute-service/test/models/ProductsResponseSpec.scala
+++ b/membership-attribute-service/test/models/ProductsResponseSpec.scala
@@ -183,7 +183,7 @@ class ProductsResponseSpec extends Specification with SafeLogging {
         |  } ]
         }""".stripMargin)
       val user = UserFromToken("test@thegulocal.com", "12345", None, None, None, None, None)
-      val productsResponseWrites = new ProductsResponseWrites(catalog)
+      val productsResponseWrites = new ProductsResponseWrites(catalog, LocalDate.parse("2025-01-01"))
       import productsResponseWrites.writes
       val productsResponseJson = Json.toJson(productsResponseWrites.from(user, List(accountDetails)))
       productsResponseJson mustEqual expectedResponse
@@ -387,7 +387,7 @@ class ProductsResponseSpec extends Specification with SafeLogging {
         }""".stripMargin)
 
       val user = UserFromToken(email, identityId, None, None, None, None, None)
-      val productsResponseWrites = new ProductsResponseWrites(catalog)
+      val productsResponseWrites = new ProductsResponseWrites(catalog, LocalDate.parse("2025-01-01"))
       import productsResponseWrites.writes
       val productsResponseJson = Json.toJson(productsResponseWrites.from(user, List(accountDetails)))
       productsResponseJson mustEqual expectedResponse

--- a/membership-common/src/main/scala/com/gu/memsub/subsv2/Subscription.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/subsv2/Subscription.scala
@@ -26,8 +26,8 @@ case class Subscription(
 
   val firstPaymentDate: LocalDate = (customerAcceptanceDate :: ratePlans.map(_.effectiveStartDate)).min
 
-  def plan(catalog: Catalog): RatePlan =
-    GetCurrentPlans.currentPlans(this, LocalDate.now, catalog).fold(error => throw new RuntimeException(error), _.head)
+  def plan(catalog: Catalog, date: LocalDate = LocalDate.now): RatePlan =
+    GetCurrentPlans.currentPlans(this, date, catalog).fold(error => throw new RuntimeException(error), _.head)
 
 }
 


### PR DESCRIPTION
models.ProductsResponseSpec was failing in the build because it was a year and a day since the test was created.

This PR parameterises the serialiser with the date, so we can pretend it's the 1st Jan for ever more.  Thus the tests all pass.