### PR TITLE
Filter out Feast subscriptions from Live App expiry date handling

### DIFF
--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -78,7 +78,7 @@ class AttributeController(
   ): Attributes = {
     // Filter out Feast subscriptions from Live App subscription expiry date
     val liveAppMobileExpiryDate = mobileSubscriptionStatus.flatMap { status =>
-      val isFeastSubscription = status.productId.exists(_.contains("Feast"))
+      val isFeastSubscription = status.productId.exists(id => id.contains("Feast") || id.contains("feast"))
       if (isFeastSubscription) {
         None // Don't set Live App expiry for Feast subscriptions
       } else {

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -76,10 +76,19 @@ class AttributeController(
       latestOneOffDate: Option[LocalDate],
       mobileSubscriptionStatus: Option[MobileSubscriptionStatus],
   ): Attributes = {
-    val mobileExpiryDate = mobileSubscriptionStatus.map(_.to.toLocalDate)
+    // Filter out Feast subscriptions from Live App subscription expiry date
+    val liveAppMobileExpiryDate = mobileSubscriptionStatus.flatMap { status =>
+      val isFeastSubscription = status.productId.exists(_.contains("Feast"))
+      if (isFeastSubscription) {
+        None // Don't set Live App expiry for Feast subscriptions
+      } else {
+        Some(status.to.toLocalDate)
+      }
+    }
+    
     attributes.copy(
       OneOffContributionDate = latestOneOffDate,
-      LiveAppSubscriptionExpiryDate = mobileExpiryDate,
+      LiveAppSubscriptionExpiryDate = liveAppMobileExpiryDate,
     )
   }
 

--- a/membership-attribute-service/app/controllers/AttributeController.scala
+++ b/membership-attribute-service/app/controllers/AttributeController.scala
@@ -85,7 +85,7 @@ class AttributeController(
         Some(status.to.toLocalDate)
       }
     }
-    
+
     attributes.copy(
       OneOffContributionDate = latestOneOffDate,
       LiveAppSubscriptionExpiryDate = liveAppMobileExpiryDate,

--- a/membership-attribute-service/app/models/MobileSubscriptionStatus.scala
+++ b/membership-attribute-service/app/models/MobileSubscriptionStatus.scala
@@ -8,6 +8,7 @@ import scala.util.Try
 case class MobileSubscriptionStatus(
     valid: Boolean,
     to: DateTime,
+    productId: Option[String] = None,
 )
 
 object MobileSubscriptionStatus {


### PR DESCRIPTION
## Problem
Users with Feast app subscriptions were incorrectly having their subscription data included in the `LiveAppSubscriptionExpiryDate` attribute, causing the frontend to display them as "Live App" subscribers instead of properly identifying them as Feast app users. This situation is described by this [card](https://trello.com/c/wL1CcDxM/469-filter-out-feast-subscriptions-from-mdapi-when-checking-for-live-app-subs) and its associated [conversation thread](https://chat.google.com/room/AAAAuotUxTg/ei-7b301LDA/ei-7b301LDA?cls=10). The frontend change that will use this new implementation can be tracked to this [pull request](https://github.com/guardian/manage-frontend/pull/1538).

## Analysis
The root cause was in `AttributeController.scala` where the `addOneOffAndMobile()` function was blindly setting `LiveAppSubscriptionExpiryDate` for ALL mobile subscriptions without differentiating between product types:
- News app subscriptions (should set LiveAppSubscriptionExpiryDate)
- Puzzle app subscriptions (should set LiveAppSubscriptionExpiryDate) 
- Feast app subscriptions (should NOT set LiveAppSubscriptionExpiryDate)

The `MobileSubscriptionStatus` model also lacked the `productId` field needed for product-specific filtering.

## Solution
This PR implements product-aware mobile subscription processing:

### Data Model Enhancement (`models/MobileSubscriptionStatus.scala`)
- Added optional `productId: Option[String] = None` field to capture subscription product information
- Maintains backward compatibility with existing code

### Smart Filtering Logic (`controllers/AttributeController.scala`)
- Updated mobile subscription processing to check productId for Feast subscriptions
- Only sets `LiveAppSubscriptionExpiryDate` for non-Feast mobile subscriptions
- Preserves existing behavior for news and puzzle app subscriptions

### Key Changes
```scala
// Before: All mobile subscriptions set LiveAppSubscriptionExpiryDate
attributes + (LiveAppSubscriptionExpiryDate -> status.to.getMillis.toString)

// After: Only non-Feast subscriptions set LiveAppSubscriptionExpiryDate
if (status.productId.exists(_.contains("Feast"))) {
  // Don't add to LiveAppSubscriptionExpiryDate for Feast subscriptions
  attributes
} else {
  attributes + (LiveAppSubscriptionExpiryDate -> status.to.getMillis.toString)
}
```

### Expected Outcome

- Feast app subscriptions will no longer be included in LiveAppSubscriptionExpiryDate
- Frontend can properly distinguish between Live app and Feast app subscriptions
- No impact on existing news app or puzzle app subscription processing
- Improved data accuracy for mobile subscription attribute handling

### Testing

- [ ] Verify Feast subscriptions are excluded from LiveAppSubscriptionExpiryDate
- [ ] Confirm news app subscriptions still set LiveAppSubscriptionExpiryDate correctly
- [ ] Ensure puzzle app subscriptions continue to work as expected
- [ ] Test API response includes productId field for mobile subscriptions