### PR TITLE
use subscription status only to decide whether a sub is cancelled

### DIFF
--- a/membership-attribute-service/app/services/zuora/rest/SimpleClientZuoraRestService.scala
+++ b/membership-attribute-service/app/services/zuora/rest/SimpleClientZuoraRestService.scala
@@ -129,10 +129,9 @@ class SimpleClientZuoraRestService(private val simpleRest: SimpleClient[Future])
 
   def getCancellationEffectiveDate(subscriptionNumber: SubscriptionNumber)(implicit logPrefix: LogPrefix): Future[String \/ Option[String]] = {
     (for {
-      amendment <- EitherT(simpleRest.get[Amendment](s"amendments/subscriptions/${subscriptionNumber.getNumber}"))
       cancelledSub <- EitherT(simpleRest.get[CancelledSubscription](s"subscriptions/${subscriptionNumber.getNumber}"))
     } yield {
-      if (amendment.`type`.contains("Cancellation") && cancelledSub.status == "Cancelled")
+      if (cancelledSub.status == "Cancelled")
         Some(cancelledSub.subscriptionEndDate)
       else
         None


### PR DESCRIPTION
At the moment, we check both the subscription status and the type of the latest amendment to decide whether to return a cancellation date to manage.

However, since composite amendments can be used, the amendment type may not match what we expect.

We know that if a subscription is cancelled, no more amendments are possible anyway, so all cancelled subscriptions must have a cancellation amendment, even if it's wrapped in a Composite type amendment.

As such, this PR changes the logic to only look at the status, and assume the amendment type is correct.

It looks like historically this code only looked at the amendment see https://github.com/guardian/membership-common/pull/629 , the subscription fetch was added later, wheras it could have replaced the subscription fetch
https://github.com/guardian/membership-common/pull/630/changes#diff-9d76b510880067db5f29de4aab3f7498fa832bd4cbc48b429f12c0385f21b0b9L598

This should also have a small speed boost as we make one less call to zuora on every view of the account overview.

Tested in CODE and showing the correct value for a cancelled subscription.