### PR TITLE
add mmaProductKey to cancelled subs endpoint

### DIFF
--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -262,6 +262,7 @@ object CancelledSubscription {
       .map { plan =>
         Json.obj(
           "tier" -> getTier(catalog, plan),
+          "mmaProductKey" -> getMMAProductKey(catalog, plan),
           "subscription" -> Json.obj(
             "subscriptionId" -> subscription.subscriptionNumber.getNumber,
             "cancellationEffectiveDate" -> subscription.termEndDate,


### PR DESCRIPTION
We recently added the mmaProductKey field to MDAPI https://github.com/guardian/members-data-api/pull/1137 so that manage can understand what kind of product people have, even when it's under the same zuora product.

There have been reports of people getting Oops error in manage recently.

It turns out that we didn't add the new field for the cancelled subs endpoint, but manage was expecting it.

This PR adds the field mmaProductKey to the cancelled subs endpoint.

## Question

Why didn't we get any alert for the elevated Oops error rate?