### PR TITLE
add low redundancy alarm to CFN

### DIFF
--- a/cloudformation/membership-attribute-service.yaml
+++ b/cloudformation/membership-attribute-service.yaml
@@ -488,6 +488,35 @@ Resources:
     DependsOn:
       - LoadBalancer
 
+  NotEnoughHealthyInstancesAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: CreateProdMonitoring
+    Properties:
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-${Stage}
+      AlarmName: !Join
+        - ' '
+        - - !FindInMap [ StageVariables, !Ref Stage, Urgent ]
+          - !Ref 'Stage'
+          - !FindInMap [ Constants , MetricFilters , MetricNamespace ]
+          - 'Not enough healthy instances'
+      AlarmDescription: !Join
+        - ' '
+        - - "Impact - members-data-api has reduced redundancy and could go down"
+          - !FindInMap [ Constants, Alarm, Process ]
+      MetricName: HealthyHostCount
+      Namespace: AWS/ELB
+      Dimensions:
+        - Name: LoadBalancerName
+          Value: !Ref LoadBalancer
+      ComparisonOperator: LessThanOrEqualToThreshold
+      Threshold: 2
+      Period: 300
+      EvaluationPeriods: 4
+      Statistic: Average
+    DependsOn:
+      - LoadBalancer
+
   High5XXRateAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: CreateProdMonitoring


### PR DESCRIPTION
we noticed that the "lack of redundancy" alarm wasn't going via alarms handler.

This is because it was never defined in CFN, so didn't have a tag or a topic to send to.

Some alarms were defined in this PR, but not including this one: https://github.com/guardian/members-data-api/pull/425

This PR defines the alarm in CFN.

Once the PR is merged the alarm can be deleted, including the ones added in the above PR.

Tested by creating a changeset in PROD (I won't execute it until approval)