### PR TITLE
fix tests that depended on the date to hard code it

### DIFF
--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -19,6 +19,7 @@ import configuration.Stage
 import monitoring.CreateMetrics
 import org.apache.pekko.actor.ActorSystem
 import org.http4s.Uri
+import org.joda.time.LocalDate
 import scalaz.{-\/, \/-}
 import scalaz.std.scalaFuture._
 import services._
@@ -142,7 +143,7 @@ class TouchpointComponents(
       }
 
   lazy val subscriptionService: SubscriptionService[Future] = {
-    lazy val zuoraSubscriptionService = new SubscriptionService(futureCatalog(_), zuoraRestClient, zuoraSoapService)
+    lazy val zuoraSubscriptionService = new SubscriptionService(futureCatalog(_), zuoraRestClient, zuoraSoapService, () => LocalDate.now())
 
     subscriptionServiceOverride.getOrElse(zuoraSubscriptionService)
   }

--- a/membership-common/src/main/scala/com/gu/memsub/subsv2/services/SubscriptionService.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/subsv2/services/SubscriptionService.scala
@@ -50,7 +50,8 @@ object Trace {
 
 }
 
-class SubscriptionService[M[_]: Monad](futureCatalog: LogPrefix => M[Catalog], rest: SimpleClient[M], soap: SoapClient[M]) extends SafeLogging {
+class SubscriptionService[M[_]: Monad](futureCatalog: LogPrefix => M[Catalog], rest: SimpleClient[M], soap: SoapClient[M], today: () => LocalDate)
+    extends SafeLogging {
   private type EitherTM[A] = EitherT[String, M, A]
 
   /** Time by which Bill Run should have run and completed. Usually starts around 5AM and takes 1 hour.
@@ -150,7 +151,7 @@ class SubscriptionService[M[_]: Monad](futureCatalog: LogPrefix => M[Catalog], r
 
   private def getCurrentSubscriptions(catalog: Catalog, subs: List[Subscription]): Disjunction[String, NonEmptyList[Subscription]] =
     Sequence(subs.map { sub =>
-      GetCurrentPlans.currentPlans(sub, LocalDate.now, catalog).map(_ => sub)
+      GetCurrentPlans.currentPlans(sub, today(), catalog).map(_ => sub)
     })
 
   private def getSubscriptionsFromContact(contact: ContactId)(implicit logPrefix: LogPrefix): M[Disjunction[String, List[Subscription]]] =

--- a/membership-common/src/test/scala/com/gu/memsub/subsv2/services/SubscriptionServiceTest.scala
+++ b/membership-common/src/test/scala/com/gu/memsub/subsv2/services/SubscriptionServiceTest.scala
@@ -68,7 +68,7 @@ class SubscriptionServiceTest extends Specification {
   }
 
   val rc = new SimpleClient[Id](ZuoraRestConfig("TESTS", "https://localhost", "foo", "bar"), subscriptions)
-  private val service = new SubscriptionService[Id](_ => catalog, rc, soapClient)
+  private val service = new SubscriptionService[Id](_ => catalog, rc, soapClient, () => LocalDate.parse("2025-01-01"))
 
   "Current Plan" should {
 
@@ -280,7 +280,7 @@ class SubscriptionServiceTest extends Specification {
 
     "Be able to fetch a supporter plus subscription" in {
       val sub = service.get(memsub.Subscription.SubscriptionNumber("1234"))
-      sub.map(_.plan(catalog)) must beSome(
+      sub.map(_.plan(catalog, LocalDate.parse("2025-01-01"))) must beSome(
         RatePlan(
           RatePlanId("8ad08ae28f9570f0018f958813ed10ca"),
           supporterPlusPrpId,


### PR DESCRIPTION
supersedes https://github.com/guardian/members-data-api/pull/1132 but doesn't pass `today` around as much

similar to https://github.com/guardian/members-data-api/pull/1130

This fixes a bunch more tests that were failing due to depending on dates and were added roughly a year ago