### PR TITLE
add extraTaxApplies field to the /mma response

### DIFF
--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -42,7 +42,7 @@ object AccountDetails {
 
       val mainPlan = subscription.plan(catalog, today)
       val product = mainPlan.product(catalog)
-      val taxExclusive = catalog.productRatePlans.get(mainPlan.productRatePlanId).exists(_.taxExclusive)
+      val taxExclusive = mainPlan.taxExclusive(catalog)
 
       val paymentMethod = paymentDetails.paymentMethod match {
         case Some(payPal: PayPalMethod) =>

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -42,7 +42,7 @@ object AccountDetails {
 
       val mainPlan = subscription.plan(catalog, today)
       val product = mainPlan.product(catalog)
-      val taxExclusive = mainPlan.taxExclusive(catalog)
+      val extraTaxApplies = mainPlan.extraTaxApplies(catalog)
 
       val paymentMethod = paymentDetails.paymentMethod match {
         case Some(payPal: PayPalMethod) =>
@@ -154,7 +154,7 @@ object AccountDetails {
       ) ++
         regNumber.fold(Json.obj())({ reg => Json.obj("regNumber" -> reg) }) ++
         billingCountry.fold(Json.obj())({ bc => Json.obj("billingCountry" -> bc.name) }) ++
-        Json.obj("taxExclusive" -> taxExclusive) ++
+        Json.obj("extraTaxApplies" -> extraTaxApplies) ++
         Json.obj(
           "joinDate" -> paymentDetails.startDate,
           "optIn" -> !paymentDetails.pendingCancellation,

--- a/membership-attribute-service/app/models/AccountDetails.scala
+++ b/membership-attribute-service/app/models/AccountDetails.scala
@@ -42,6 +42,7 @@ object AccountDetails {
 
       val mainPlan = subscription.plan(catalog, today)
       val product = mainPlan.product(catalog)
+      val taxExclusive = catalog.productRatePlans.get(mainPlan.productRatePlanId).exists(_.taxExclusive)
 
       val paymentMethod = paymentDetails.paymentMethod match {
         case Some(payPal: PayPalMethod) =>
@@ -153,6 +154,7 @@ object AccountDetails {
       ) ++
         regNumber.fold(Json.obj())({ reg => Json.obj("regNumber" -> reg) }) ++
         billingCountry.fold(Json.obj())({ bc => Json.obj("billingCountry" -> bc.name) }) ++
+        Json.obj("taxExclusive" -> taxExclusive) ++
         Json.obj(
           "joinDate" -> paymentDetails.startDate,
           "optIn" -> !paymentDetails.pendingCancellation,

--- a/membership-attribute-service/test/models/ProductsResponseSpec.scala
+++ b/membership-attribute-service/test/models/ProductsResponseSpec.scala
@@ -120,6 +120,7 @@ class ProductsResponseSpec extends Specification with SafeLogging {
         |      "phoneRegionsToDisplay" : [ "UK & ROW", "US", "AUS" ]
         |    },
         |    "billingCountry" : "United Kingdom",
+        |    "taxExclusive" : false,
         |    "joinDate" : "2024-05-15",
         |    "optIn" : true,
         |    "subscription" : {
@@ -324,6 +325,7 @@ class ProductsResponseSpec extends Specification with SafeLogging {
         |        ]
         |      },
         |      "billingCountry": "$country",
+        |      "taxExclusive": false,
         |      "joinDate" : "$startDate",
         |      "optIn": true,
         |      "subscription": {

--- a/membership-attribute-service/test/models/ProductsResponseSpec.scala
+++ b/membership-attribute-service/test/models/ProductsResponseSpec.scala
@@ -120,7 +120,7 @@ class ProductsResponseSpec extends Specification with SafeLogging {
         |      "phoneRegionsToDisplay" : [ "UK & ROW", "US", "AUS" ]
         |    },
         |    "billingCountry" : "United Kingdom",
-        |    "taxExclusive" : false,
+        |    "extraTaxApplies" : false,
         |    "joinDate" : "2024-05-15",
         |    "optIn" : true,
         |    "subscription" : {
@@ -325,7 +325,7 @@ class ProductsResponseSpec extends Specification with SafeLogging {
         |        ]
         |      },
         |      "billingCountry": "$country",
-        |      "taxExclusive": false,
+        |      "extraTaxApplies": false,
         |      "joinDate" : "$startDate",
         |      "optIn": true,
         |      "subscription": {

--- a/membership-common/src/main/scala/com/gu/memsub/subsv2/Plan.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/subsv2/Plan.scala
@@ -224,8 +224,8 @@ case class RatePlan(
   def productType(catalog: Catalog): ProductType =
     productRatePlan(catalog).productType
 
-  def taxExclusive(catalog: Catalog): Boolean =
-    productRatePlan(catalog).taxExclusive
+  def extraTaxApplies(catalog: Catalog): Boolean =
+    productRatePlan(catalog).extraTaxApplies
 
   def getChargeTypes(catalog: Catalog): List[ProductRatePlanChargeProductType] = {
     val getChargeProductType = catalog.productRatePlans(productRatePlanId).productRatePlanCharges
@@ -245,7 +245,7 @@ case class ProductRatePlan(
     productId: ProductId,
     productRatePlanCharges: Map[ProductRatePlanChargeId, ProductRatePlanChargeProductType],
     private val productTypeOption: Option[ProductType],
-    taxExclusive: Boolean = false,
+    extraTaxApplies: Boolean = false,
 ) {
   lazy val productType: ProductType = productTypeOption.getOrElse(throw new RuntimeException("Product type is undefined for plan: " + name))
 }

--- a/membership-common/src/main/scala/com/gu/memsub/subsv2/Plan.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/subsv2/Plan.scala
@@ -242,6 +242,7 @@ case class ProductRatePlan(
     productId: ProductId,
     productRatePlanCharges: Map[ProductRatePlanChargeId, ProductRatePlanChargeProductType],
     private val productTypeOption: Option[ProductType],
+    taxExclusive: Boolean = false,
 ) {
   lazy val productType: ProductType = productTypeOption.getOrElse(throw new RuntimeException("Product type is undefined for plan: " + name))
 }

--- a/membership-common/src/main/scala/com/gu/memsub/subsv2/Plan.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/subsv2/Plan.scala
@@ -224,6 +224,9 @@ case class RatePlan(
   def productType(catalog: Catalog): ProductType =
     productRatePlan(catalog).productType
 
+  def taxExclusive(catalog: Catalog): Boolean =
+    productRatePlan(catalog).taxExclusive
+
   def getChargeTypes(catalog: Catalog): List[ProductRatePlanChargeProductType] = {
     val getChargeProductType = catalog.productRatePlans(productRatePlanId).productRatePlanCharges
     ratePlanCharges.list.toList

--- a/membership-common/src/main/scala/com/gu/memsub/subsv2/reads/CatJsonReads.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/subsv2/reads/CatJsonReads.scala
@@ -37,8 +37,8 @@ object CatJsonReads {
     }
   }
 
-  // A plan is tax exclusive when any of its charges carry Zuora's taxMode "TaxExclusive" (the rest are "TaxInclusive" or absent).
-  private val taxExclusiveReads: Reads[Boolean] = new Reads[Boolean] {
+  // Extra tax applies when any of a plan's charges carry Zuora's taxMode "TaxExclusive" (the rest are "TaxInclusive" or absent).
+  private val extraTaxAppliesReads: Reads[Boolean] = new Reads[Boolean] {
     override def reads(json: JsValue): JsResult[Boolean] = json match {
       case JsArray(charges) => JsSuccess(charges.exists(charge => (charge \ "taxMode").asOpt[String].contains("TaxExclusive")))
       case _ => JsSuccess(false)
@@ -52,7 +52,7 @@ object CatJsonReads {
         Reads.pure(pid) and
         (__ \ "productRatePlanCharges").read[Map[ProductRatePlanChargeId, ProductRatePlanChargeProductType]](productRatePlanChargesReads) and
         Reads.pure(productType) and
-        (__ \ "productRatePlanCharges").read[Boolean](taxExclusiveReads))(ProductRatePlan.apply _).reads(json)
+        (__ \ "productRatePlanCharges").read[Boolean](extraTaxAppliesReads))(ProductRatePlan.apply _).reads(json)
     }
 
   val productsReads: Reads[List[ProductRatePlan]] =

--- a/membership-common/src/main/scala/com/gu/memsub/subsv2/reads/CatJsonReads.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/subsv2/reads/CatJsonReads.scala
@@ -41,7 +41,7 @@ object CatJsonReads {
   private val extraTaxAppliesReads: Reads[Boolean] = new Reads[Boolean] {
     override def reads(json: JsValue): JsResult[Boolean] = json match {
       case JsArray(charges) => JsSuccess(charges.exists(charge => (charge \ "taxMode").asOpt[String].contains("TaxExclusive")))
-      case _ => JsSuccess(false)
+      case _ => JsError("expected productRatePlanCharges to be an array")
     }
   }
 

--- a/membership-common/src/main/scala/com/gu/memsub/subsv2/reads/CatJsonReads.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/subsv2/reads/CatJsonReads.scala
@@ -37,13 +37,22 @@ object CatJsonReads {
     }
   }
 
+  // A plan is tax exclusive when any of its charges carry Zuora's taxMode "TaxExclusive" (the rest are "TaxInclusive" or absent).
+  private val taxExclusiveReads: Reads[Boolean] = new Reads[Boolean] {
+    override def reads(json: JsValue): JsResult[Boolean] = json match {
+      case JsArray(charges) => JsSuccess(charges.exists(charge => (charge \ "taxMode").asOpt[String].contains("TaxExclusive")))
+      case _ => JsSuccess(false)
+    }
+  }
+
   private def productRatePlanReads(productType: Option[ProductType], pid: ProductId): Reads[ProductRatePlan] =
     (json: JsValue) => {
       ((__ \ "id").read[String].map(ProductRatePlanId) and
         (__ \ "name").read[String] and
         Reads.pure(pid) and
         (__ \ "productRatePlanCharges").read[Map[ProductRatePlanChargeId, ProductRatePlanChargeProductType]](productRatePlanChargesReads) and
-        Reads.pure(productType))(ProductRatePlan.apply _).reads(json)
+        Reads.pure(productType) and
+        (__ \ "productRatePlanCharges").read[Boolean](taxExclusiveReads))(ProductRatePlan.apply _).reads(json)
     }
 
   val productsReads: Reads[List[ProductRatePlan]] =

--- a/membership-common/src/test/scala/com/gu/memsub/subsv2/reads/CatReadsTest.scala
+++ b/membership-common/src/test/scala/com/gu/memsub/subsv2/reads/CatReadsTest.scala
@@ -23,7 +23,7 @@ class CatReadsTest extends AnyFlatSpec {
         productId = ProductId("2c92c0f8574b2b8101574c4a9473068b"),
         productRatePlanCharges = Map(ProductRatePlanChargeId("2c92c0f958aa45600158ac00e19d5daf") -> Weekly),
         productTypeOption = Some(ProductType("Guardian Weekly")),
-        taxExclusive = true,
+        extraTaxApplies = true,
       ),
     )
 
@@ -66,14 +66,14 @@ class CatReadsTest extends AnyFlatSpec {
 
   }
 
-  it should "mark a plan as tax exclusive when a charge has taxMode TaxExclusive" in {
+  it should "mark a plan as extra tax applies when a charge has taxMode TaxExclusive" in {
     val taxExclusivePlan = plans.find(_.id.get == "2c92c0f958aa455e0158aa6bc72f2aba")
-    assert(taxExclusivePlan.exists(_.taxExclusive))
+    assert(taxExclusivePlan.exists(_.extraTaxApplies))
   }
 
-  it should "not mark a plan as tax exclusive when its charges are tax inclusive" in {
+  it should "not mark a plan as extra tax applies when its charges are tax inclusive" in {
     val taxInclusivePlan = plans.find(_.id.get == "2c92c0f96df75b5a016df81ba1c62609")
-    assert(taxInclusivePlan.exists(!_.taxExclusive))
+    assert(taxInclusivePlan.exists(!_.extraTaxApplies))
   }
 
 }

--- a/membership-common/src/test/scala/com/gu/memsub/subsv2/reads/CatReadsTest.scala
+++ b/membership-common/src/test/scala/com/gu/memsub/subsv2/reads/CatReadsTest.scala
@@ -23,6 +23,7 @@ class CatReadsTest extends AnyFlatSpec {
         productId = ProductId("2c92c0f8574b2b8101574c4a9473068b"),
         productRatePlanCharges = Map(ProductRatePlanChargeId("2c92c0f958aa45600158ac00e19d5daf") -> Weekly),
         productTypeOption = Some(ProductType("Guardian Weekly")),
+        taxExclusive = true,
       ),
     )
 
@@ -63,6 +64,16 @@ class CatReadsTest extends AnyFlatSpec {
 
     Diff.assertEquals(expected, result)
 
+  }
+
+  it should "mark a plan as tax exclusive when a charge has taxMode TaxExclusive" in {
+    val taxExclusivePlan = plans.find(_.id.get == "2c92c0f958aa455e0158aa6bc72f2aba")
+    assert(taxExclusivePlan.exists(_.taxExclusive))
+  }
+
+  it should "not mark a plan as tax exclusive when its charges are tax inclusive" in {
+    val taxInclusivePlan = plans.find(_.id.get == "2c92c0f96df75b5a016df81ba1c62609")
+    assert(taxInclusivePlan.exists(!_.taxExclusive))
   }
 
 }


### PR DESCRIPTION
### Why do we need this?

Manage frontend needs to show a "price excludes tax" notice on the account overview and manage pages for Canadian tax-exclusive plans (guardian/manage-frontend#1665). Until now there was nothing in the /mma response to tell it whether a plan is tax exclusive, so the notice was being driven by a mock.

### The changes

We already load the Zuora product catalog, which carries a taxMode on each charge, but we were parsing it and throwing it away. This PR derives an extraTaxApplies flag - a plan applies extra tax when any of its charges has taxMode "TaxExclusive" - exposes it on ProductRatePlan, and adds it at the top level of the /mma response next to billingCountry.

We depend on the plan itself rather than the customer's billing country on purpose: the same plans will be rolled out to US customers later, so the flag should follow the plan from the start.

Tested with unit tests covering the catalog reads (a tax exclusive plan vs a tax inclusive one) and the /mma serialisation.

Tested in CODE and showing the correct value on the /mma response, next to billingCountry. The tax inclusive plans I could subscribe to all return false as expected; the tax exclusive case is covered by the catalog reads unit test, as the tax exclusive plans aren't on the normal acquisition flow in CODE.

Related frontend PR: guardian/manage-frontend#1665
Zuora config adding the tax-exclusive charges: guardian/zuora-config#198