### PR TITLE
fix tests that depended on the date to hard code it

### DIFF
--- a/membership-attribute-service/test/acceptance/AccountControllerAcceptanceTest.scala
+++ b/membership-attribute-service/test/acceptance/AccountControllerAcceptanceTest.scala
@@ -158,7 +158,7 @@ class AccountControllerAcceptanceTest extends AcceptanceTest {
       )
       val nonGiftSubscriptionAccountId = nonGiftSubscription.accountId
 
-      subscriptionServiceMock.current(contact)(any) returns
+      subscriptionServiceMock.current(contact, any)(any) returns
         Future(List(nonGiftSubscription))
 
       val giftSubscriptionFromSubscriptionService = TestSubscription(
@@ -216,7 +216,7 @@ class AccountControllerAcceptanceTest extends AcceptanceTest {
 
       contactRepositoryMock.get("200067388")(any) was called
       supporterProductDataServiceMock.getSupporterRatePlanItems("200067388")(any[LogPrefix]) was called
-      subscriptionServiceMock.current(contact)(any) was called
+      subscriptionServiceMock.current(contact, any)(any) was called
       zuoraRestServiceMock.getGiftSubscriptionRecordsFromIdentityId("200067388")(any) was called
       subscriptionServiceMock.get(Subscription.SubscriptionNumber(giftSubscription.Name), isActiveToday = false)(any) was called
 
@@ -340,7 +340,7 @@ class AccountControllerAcceptanceTest extends AcceptanceTest {
         plans = List(plan),
       )
 
-      subscriptionServiceMock.current(contact)(any) returns Future(List(subscription))
+      subscriptionServiceMock.current(contact, any)(any) returns Future(List(subscription))
 
       zuoraRestServiceMock.updateChargeAmount(
         subscription.subscriptionNumber,
@@ -368,7 +368,7 @@ class AccountControllerAcceptanceTest extends AcceptanceTest {
       contactRepositoryMock.get("200067388")(any) was called
 
       identityMockClientAndServer.verify(identityRequest)
-      subscriptionServiceMock.current(contact)(any) was called
+      subscriptionServiceMock.current(contact, any)(any) was called
       zuoraRestServiceMock.updateChargeAmount(
         subscription.subscriptionNumber,
         charge.id,
@@ -444,7 +444,7 @@ class AccountControllerAcceptanceTest extends AcceptanceTest {
         termEndDate = new LocalDate(2024, 4, 12),
       )
 
-      subscriptionServiceMock.current(contact)(any) returns Future(List(subscription))
+      subscriptionServiceMock.current(contact, any)(any) returns Future(List(subscription))
 
       val cancellationEffectiveDate = new LocalDate(2024, 4, 5)
       subscriptionServiceMock
@@ -452,7 +452,7 @@ class AccountControllerAcceptanceTest extends AcceptanceTest {
         .right(Some(cancellationEffectiveDate))
 
       subscriptionServiceMock
-        .subscriptionsForAccountId(subscription.accountId)(any) shouldReturn SimpleEitherT
+        .subscriptionsForAccountId(subscription.accountId, any)(any) shouldReturn SimpleEitherT
         .right(List(subscription))
         .run
 
@@ -482,10 +482,10 @@ class AccountControllerAcceptanceTest extends AcceptanceTest {
       contactRepositoryMock.get("200067388")(any) was called
 
       identityMockClientAndServer.verify(identityRequest)
-      subscriptionServiceMock.current(contact)(any) was called
+      subscriptionServiceMock.current(contact, any)(any) was called
 
       subscriptionServiceMock.decideCancellationEffectiveDate(SubscriptionNumber(subscriptionId), any, any)(any) was called
-      subscriptionServiceMock.subscriptionsForAccountId(subscription.accountId)(any) was called
+      subscriptionServiceMock.subscriptionsForAccountId(subscription.accountId, any)(any) was called
       zuoraRestServiceMock.disableAutoPay(subscription.accountId)(any) was called
       zuoraRestServiceMock.updateCancellationReason(SubscriptionNumber(subscriptionId), "My reason")(any) was called
       zuoraRestServiceMock.cancelSubscription(SubscriptionNumber(subscriptionId), subscription.termEndDate, Some(cancellationEffectiveDate))(

--- a/membership-attribute-service/test/acceptance/PaymentUpdateControllerAcceptanceTest.scala
+++ b/membership-attribute-service/test/acceptance/PaymentUpdateControllerAcceptanceTest.scala
@@ -156,7 +156,7 @@ class PaymentUpdateControllerAcceptanceTest extends AcceptanceTest {
         plans = List(TestPaidSubscriptionPlan(productRatePlanId = TestCatalog.homeDeliveryPrpId)),
       )
 
-      subscriptionServiceMock.current(contact)(any) returns Future(List(subscription))
+      subscriptionServiceMock.current(contact, any)(any) returns Future(List(subscription))
 
       val account = TestQueriesAccount()
       val paymentMethodId = randomId("paymentMethod")
@@ -211,7 +211,7 @@ class PaymentUpdateControllerAcceptanceTest extends AcceptanceTest {
       httpResponse.getStatus shouldEqual 200
 
       identityMockClientAndServer.verify(identityRequest)
-      subscriptionServiceMock.current(contact)(any) was called
+      subscriptionServiceMock.current(contact, any)(any) was called
       contactRepositoryMock.get("200067388")(any) was called
       zuoraSoapServiceMock.getAccount(subscription.accountId)(any) wasCalled twice
       zuoraSoapServiceMock.getContact(account.billToId)(any) was called
@@ -314,7 +314,7 @@ class PaymentUpdateControllerAcceptanceTest extends AcceptanceTest {
         plans = List(TestPaidSubscriptionPlan(productRatePlanId = TestCatalog.digipackPrpId)),
       )
 
-      subscriptionServiceMock.current(contact)(any) returns Future(List(subscription))
+      subscriptionServiceMock.current(contact, any)(any) returns Future(List(subscription))
 
       val customer = TestStripeCustomer(card =
         TestStripeCard(
@@ -358,7 +358,7 @@ class PaymentUpdateControllerAcceptanceTest extends AcceptanceTest {
       httpResponse.getStatus shouldEqual 200
 
       identityMockClientAndServer.verify(identityRequest)
-      subscriptionServiceMock.current(contact)(any) was called
+      subscriptionServiceMock.current(contact, any)(any) was called
       contactRepositoryMock.get("200067388")(any) was called
       ukStripeServiceMock.createCustomerWithStripePaymentMethod("myStripePaymentMethodId")(any) was called
       ukStripeServiceMock.paymentIntentsGateway was called

--- a/membership-attribute-service/test/integration/AccountDetailsFromZuoraIntegrationTest.scala
+++ b/membership-attribute-service/test/integration/AccountDetailsFromZuoraIntegrationTest.scala
@@ -26,7 +26,7 @@ class AccountDetailsFromZuoraIntegrationTest extends Specification {
       val eventualResult = for {
         catalog <- touchpointComponents.futureCatalog
         result <- touchpointComponents.accountDetailsFromZuora
-          .fetch("200421949", AccountHelpers.NoFilter)
+          .fetch("200421949", AccountHelpers.NoFilter, LocalDate.parse("2025-01-01"))
           .run
           .map { list =>
             println(s"Fetched this list: $list")

--- a/membership-common/src/test/scala/com/gu/memsub/subsv2/services/SubscriptionServiceTest.scala
+++ b/membership-common/src/test/scala/com/gu/memsub/subsv2/services/SubscriptionServiceTest.scala
@@ -280,7 +280,7 @@ class SubscriptionServiceTest extends Specification {
 
     "Be able to fetch a supporter plus subscription" in {
       val sub = service.get(memsub.Subscription.SubscriptionNumber("1234"))
-      sub.map(_.plan(catalog)) must beSome(
+      sub.map(_.plan(catalog, LocalDate.parse("2025-01-01"))) must beSome(
         RatePlan(
           RatePlanId("8ad08ae28f9570f0018f958813ed10ca"),
           supporterPlusPrpId,
@@ -338,12 +338,12 @@ class SubscriptionServiceTest extends Specification {
     }
 
     "Leverage the soap client to fetch subs by contact ID" in {
-      val subs = service.current(contact)
+      val subs = service.current(contact, LocalDate.parse("2025-01-01"))
       subs.map(_.subscriptionNumber.getNumber).sorted mustEqual List("A-S00890520", "A-S00890521") // from the test resources jsons
     }
 
     "Be able to fetch subs where term ends after the specified date" in {
-      val currentSubs = service.current(contact)
+      val currentSubs = service.current(contact, LocalDate.parse("2025-01-01"))
       val sinceSubs = service.since(1 Jun 2025)(contact)
       currentSubs mustNotEqual sinceSubs
       sinceSubs.length mustEqual 0 // because no subscriptions have a term end date AFTER 1 Jun 2025


### PR DESCRIPTION
similar to https://github.com/guardian/members-data-api/pull/1130

This fixes a bunch more tests that were failing due to depending on dates and were added roughly a year ago