### PR TITLE
fix(deps): exclude vulnerable org.lz4:lz4-java transitive dependency

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -79,6 +79,7 @@ object Dependencies {
     mockServer,
     mockitoScala,
     ionJava, // Replace excluded software.amazon.ion:ion-java (CVE-2024-21634)
+    lz4Java, // Replace excluded org.lz4:lz4-java (CVE-2025-12183, CVE-2025-66566)
   ) ++ jackson ++ oktaJwtVerifier
 
   val dependencyOverrides = jackson ++ Seq(
@@ -94,5 +95,6 @@ object Dependencies {
     ExclusionRule("com.squareup.okio", "okio"),
     ExclusionRule("net.sourceforge.htmlunit", "htmlunit"), // Block vulnerable version from all transitive deps
     ExclusionRule("software.amazon.ion", "ion-java"), // Exclude old groupId, replaced by com.amazon.ion (CVE-2024-21634)
+    ExclusionRule("org.lz4", "lz4-java"), // Exclude old groupId, replaced by at.yawk.lz4 (CVE-2025-12183, CVE-2025-66566)
   )
 }


### PR DESCRIPTION
### Why do we need this?

Dependabot alerts #41 (CVE-2025-12183) and #43 (CVE-2025-66566) flag the transitive
`org.lz4:lz4-java` dependency as vulnerable. The previous fix added
`at.yawk.lz4:lz4-java:1.10.1` as a dependency override, but because the two artifacts
have different Maven group IDs, the old `org.lz4:lz4-java` was still being resolved
transitively and Dependabot kept reporting the vulnerabilities.

### The changes

- Add an `ExclusionRule("org.lz4", "lz4-java")` to block the vulnerable transitive
  dependency from being resolved — following the same pattern already used for
  `software.amazon.ion:ion-java`.
- Add `lz4Java` (`at.yawk.lz4:lz4-java:1.10.1`) as a direct dependency in
  `apiDependencies` to ensure the patched replacement is on the classpath.

### trello card/screenshot/json/related PRs etc

- https://github.com/guardian/members-data-api/security/dependabot/41
- https://github.com/guardian/members-data-api/security/dependabot/43
- Related previous fix: #1211