### PR TITLE
add isTaxableCountry field

### DIFF
--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -152,7 +152,12 @@ object AccountDetails {
         ),
       ) ++
         regNumber.fold(Json.obj())({ reg => Json.obj("regNumber" -> reg) }) ++
-        billingCountry.fold(Json.obj())({ bc => Json.obj("billingCountry" -> bc.name) }) ++
+        billingCountry.fold(Json.obj()) { bc =>
+          Json.obj(
+            "billingCountry" -> bc.name,
+            "isTaxableCountry" -> TaxableCountries.isTaxable(bc),
+          )
+        } ++
         Json.obj(
           "joinDate" -> paymentDetails.startDate,
           "optIn" -> !paymentDetails.pendingCancellation,

--- a/membership-attribute-service/app/models/TaxableCountries.scala
+++ b/membership-attribute-service/app/models/TaxableCountries.scala
@@ -1,0 +1,12 @@
+package models
+
+import com.gu.i18n.Country
+
+object TaxableCountries {
+
+  private val countries: Set[Country] = Set(Country.Canada)
+
+  def isTaxable(bc: Country): Boolean =
+    countries.contains(bc)
+
+}

--- a/membership-attribute-service/test/models/ProductsResponseSpec.scala
+++ b/membership-attribute-service/test/models/ProductsResponseSpec.scala
@@ -120,6 +120,7 @@ class ProductsResponseSpec extends Specification with SafeLogging {
         |      "phoneRegionsToDisplay" : [ "UK & ROW", "US", "AUS" ]
         |    },
         |    "billingCountry" : "United Kingdom",
+        |    "isTaxableCountry": false,
         |    "joinDate" : "2024-05-15",
         |    "optIn" : true,
         |    "subscription" : {
@@ -324,6 +325,7 @@ class ProductsResponseSpec extends Specification with SafeLogging {
         |        ]
         |      },
         |      "billingCountry": "$country",
+        |      "isTaxableCountry": false,
         |      "joinDate" : "$startDate",
         |      "optIn": true,
         |      "subscription": {

--- a/membership-attribute-service/test/models/TaxableCountriesTest.scala
+++ b/membership-attribute-service/test/models/TaxableCountriesTest.scala
@@ -1,0 +1,23 @@
+package models
+
+import com.gu.i18n.Country.{Canada, UK, US}
+import org.specs2.mutable.Specification
+
+class TaxableCountriesTest extends Specification {
+
+  "TaxableCountries.isTaxable" should {
+
+    "return true for taxable countries" in {
+      Set(Canada).map { country =>
+        TaxableCountries.isTaxable(country) shouldEqual true
+      }.toList
+    }
+
+    "return false for non-taxable countries" in {
+      Set(UK, US).map { country =>
+        TaxableCountries.isTaxable(country) shouldEqual false
+      }.toList
+    }
+
+  }
+}


### PR DESCRIPTION
We want to know whether to display "taxes may apply" wording against each upcoming payment on the manage site.

This initially applies in Canada only.

See designs here: https://www.figma.com/design/bruXbfgh0XNSohIGB5v42c/Tax-exclusive-pricing?node-id=1-32&p=f&t=BqPDzNEmrkeGjALT-0

This PR adds a new isTaxableCountry field alongside billingCountry and mmaProductKey, so that manage knows what wording to use.