### PR TITLE
add new mmaProductKey with distinct value for paper+ subscriptions

### DIFF
--- a/membership-attribute-service/test/models/GetMMAProductKeyTest.scala
+++ b/membership-attribute-service/test/models/GetMMAProductKeyTest.scala
@@ -1,0 +1,44 @@
+package models
+
+import acceptance.data.TestSingleCharge
+import com.gu.memsub.Subscription.RatePlanId
+import com.gu.memsub.subsv2.RatePlan
+import com.gu.memsub.subsv2.services.TestCatalog
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import scalaz.NonEmptyList
+
+class GetMMAProductKeyTest extends AnyFlatSpec with Matchers {
+
+  "getMMAProductKey" should "handle a newspaper subscription" in {
+    val testRatePlanNewspaper = RatePlan(
+      RatePlanId("idid"),
+      TestCatalog.homeDeliveryPrpId,
+      "Home Delivery",
+      None,
+      Nil,
+      NonEmptyList(
+        TestSingleCharge(chargeId = TestCatalog.ProductRatePlanChargeIds.homeDelMondayCharge),
+      ),
+    )
+    val actual = AccountDetails.getMMAProductKey(TestCatalog.catalog, testRatePlanNewspaper)
+    actual should be("Home Delivery")
+  }
+
+  it should "handle a plus subscription" in {
+    val testRatePlanNewspaper = RatePlan(
+      RatePlanId("idid"),
+      TestCatalog.homeDeliveryPlusPrpId,
+      "Home Delivery",
+      None,
+      Nil,
+      NonEmptyList(
+        TestSingleCharge(chargeId = TestCatalog.ProductRatePlanChargeIds.homeDeliveryPlusChargeId),
+        TestSingleCharge(chargeId = TestCatalog.ProductRatePlanChargeIds.homeDelMondayCharge),
+      ),
+    )
+    val actual = AccountDetails.getMMAProductKey(TestCatalog.catalog, testRatePlanNewspaper)
+    actual should be("Home Delivery + Digital")
+  }
+
+}

--- a/membership-attribute-service/test/models/ProductsResponseSpec.scala
+++ b/membership-attribute-service/test/models/ProductsResponseSpec.scala
@@ -112,6 +112,7 @@ class ProductsResponseSpec extends Specification with SafeLogging {
         |  },
         |  "products" : [ {
         |    "tier" : "Supporter Plus",
+        |    "mmaProductKey" : "Supporter Plus",
         |    "isPaidTier" : true,
         |    "selfServiceCancellation" : {
         |      "isAllowed" : true,
@@ -164,6 +165,7 @@ class ProductsResponseSpec extends Specification with SafeLogging {
         |      },
         |      "currentPlans" : [ {
         |        "tier": "Supporter Plus",
+        |        "mmaProductKey": "Supporter Plus",
         |        "name" : null,
         |        "start" : "2024-05-15",
         |        "end" : "2025-05-15",
@@ -310,6 +312,7 @@ class ProductsResponseSpec extends Specification with SafeLogging {
         |  "products": [
         |    {
         |      "tier": "$productName",
+        |      "mmaProductKey": "$productName",
         |      "isPaidTier": true,
         |      "selfServiceCancellation": {
         |        "isAllowed": true,
@@ -366,6 +369,7 @@ class ProductsResponseSpec extends Specification with SafeLogging {
         |        },
         |        "currentPlans" : [ {
         |          "tier": "$productName",
+        |          "mmaProductKey": "$productName",
         |          "name" : null,
         |          "start" : "$startDate",
         |          "end" : "$endDate",

--- a/membership-common/src/main/scala/com/gu/memsub/ProductFamily.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/ProductFamily.scala
@@ -16,6 +16,7 @@ object Product {
 
   sealed trait Paper extends ContentSubscription
   sealed trait Weekly extends Paper
+  sealed trait Newspaper extends Paper
 
   case object UnknownProduct extends Product {
     val name = "UNKNOWN_PRODUCT"
@@ -39,16 +40,16 @@ object Product {
   case object Digipack extends ContentSubscription {
     val name = "digitalpack"
   }
-  case object Delivery extends Paper {
+  case object Delivery extends Newspaper {
     val name = "delivery"
   }
-  case object NationalDelivery extends Paper {
+  case object NationalDelivery extends Newspaper {
     val name = "nationalDelivery"
   }
-  case object Voucher extends Paper {
+  case object Voucher extends Newspaper {
     val name = "voucher"
   }
-  case object DigitalVoucher extends Paper {
+  case object DigitalVoucher extends Newspaper {
     val name = "digitalVoucher"
   }
   case object WeeklyZoneA extends Weekly {

--- a/membership-common/src/main/scala/com/gu/memsub/subsv2/Plan.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/subsv2/Plan.scala
@@ -224,6 +224,14 @@ case class RatePlan(
   def productType(catalog: Catalog): ProductType =
     productRatePlan(catalog).productType
 
+  def getChargeTypes(catalog: Catalog): List[ProductRatePlanChargeProductType] = {
+    val getChargeProductType = catalog.productRatePlans(productRatePlanId).productRatePlanCharges
+    ratePlanCharges.list.toList
+      .map(_.productRatePlanChargeId)
+      .map(getChargeProductType)
+      .distinct
+  }
+
 }
 
 /** Low level model of a product rate plan, as it appears in the Zuora product catalog

--- a/membership-common/src/test/scala/com/gu/memsub/subsv2/services/TestCatalog.scala
+++ b/membership-common/src/test/scala/com/gu/memsub/subsv2/services/TestCatalog.scala
@@ -31,6 +31,7 @@ object TestCatalog {
   val digipackPrpId = ProductRatePlanId("2c92c0f94f2acf73014f2c908f671591")
   val gw6for6PrpId = ProductRatePlanId("2c92c0f965f212210165f69b94c92d66")
   val homeDeliveryPrpId = ProductRatePlanId("homedelPRPid")
+  val homeDeliveryPlusPrpId = ProductRatePlanId("homedelPlusPRPid")
   val gw = ProductRatePlanId("2c92c0f965dc30640165f150c0956859")
   val discountPrpId = ProductRatePlanId("2c92c0f96b03800b016b081fc04f1ba2")
   val now = 27 Sep 2016
@@ -42,6 +43,9 @@ object TestCatalog {
     val tierThreeDigitalId = ProductRatePlanChargeId("tierthreedigiPRPCid")
     val tierThreeGWId = ProductRatePlanChargeId("tierthreeGWprpcID")
     val guardianAdLiteChargeId = ProductRatePlanChargeId("8a1285e294443da501944b04cb9d2ca0")
+    val homeDeliveryPlusChargeId: ProductRatePlanChargeId = ProductRatePlanChargeId("homedelchargedpID")
+    val homeDelMondayCharge: ProductRatePlanChargeId = ProductRatePlanChargeId("homedelchargemondayID")
+
   }
   import ProductRatePlanChargeIds._
 
@@ -121,7 +125,17 @@ object TestCatalog {
       homeDeliveryPrpId,
       "Newspaper - Home Delivery",
       idForProduct(Product.Delivery),
-      Map(ProductRatePlanChargeId("homedelchargeID") -> MondayPaper),
+      Map(homeDelMondayCharge -> MondayPaper),
+      Some(ProductType("Newspaper - Home Delivery")),
+    ),
+    homeDeliveryPlusPrpId -> ProductRatePlan(
+      homeDeliveryPlusPrpId,
+      "Newspaper - Home Delivery",
+      idForProduct(Product.Delivery),
+      Map(
+        homeDelMondayCharge -> MondayPaper,
+        homeDeliveryPlusChargeId -> Digipack,
+      ),
       Some(ProductType("Newspaper - Home Delivery")),
     ),
     contributorPrpId -> ProductRatePlan(


### PR DESCRIPTION
Some of our customer are on newspaper plans, and some are on newspaper plus digital.

At the moment they all get the same digital access.  We want to migrate everyone onto the actual digital plans over time.

In the mean time, people already on the non digital plan are being given the option to move across, or stay on the lower price but lose the digital access.

As part of this work, we want it to be clear in manage whether they are entitled to digital benefits.

At the moment, in the response, we return the same tier, and similar name if someone has digital access.

This PR adds a new mmaProductKey property to the subscription and current/futurePlans objects to indicate which product they have.

It is identical to the existing "tier" however if they have a plus paper then it will append " + Digital" on the end.

Tested in CODE, no obvious regressions and the mmaProductKey is coming through with reasonable looking values.