### PR TITLE
Fix: Incorrect "Next monthly payment" display for Australian Student Offer (24-month free promo)

### DIFF
--- a/membership-attribute-service/app/services/zuora/payment/PaymentService.scala
+++ b/membership-attribute-service/app/services/zuora/payment/PaymentService.scala
@@ -37,7 +37,9 @@ class PaymentService(zuoraService: ZuoraSoapService)(implicit ec: ExecutionConte
 
     for {
       account <- zuoraService.getAccount(sub.accountId)
-      eventualBills = getNextBill(sub.id, account, 15).withLogging(s"next bill for $sub")
+      // Request 30 bills to handle long promotional periods (e.g., Australian student offer: 24 months free)
+      // 24 bills for promo + 6 buffer bills ensures we find the first paid bill even with billing irregularities
+      eventualBills = getNextBill(sub.id, account, 30).withLogging(s"next bill for $sub")
       eventualMaybePaymentMethod = getPaymentMethod(account.defaultPaymentMethodId, defaultMandateIdIfApplicable) // kick off async
       bills <- eventualBills
       maybePaymentMethod <- eventualMaybePaymentMethod

--- a/membership-attribute-service/test/acceptance/AccountControllerAcceptanceTest.scala
+++ b/membership-attribute-service/test/acceptance/AccountControllerAcceptanceTest.scala
@@ -184,7 +184,7 @@ class AccountControllerAcceptanceTest extends AcceptanceTest {
 
       zuoraSoapServiceMock.getPaymentSummary(nonGiftSubscription.subscriptionNumber, Currency.GBP)(any) returns Future(TestPaymentSummary())
       zuoraSoapServiceMock.getAccount(nonGiftSubscriptionAccountId)(any) returns Future(TestQueriesAccount())
-      zuoraSoapServiceMock.previewInvoices(nonGiftSubscription.id, 15)(any) returns Future(Seq(TestPreviewInvoiceItem()))
+      zuoraSoapServiceMock.previewInvoices(nonGiftSubscription.id, 30)(any) returns Future(Seq(TestPreviewInvoiceItem()))
 
       val patronSubscription = TestDynamoSupporterRatePlanItem(
         subscriptionName = patronSubscriptionName,
@@ -228,7 +228,7 @@ class AccountControllerAcceptanceTest extends AcceptanceTest {
 
       zuoraSoapServiceMock.getAccount(nonGiftSubscriptionAccountId)(any) was called
       zuoraSoapServiceMock.getPaymentSummary(nonGiftSubscription.subscriptionNumber, Currency.GBP)(any) was called
-      zuoraSoapServiceMock.previewInvoices(nonGiftSubscription.id, 15)(any) was called
+      zuoraSoapServiceMock.previewInvoices(nonGiftSubscription.id, 30)(any) was called
 
       supporterProductDataServiceMock wasNever calledAgain
       contactRepositoryMock wasNever calledAgain

--- a/membership-common/src/main/scala/com/gu/services/model/PaymentDetails.scala
+++ b/membership-common/src/main/scala/com/gu/services/model/PaymentDetails.scala
@@ -48,7 +48,7 @@ object PaymentDetails extends SafeLogging {
       chargedThroughDate = plan.chargedThroughDate,
       customerAcceptanceDate = sub.customerAcceptanceDate,
       // If nextPayment is None (no bills with amount > 0 found), return 0 instead of None.
-      // This happens when users have free products or 100% discount/promo codes forever
+      // This happens when users have free products or 100% discount/promo codes for more than 30 months
       nextPaymentPrice = nextPayment.map(p => (BigDecimal.decimal(p.price.amount) * 100).setScale(2, HALF_UP).intValue).orElse(Some(0)),
       lastPaymentDate = lastPaymentDate,
       nextPaymentDate = nextPayment.map(_.date),

--- a/membership-common/src/main/scala/com/gu/services/model/PaymentDetails.scala
+++ b/membership-common/src/main/scala/com/gu/services/model/PaymentDetails.scala
@@ -47,7 +47,9 @@ object PaymentDetails extends SafeLogging {
       startDate = sub.contractEffectiveDate,
       chargedThroughDate = plan.chargedThroughDate,
       customerAcceptanceDate = sub.customerAcceptanceDate,
-      nextPaymentPrice = nextPayment.map(p => (BigDecimal.decimal(p.price.amount) * 100).setScale(2, HALF_UP).intValue),
+      // If nextPayment is None (no bills with amount > 0 found), return 0 instead of None.
+      // This happens when users have free products or 100% discount/promo codes forever
+      nextPaymentPrice = nextPayment.map(p => (BigDecimal.decimal(p.price.amount) * 100).setScale(2, HALF_UP).intValue).orElse(Some(0)),
       lastPaymentDate = lastPaymentDate,
       nextPaymentDate = nextPayment.map(_.date),
       nextInvoiceDate = nextInvoiceDate,


### PR DESCRIPTION
#### Problem
Users with the Australian Student Offer (24 months of Supporter Plus for free) were seeing "Next monthly payment: $20.00 AUD" in MMA instead of $0.00 during the promotional period. This occurred because the backend was only fetching 15 bills from Zuora's preview invoice API, which was insufficient to cover the full 24-month promotional period.

#### Root Cause Analysis
The payment calculation flow works as follows:

```
MMA Frontend Request → PaymentService.getPaymentSummary() → Zuora Preview Invoice API → BillingSchedule.fromPreviewInvoiceItems() → Find first bill with amount > 0 → Set as nextPaymentPrice
```

**Issue**: The preview invoice call was limited to 15 bills, but with a 24-month promotional period, the first paid bill (amount > 0) occurs after 24 months, requiring at least 24 bills to be fetched.

**Impact**: The system found no bills with amount > 0 within the first 15 bills, causing `nextPaymentPrice` to be set to `None/null`, which the frontend displayed as the regular subscription price ($20.00 AUD).

#### Solution
Made two key changes to ensure accurate payment calculations for long promotional periods:

1. **Increased preview invoice fetch count** (PaymentService.scala):
   - Changed from 15 to 30 bills to accommodate 24-month promo + 6 buffer bills
   - Added explanatory comment documenting the rationale

2. **Enhanced fallback logic** (PaymentDetails.scala):
   - When no positive-amount bill is found, set `nextPaymentPrice` to 0 instead of None
   - Added comment explaining this handles 100% discount/promo scenarios

#### Code Changes

**Before:**
```scala
// PaymentService.scala
eventualBills = getNextBill(sub.id, account, 15).withLogging(s"next bill for $sub")

// PaymentDetails.scala  
nextPaymentPrice = nextPayment.map(p => (BigDecimal.decimal(p.price.amount) * 100).setScale(2, HALF_UP).intValue),
```

**After:**
```scala
// PaymentService.scala
// Request 30 bills to handle long promotional periods (e.g., Australian student offer: 24 months free)
// 24 bills for promo + 6 buffer bills ensures we find the first paid bill even with billing irregularities
eventualBills = getNextBill(sub.id, account, 30).withLogging(s"next bill for $sub")

// PaymentDetails.scala
// If nextPayment is None (no bills with amount > 0 found), return 0 instead of None.
// This happens when users have free products or 100% discount/promo codes for more than 30 months
nextPaymentPrice = nextPayment.map(p => (BigDecimal.decimal(p.price.amount) * 100).setScale(2, HALF_UP).intValue).orElse(Some(0)),
```

#### Performance Considerations
- Minimal impact expected: Zuora SOAP API could efficiently handle 30 bills vs 15 - But we should test it!
- Future-proofed: Accommodates potential longer promotional periods
- No breaking changes to existing API contracts

#### Related Issues
- Fixes display issue for Australian Student Offer
- Improves handling of any long-term promotional subscriptions
- Enhances robustness for 100% discount scenarios

---

## Frontend Suggestion for MMA

### Issue with Current Frontend Display
The MMA currently shows "Next monthly payment: $X.XX" even when the next payment is not due for many months (e.g., 24 months into the future). This is misleading for users with long promotional periods.

### Recommended Frontend Enhancement

**Current behavior:** Always shows "Next monthly payment: $X.XX"

**Suggested improvement:** Conditionally display payment information based on when the next payment is actually due:

```javascript
// Pseudocode for frontend logic
const displayPaymentInfo = (nextPaymentDate, nextPaymentAmount) => {
  const now = new Date();
  const paymentDate = new Date(nextPaymentDate);
  const monthsUntilPayment = Math.ceil((paymentDate - now) / (1000 * 60 * 60 * 24 * 30));
  
  if (nextPaymentAmount === 0) {
    return "Your subscription is currently free";
  } else if (monthsUntilPayment <= 2) {
    return `Next monthly payment: $${nextPaymentAmount}`;
  } else if (monthsUntilPayment <= 12) {
    return `Next payment: $${nextPaymentAmount} (due in ${monthsUntilPayment} months)`;
  } else {
    return `Next payment: $${nextPaymentAmount} (due ${paymentDate.toLocaleDateString()})`;
  }
};
```

### Alternative Approaches

1. **Promo-specific messaging:**
   ```
   "Your promotional period is active until [date]"
   "After [date], your subscription will be $X.XX per month"
   ```

2. **Progressive disclosure:**
   ```
   "Next payment: $0.00 (promotional pricing)"
   [Show details] → "Your next paid billing cycle starts on [date] at $X.XX/month"
   ```

3. **Status-based display:**
   ```
   - During promo: "Promotional subscription (free until [date])"
   - Regular billing: "Next monthly payment: $X.XX"
   ```

### Implementation Priority
**High Priority:** This frontend improvement is essential for user experience, as the current display can be confusing and may cause users to think they're being charged when they're not.

### Files to modify in manage-frontend:
- Payment display components
- Subscription status components  
- Any components that render `nextPaymentPrice` from the MDAPI