### PR TITLE
allow self service cancellation for GW in the UK

### DIFF
--- a/membership-attribute-service/app/models/SelfServiceCancellation.scala
+++ b/membership-attribute-service/app/models/SelfServiceCancellation.scala
@@ -29,6 +29,12 @@ object SelfServiceCancellation {
         shouldDisplayEmail = true,
         phoneRegionsToDisplay = allPhones,
       )
+    } else if (isOneOf(product, WeeklyDomestic, WeeklyRestOfWorld, WeeklyZoneA, WeeklyZoneB, WeeklyZoneC)) {
+      SelfServiceCancellation(
+        isAllowed = true,
+        shouldDisplayEmail = true,
+        phoneRegionsToDisplay = allPhones,
+      )
     } else if (billingCountry.contains(UK)) {
       SelfServiceCancellation(
         isAllowed = false,

--- a/membership-attribute-service/app/models/SelfServiceCancellation.scala
+++ b/membership-attribute-service/app/models/SelfServiceCancellation.scala
@@ -29,15 +29,10 @@ object SelfServiceCancellation {
         shouldDisplayEmail = true,
         phoneRegionsToDisplay = allPhones,
       )
-    } else if (isOneOf(product, WeeklyDomestic, WeeklyRestOfWorld, WeeklyZoneA, WeeklyZoneB, WeeklyZoneC)) {
-      SelfServiceCancellation(
-        isAllowed = true,
-        shouldDisplayEmail = true,
-        phoneRegionsToDisplay = allPhones,
-      )
     } else if (billingCountry.contains(UK)) {
+      val isWeekly = isOneOf(product, WeeklyDomestic, WeeklyRestOfWorld, WeeklyZoneA, WeeklyZoneB, WeeklyZoneC)
       SelfServiceCancellation(
-        isAllowed = false,
+        isAllowed = isWeekly,
         shouldDisplayEmail = false,
         phoneRegionsToDisplay = List(ukRowPhone),
       )

--- a/membership-attribute-service/test/models/SelfServiceCancellationTest.scala
+++ b/membership-attribute-service/test/models/SelfServiceCancellationTest.scala
@@ -3,9 +3,11 @@ package models
 import com.gu.i18n.Country.{Australia, Canada, Ireland, NewZealand, UK, US}
 import com.gu.memsub.Product._
 import org.specs2.mutable.Specification
+import org.specs2.specification.core.Fragment
 
 class SelfServiceCancellationTest extends Specification {
   val allCountries = Set(UK, Australia, US, Canada, NewZealand, Ireland)
+  private val weeklies = Set(WeeklyDomestic, WeeklyRestOfWorld, WeeklyZoneA, WeeklyZoneB, WeeklyZoneC)
   val allProducts = Set(
     Membership,
     Contribution,
@@ -17,12 +19,7 @@ class SelfServiceCancellationTest extends Specification {
     DigitalVoucher,
     Digipack,
     GuardianPatron,
-    WeeklyDomestic,
-    WeeklyRestOfWorld,
-    WeeklyZoneA,
-    WeeklyZoneB,
-    WeeklyZoneC,
-  )
+  ) ++ weeklies
 
   "SelfServiceCancellation.apply" should {
 
@@ -50,13 +47,21 @@ class SelfServiceCancellationTest extends Specification {
       }.toList
     }
 
+    "allow cancellation for Guardian Weekly in the UK" in {
+      weeklies.map { product =>
+        SelfServiceCancellation(product, Some(UK)).isAllowed shouldEqual true
+      }.toList
+    }
+
     "disallow cancellation for all products except Membership, Contribution, Digipack, Tier Three, Guardian Ad-Lite and Supporter Plus in the UK" in {
-      allProducts
-        .diff(Set(Membership, Contribution, SupporterPlus, Digipack, TierThree, AdLite))
-        .map { product =>
+      val productsToTest = allProducts
+        .diff(Set(Membership, Contribution, SupporterPlus, Digipack, TierThree, AdLite) ++ weeklies)
+        .toList
+      Fragment.foreach(productsToTest) { product =>
+        s"$product" in {
           SelfServiceCancellation(product, Some(UK)).isAllowed shouldEqual false
         }
-        .toList
+      }
     }
 
     "allow cancellation for all products in countries other than the UK" in {


### PR DESCRIPTION
We are gradually rolling out online cancellation for print products in the UK.  The first stage is Guardian Weekly.
Although the flow itself is ready in https://github.com/guardian/manage-frontend/pull/1629 , it turns out that the decision whether to allow cancellation or not is on the backend here.

This PR changes it so GW in the UK allows online cancellation.

Deployed to CODE for testing.