### PR TITLE
replace SOAP amend-preview with REST billing-preview for next payment

### DIFF
--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -147,7 +147,7 @@ class TouchpointComponents(
 
     subscriptionServiceOverride.getOrElse(zuoraSubscriptionService)
   }
-  lazy val paymentService: PaymentService = new PaymentService(zuoraSoapService)
+  lazy val paymentService: PaymentService = new PaymentService(zuoraSoapService, zuoraRestService)
 
   lazy val idapiService = new IdapiService(backendConfig.idapi, RequestRunners.futureRunner)
   lazy val tokenVerifierConfig = OktaTokenValidationConfig(

--- a/membership-attribute-service/app/services/zuora/payment/PaymentService.scala
+++ b/membership-attribute-service/app/services/zuora/payment/PaymentService.scala
@@ -102,8 +102,7 @@ class PaymentService(zuoraService: ZuoraSoapService, restService: ZuoraRestServi
     } yield bill
 
   /** billing-preview is account-scoped, so we request the whole account and keep only the target subscription's items. A preview failure only means
-    * we show no next payment; it must never fail the whole /mma call, so we log it and carry on with an empty list (as before, but now with a log
-    * line so the failure is visible).
+    * we show no next payment; it must never fail the whole /mma call, so we log it and carry on.
     */
   private def getPreviewInvoiceItems(subId: Id, accountId: AccountId, targetDate: LocalDate)(implicit
       logPrefix: LogPrefix,

--- a/membership-attribute-service/app/services/zuora/payment/PaymentService.scala
+++ b/membership-attribute-service/app/services/zuora/payment/PaymentService.scala
@@ -101,31 +101,20 @@ class PaymentService(zuoraService: ZuoraSoapService, restService: ZuoraRestServi
         .toList
     } yield bill
 
-  // Zuora's billing-preview is account-scoped, so we ask for the whole account and keep only the target subscription's
-  // items, mapping them to the shape BillingSchedule expects. price includes tax to stay like-for-like with the old
-  // SOAP amend-with-preview. On failure we return no items (no preview shown), matching the previous behaviour.
+  // billing-preview is account-scoped, so we request the whole account and keep only the target subscription's items.
+  // A Zuora error means we show no next payment (as before); we let unexpected failures propagate rather than hide them.
+  // TODO if an account has several subscriptions this runs once per subscription; it could be fetched once per account
+  // and shared to save Zuora calls.
   private def getPreviewInvoiceItems(subId: Id, accountId: AccountId, targetDate: LocalDate)(implicit
       logPrefix: LogPrefix,
   ): Future[Seq[Queries.PreviewInvoiceItem]] =
-    restService
-      .getBillingPreview(accountId, targetDate)
-      .map {
-        case \/-(items) =>
-          items.collect {
-            case item if item.subscriptionId == subId.get =>
-              Queries.PreviewInvoiceItem(
-                price = (item.chargeAmount + item.taxAmount).toFloat,
-                serviceStartDate = new LocalDate(item.serviceStartDate),
-                serviceEndDate = new LocalDate(item.serviceEndDate),
-                productId = "",
-                productRatePlanChargeId = "",
-                chargeName = item.chargeName,
-                unitPrice = (item.chargeAmount + item.taxAmount).toFloat,
-              )
-          }
-        case -\/(_) => Nil
-      }
-      .recover { case _ => Nil }
+    restService.getBillingPreview(accountId, targetDate).map {
+      case \/-(items) =>
+        items.collect { case item if item.subscriptionId == subId.get => PaymentService.toPreviewInvoiceItem(item) }
+      case -\/(error) =>
+        logger.warn(s"could not get billing preview for account ${accountId.get}, showing no next payment: $error")
+        Nil
+    }
 
   def getPaymentMethod(maybePaymentMethodId: Option[String], defaultMandateIdIfApplicable: Option[String] = None)(implicit
       logPrefix: LogPrefix,
@@ -137,4 +126,23 @@ class PaymentService(zuoraService: ZuoraSoapService, restService: ZuoraRestServi
     } yield buildPaymentMethod(defaultMandateIdIfApplicable, soapPaymentMethod))
       .getOrElse(Future.successful(None))
 
+}
+
+object PaymentService {
+
+  // Map a Zuora billing-preview invoice item to the internal preview shape BillingSchedule consumes.
+  // price includes tax to stay like-for-like with the old SOAP amend-with-preview.
+  // productId and productRatePlanChargeId are not returned by billing-preview and are unused by BillingSchedule.
+  def toPreviewInvoiceItem(item: ZuoraRestService.BillingPreviewInvoiceItem): Queries.PreviewInvoiceItem = {
+    val grossPrice = (item.chargeAmount + item.taxAmount).toFloat
+    Queries.PreviewInvoiceItem(
+      price = grossPrice,
+      serviceStartDate = new LocalDate(item.serviceStartDate),
+      serviceEndDate = new LocalDate(item.serviceEndDate),
+      productId = "",
+      productRatePlanChargeId = "",
+      chargeName = item.chargeName,
+      unitPrice = grossPrice,
+    )
+  }
 }

--- a/membership-attribute-service/app/services/zuora/payment/PaymentService.scala
+++ b/membership-attribute-service/app/services/zuora/payment/PaymentService.scala
@@ -111,7 +111,7 @@ class PaymentService(zuoraService: ZuoraSoapService, restService: ZuoraRestServi
       .getBillingPreview(accountId, targetDate)
       .map {
         case \/-(items) =>
-          items.collect { case item if item.subscriptionId == subId.get => PaymentService.toPreviewInvoiceItem(item) }
+          items.filter(_.subscriptionId == subId.get).map(PaymentService.toPreviewInvoiceItem)
         case -\/(error) =>
           logger.warn(s"could not get billing preview for account ${accountId.get}, showing no next payment: $error")
           Nil

--- a/membership-attribute-service/app/services/zuora/payment/PaymentService.scala
+++ b/membership-attribute-service/app/services/zuora/payment/PaymentService.scala
@@ -101,9 +101,10 @@ class PaymentService(zuoraService: ZuoraSoapService, restService: ZuoraRestServi
         .toList
     } yield bill
 
-  // billing-preview is account-scoped, so we request the whole account and keep only the target subscription's items.
-  // A preview failure only means we show no next payment; it must never fail the whole /mma call, so we log it and
-  // carry on with an empty list (as before, but now with a log line so the failure is visible).
+  /** billing-preview is account-scoped, so we request the whole account and keep only the target subscription's items. A preview failure only means
+    * we show no next payment; it must never fail the whole /mma call, so we log it and carry on with an empty list (as before, but now with a log
+    * line so the failure is visible).
+    */
   private def getPreviewInvoiceItems(subId: Id, accountId: AccountId, targetDate: LocalDate)(implicit
       logPrefix: LogPrefix,
   ): Future[Seq[Queries.PreviewInvoiceItem]] =
@@ -135,9 +136,9 @@ class PaymentService(zuoraService: ZuoraSoapService, restService: ZuoraRestServi
 
 object PaymentService {
 
-  // Map a Zuora billing-preview invoice item to the internal preview shape BillingSchedule consumes.
-  // price includes tax to stay like-for-like with the old SOAP amend-with-preview.
-  // productId and productRatePlanChargeId are not returned by billing-preview and are unused by BillingSchedule.
+  /** Map a Zuora billing-preview invoice item to the internal preview shape BillingSchedule consumes. price includes tax to stay like-for-like with
+    * the old SOAP amend-with-preview. productId and productRatePlanChargeId are not returned by billing-preview and are unused by BillingSchedule.
+    */
   def toPreviewInvoiceItem(item: ZuoraRestService.BillingPreviewInvoiceItem): Queries.PreviewInvoiceItem = {
     val grossPrice = (item.chargeAmount + item.taxAmount).toFloat
     Queries.PreviewInvoiceItem(

--- a/membership-attribute-service/app/services/zuora/payment/PaymentService.scala
+++ b/membership-attribute-service/app/services/zuora/payment/PaymentService.scala
@@ -102,19 +102,24 @@ class PaymentService(zuoraService: ZuoraSoapService, restService: ZuoraRestServi
     } yield bill
 
   // billing-preview is account-scoped, so we request the whole account and keep only the target subscription's items.
-  // A Zuora error means we show no next payment (as before); we let unexpected failures propagate rather than hide them.
-  // TODO if an account has several subscriptions this runs once per subscription; it could be fetched once per account
-  // and shared to save Zuora calls.
+  // A preview failure only means we show no next payment; it must never fail the whole /mma call, so we log it and
+  // carry on with an empty list (as before, but now with a log line so the failure is visible).
   private def getPreviewInvoiceItems(subId: Id, accountId: AccountId, targetDate: LocalDate)(implicit
       logPrefix: LogPrefix,
   ): Future[Seq[Queries.PreviewInvoiceItem]] =
-    restService.getBillingPreview(accountId, targetDate).map {
-      case \/-(items) =>
-        items.collect { case item if item.subscriptionId == subId.get => PaymentService.toPreviewInvoiceItem(item) }
-      case -\/(error) =>
-        logger.warn(s"could not get billing preview for account ${accountId.get}, showing no next payment: $error")
+    restService
+      .getBillingPreview(accountId, targetDate)
+      .map {
+        case \/-(items) =>
+          items.collect { case item if item.subscriptionId == subId.get => PaymentService.toPreviewInvoiceItem(item) }
+        case -\/(error) =>
+          logger.warn(s"could not get billing preview for account ${accountId.get}, showing no next payment: $error")
+          Nil
+      }
+      .recover { case error =>
+        logger.warn(s"could not get billing preview for account ${accountId.get}, showing no next payment", error)
         Nil
-    }
+      }
 
   def getPaymentMethod(maybePaymentMethodId: Option[String], defaultMandateIdIfApplicable: Option[String] = None)(implicit
       logPrefix: LogPrefix,

--- a/membership-attribute-service/app/services/zuora/payment/PaymentService.scala
+++ b/membership-attribute-service/app/services/zuora/payment/PaymentService.scala
@@ -13,6 +13,9 @@ import com.gu.zuora.ZuoraSoapService
 import com.gu.zuora.soap.models.Queries
 import com.gu.zuora.soap.models.Queries.Account
 import com.gu.zuora.soap.models.Queries.PaymentMethod._
+import org.joda.time.LocalDate
+import services.zuora.rest.ZuoraRestService
+import scalaz.{-\/, \/-}
 import scalaz.std.option._
 import scalaz.syntax.monad._
 import scalaz.syntax.std.option._
@@ -20,7 +23,7 @@ import scalaz.syntax.std.option._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
-class PaymentService(zuoraService: ZuoraSoapService)(implicit ec: ExecutionContext) extends SafeLogging {
+class PaymentService(zuoraService: ZuoraSoapService, restService: ZuoraRestService)(implicit ec: ExecutionContext) extends SafeLogging {
 
   def paymentDetails(
       sub: Subscription,
@@ -37,9 +40,9 @@ class PaymentService(zuoraService: ZuoraSoapService)(implicit ec: ExecutionConte
 
     for {
       account <- zuoraService.getAccount(sub.accountId)
-      // Request 30 bills to handle long promotional periods (e.g., Australian student offer: 24 months free)
-      // 24 bills for promo + 6 buffer bills ensures we find the first paid bill even with billing irregularities
-      eventualBills = getNextBill(sub.id, account, 30).withLogging(s"next bill for $sub")
+      // Preview ~30 months ahead to handle long promotional periods (e.g. Australian student offer: 24 months free),
+      // so we still find the first paid bill for those. Like-for-like with the previous SOAP 30-billing-periods request.
+      eventualBills = getNextBill(sub.id, account, LocalDate.now.plusMonths(30)).withLogging(s"next bill for $sub")
       eventualMaybePaymentMethod = getPaymentMethod(account.defaultPaymentMethodId, defaultMandateIdIfApplicable) // kick off async
       bills <- eventualBills
       maybePaymentMethod <- eventualMaybePaymentMethod
@@ -86,9 +89,9 @@ class PaymentService(zuoraService: ZuoraSoapService)(implicit ec: ExecutionConte
       case _ => None
     }
 
-  private def getNextBill(subId: Id, account: Account, numberOfBills: Int)(implicit logPrefix: LogPrefix): Future[List[Bill]] =
+  private def getNextBill(subId: Id, account: Account, targetDate: LocalDate)(implicit logPrefix: LogPrefix): Future[List[Bill]] =
     for {
-      previewInvoiceItems <- zuoraService.previewInvoices(subId, numberOfBills)
+      previewInvoiceItems <- getPreviewInvoiceItems(subId, AccountId(account.id), targetDate)
     } yield for {
       billingSched <- BillingSchedule.fromPreviewInvoiceItems(previewInvoiceItems).toList
       bill <- billingSched
@@ -97,6 +100,32 @@ class PaymentService(zuoraService: ZuoraSoapService)(implicit ec: ExecutionConte
         .list
         .toList
     } yield bill
+
+  // Zuora's billing-preview is account-scoped, so we ask for the whole account and keep only the target subscription's
+  // items, mapping them to the shape BillingSchedule expects. price includes tax to stay like-for-like with the old
+  // SOAP amend-with-preview. On failure we return no items (no preview shown), matching the previous behaviour.
+  private def getPreviewInvoiceItems(subId: Id, accountId: AccountId, targetDate: LocalDate)(implicit
+      logPrefix: LogPrefix,
+  ): Future[Seq[Queries.PreviewInvoiceItem]] =
+    restService
+      .getBillingPreview(accountId, targetDate)
+      .map {
+        case \/-(items) =>
+          items.collect {
+            case item if item.subscriptionId == subId.get =>
+              Queries.PreviewInvoiceItem(
+                price = (item.chargeAmount + item.taxAmount).toFloat,
+                serviceStartDate = new LocalDate(item.serviceStartDate),
+                serviceEndDate = new LocalDate(item.serviceEndDate),
+                productId = "",
+                productRatePlanChargeId = "",
+                chargeName = item.chargeName,
+                unitPrice = (item.chargeAmount + item.taxAmount).toFloat,
+              )
+          }
+        case -\/(_) => Nil
+      }
+      .recover { case _ => Nil }
 
   def getPaymentMethod(maybePaymentMethodId: Option[String], defaultMandateIdIfApplicable: Option[String] = None)(implicit
       logPrefix: LogPrefix,

--- a/membership-attribute-service/app/services/zuora/rest/SimpleClientZuoraRestService.scala
+++ b/membership-attribute-service/app/services/zuora/rest/SimpleClientZuoraRestService.scala
@@ -35,6 +35,15 @@ class SimpleClientZuoraRestService(private val simpleRest: SimpleClient[Future])
   def getPaymentMethod(paymentMethodId: String)(implicit logPrefix: LogPrefix): Future[String \/ PaymentMethodResponse] =
     simpleRest.get[PaymentMethodResponse](s"object/payment-method/$paymentMethodId")
 
+  def getBillingPreview(accountId: AccountId, targetDate: LocalDate)(implicit
+      logPrefix: LogPrefix,
+  ): Future[String \/ List[BillingPreviewInvoiceItem]] = {
+    val request = BillingPreviewRequest(accountId.get, targetDate)
+    EitherT(simpleRest.post[BillingPreviewRequest, BillingPreviewResponse]("operations/billing-preview", request))
+      .map(_.invoiceItems)
+      .run
+  }
+
   private def unsuccessfulResponseToLeft(restResponse: EitherT[String, Future, ZuoraResponse]): EitherT[String, Future, ZuoraResponse] = {
     val futureMonad = implicitly[Monad[Future]]
 

--- a/membership-attribute-service/app/services/zuora/rest/ZuoraRestService.scala
+++ b/membership-attribute-service/app/services/zuora/rest/ZuoraRestService.scala
@@ -200,8 +200,10 @@ object ZuoraRestService {
   case class RestQuery(queryString: String)
   implicit val restQueryWrites = Json.writes[RestQuery]
 
-  // Billing Preview (REST replacement for the SOAP amend-with-preview hack). assumeRenewal projects the next
-  // charge for subs already billed for their current term, so the old "evergreen" trick is no longer needed.
+  /** Billing Preview, the REST replacement for the SOAP amend-with-preview hack. assumeRenewal projects the next charge for subs already billed for
+    * their current term, so the old "evergreen" trick is no longer needed. See
+    * https://www.zuora.com/developer/api-references/api/operation/POST_BillingPreview
+    */
   case class BillingPreviewRequest(accountId: String, targetDate: LocalDate, assumeRenewal: String = "Autorenew")
   implicit val billingPreviewRequestWrites = Json.writes[BillingPreviewRequest]
 

--- a/membership-attribute-service/app/services/zuora/rest/ZuoraRestService.scala
+++ b/membership-attribute-service/app/services/zuora/rest/ZuoraRestService.scala
@@ -15,6 +15,7 @@ import services.zuora.rest.ZuoraRestService.{
   AccountSummary,
   AccountsByCrmIdResponse,
   AccountsByCrmIdResponseRecord,
+  BillingPreviewInvoiceItem,
   ContactData,
   GetAccountsQueryResponse,
   GiftSubscriptionsFromIdentityIdRecord,
@@ -198,6 +199,24 @@ object ZuoraRestService {
 
   case class RestQuery(queryString: String)
   implicit val restQueryWrites = Json.writes[RestQuery]
+
+  // Billing Preview (REST replacement for the SOAP amend-with-preview hack). assumeRenewal projects the next
+  // charge for subs already billed for their current term, so the old "evergreen" trick is no longer needed.
+  case class BillingPreviewRequest(accountId: String, targetDate: LocalDate, assumeRenewal: String = "Autorenew")
+  implicit val billingPreviewRequestWrites = Json.writes[BillingPreviewRequest]
+
+  case class BillingPreviewInvoiceItem(
+      subscriptionId: String,
+      chargeAmount: Double,
+      taxAmount: Double,
+      serviceStartDate: String,
+      serviceEndDate: String,
+      chargeName: String,
+  )
+  implicit val billingPreviewInvoiceItemReads = Json.reads[BillingPreviewInvoiceItem]
+
+  case class BillingPreviewResponse(invoiceItems: List[BillingPreviewInvoiceItem])
+  implicit val billingPreviewResponseReads = Json.reads[BillingPreviewResponse]
 
   case class SalesforceContactId(get: String) extends AnyVal
 
@@ -408,6 +427,10 @@ trait ZuoraRestService {
   ): Future[String \/ List[GiftSubscriptionsFromIdentityIdRecord]]
 
   def getPaymentMethod(paymentMethodId: String)(implicit logPrefix: LogPrefix): Future[String \/ PaymentMethodResponse]
+
+  def getBillingPreview(accountId: AccountId, targetDate: LocalDate)(implicit
+      logPrefix: LogPrefix,
+  ): Future[String \/ List[BillingPreviewInvoiceItem]]
 
   def cancelSubscription(
       subscriptionNumber: SubscriptionNumber,

--- a/membership-attribute-service/test/acceptance/AccountControllerAcceptanceTest.scala
+++ b/membership-attribute-service/test/acceptance/AccountControllerAcceptanceTest.scala
@@ -183,8 +183,12 @@ class AccountControllerAcceptanceTest extends AcceptanceTest {
       zuoraRestServiceMock.getCancellationEffectiveDate(nonGiftSubscription.subscriptionNumber)(any) returns Future(\/.right(None))
 
       zuoraSoapServiceMock.getPaymentSummary(nonGiftSubscription.subscriptionNumber, Currency.GBP)(any) returns Future(TestPaymentSummary())
-      zuoraSoapServiceMock.getAccount(nonGiftSubscriptionAccountId)(any) returns Future(TestQueriesAccount())
-      zuoraSoapServiceMock.previewInvoices(nonGiftSubscription.id, 30)(any) returns Future(Seq(TestPreviewInvoiceItem()))
+      zuoraSoapServiceMock.getAccount(nonGiftSubscriptionAccountId)(any) returns Future(
+        TestQueriesAccount(id = nonGiftSubscriptionAccountId.get),
+      )
+      zuoraRestServiceMock.getBillingPreview(eqTo(nonGiftSubscriptionAccountId), any)(any) returns Future(
+        \/.right(List(TestBillingPreviewInvoiceItem(subscriptionId = nonGiftSubscription.id.get))),
+      )
 
       val patronSubscription = TestDynamoSupporterRatePlanItem(
         subscriptionName = patronSubscriptionName,
@@ -228,7 +232,7 @@ class AccountControllerAcceptanceTest extends AcceptanceTest {
 
       zuoraSoapServiceMock.getAccount(nonGiftSubscriptionAccountId)(any) was called
       zuoraSoapServiceMock.getPaymentSummary(nonGiftSubscription.subscriptionNumber, Currency.GBP)(any) was called
-      zuoraSoapServiceMock.previewInvoices(nonGiftSubscription.id, 30)(any) was called
+      zuoraRestServiceMock.getBillingPreview(eqTo(nonGiftSubscriptionAccountId), any)(any) was called
 
       supporterProductDataServiceMock wasNever calledAgain
       contactRepositoryMock wasNever calledAgain

--- a/membership-attribute-service/test/acceptance/data/TestBillingPreviewInvoiceItem.scala
+++ b/membership-attribute-service/test/acceptance/data/TestBillingPreviewInvoiceItem.scala
@@ -1,0 +1,21 @@
+package acceptance.data
+
+import services.zuora.rest.ZuoraRestService.BillingPreviewInvoiceItem
+
+object TestBillingPreviewInvoiceItem {
+  def apply(
+      subscriptionId: String = "subscriptionId",
+      chargeAmount: Double = 10,
+      taxAmount: Double = 0,
+      serviceStartDate: String = "2024-01-01",
+      serviceEndDate: String = "2024-02-01",
+      chargeName: String = "chargeName",
+  ): BillingPreviewInvoiceItem = BillingPreviewInvoiceItem(
+    subscriptionId,
+    chargeAmount,
+    taxAmount,
+    serviceStartDate,
+    serviceEndDate,
+    chargeName,
+  )
+}

--- a/membership-attribute-service/test/services/PaymentServiceTest.scala
+++ b/membership-attribute-service/test/services/PaymentServiceTest.scala
@@ -1,0 +1,29 @@
+package services
+
+import acceptance.data.TestBillingPreviewInvoiceItem
+import org.joda.time.LocalDate
+import org.specs2.mutable.Specification
+import services.zuora.payment.PaymentService
+
+class PaymentServiceTest extends Specification {
+
+  "toPreviewInvoiceItem" should {
+
+    "include tax in the price, matching the old SOAP amend-with-preview" in {
+      val item = TestBillingPreviewInvoiceItem(chargeAmount = 10, taxAmount = 2)
+      PaymentService.toPreviewInvoiceItem(item).price should_=== 12f
+    }
+
+    "carry the charge name and parse the service dates" in {
+      val item = TestBillingPreviewInvoiceItem(
+        serviceStartDate = "2027-06-25",
+        serviceEndDate = "2028-06-24",
+        chargeName = "Subscription",
+      )
+      val result = PaymentService.toPreviewInvoiceItem(item)
+      result.chargeName should_=== "Subscription"
+      result.serviceStartDate should_=== new LocalDate("2027-06-25")
+      result.serviceEndDate should_=== new LocalDate("2028-06-24")
+    }
+  }
+}

--- a/membership-common/src/main/scala/com/gu/zuora/ZuoraSoapService.scala
+++ b/membership-common/src/main/scala/com/gu/zuora/ZuoraSoapService.scala
@@ -13,12 +13,10 @@ import com.gu.zuora.soap._
 import com.gu.zuora.soap.actions.{Action, XmlWriterAction}
 import com.gu.zuora.soap.actions.Actions._
 import com.gu.zuora.soap.models.Commands.CreatePaymentMethod
-import com.gu.zuora.soap.models.Queries.PreviewInvoiceItem
-import com.gu.zuora.soap.models.Results.{AmendResult, CreateResult, UpdateResult}
+import com.gu.zuora.soap.models.Results.{CreateResult, UpdateResult}
 import com.gu.zuora.soap.models.errors._
 import com.gu.zuora.soap.models.{PaymentSummary, Queries => SoapQueries}
 import com.gu.zuora.soap.writers.Command.createPaymentMethodWrites
-import org.joda.time.LocalDate
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -53,26 +51,6 @@ class ZuoraSoapService(soapClient: soap.Client)(implicit ec: ExecutionContext) e
 
   def getContact(contactId: String)(implicit logPrefix: LogPrefix): Future[SoapQueries.Contact] =
     soapClient.queryOne[SoapQueries.Contact](SimpleFilter("Id", contactId))
-
-  def getSubscription(id: S.Id)(implicit logPrefix: LogPrefix): Future[SoapQueries.Subscription] =
-    soapClient.queryOne[SoapQueries.Subscription](SimpleFilter("id", id.get))
-
-  private def previewInvoices(subscriptionId: String, paymentDate: LocalDate, action: (String, LocalDate) => Action[AmendResult])(implicit
-      logPrefix: LogPrefix,
-  ) = {
-    val invoices = soapClient.authenticatedRequest(action(subscriptionId, paymentDate)).map(_.invoiceItems)
-    invoices recover {
-      case e: Error => Nil
-      case e: Throwable => throw e
-    }
-  }
-
-  def previewInvoices(subscriptionId: S.Id, number: Int = 2)(implicit logPrefix: LogPrefix): Future[Seq[PreviewInvoiceItem]] = {
-    for {
-      sub <- getSubscription(subscriptionId)
-      previewInvoiceItems <- previewInvoices(sub.id, sub.contractAcceptanceDate, PreviewInvoicesViaAmend(number) _)
-    } yield previewInvoiceItems
-  }
 
   private def setDefaultPaymentMethod(
       accountId: AccountId,

--- a/membership-common/src/main/scala/com/gu/zuora/soap/actions/Actions.scala
+++ b/membership-common/src/main/scala/com/gu/zuora/soap/actions/Actions.scala
@@ -152,43 +152,6 @@ object Actions {
 
   }
 
-  /** A hack to get when a subscription charge dates will be effective. While it's possible to get this data from an Invoice of a subscription that
-    * charges the user immediately (e.g. annual partner sign up), it's not possible to get this for data for subscriptions that charge in the future
-    * (subs offer that charges 6 months in). To achieve the latter an amend call with preview can be used - this works for the first case too
-    *
-    * The dummy amend also sets the subscription to be evergreen - an infinite term length while the real subscriptions have one year terms. This is
-    * so we still get invoices for annual subs which have already been billed
-    */
-  case class PreviewInvoicesViaAmend(numberOfPeriods: Int = 2)(subscriptionId: String, paymentDate: LocalDate = now) extends Action[AmendResult] {
-    override def additionalLogInfo =
-      Map("SubscriptionId" -> subscriptionId, "PaymentDate" -> paymentDate.toString, "NumberOfPeriods" -> numberOfPeriods.toString)
-
-    val date = if (now isBefore paymentDate) paymentDate else now
-
-    val body = {
-      <ns1:amend>
-        <ns1:requests>
-          <ns1:Amendments>
-            <ns2:ContractEffectiveDate>{date}</ns2:ContractEffectiveDate>
-            <ns2:CustomerAcceptanceDate>{date}</ns2:CustomerAcceptanceDate>
-            <ns2:TermType>EVERGREEN</ns2:TermType>
-            <ns2:Name>GetSubscriptionDetailsViaAmend</ns2:Name>
-            <ns2:SubscriptionId>{subscriptionId}</ns2:SubscriptionId>
-            <ns2:Type>TermsAndConditions</ns2:Type>
-          </ns1:Amendments>
-          <ns1:AmendOptions>
-            <ns1:GenerateInvoice>False</ns1:GenerateInvoice>
-            <ns1:ProcessPayments>False</ns1:ProcessPayments>
-          </ns1:AmendOptions>
-          <ns1:PreviewOptions>
-            <ns1:EnablePreviewMode>True</ns1:EnablePreviewMode>
-            <ns1:NumberOfPeriods>{numberOfPeriods}</ns1:NumberOfPeriods>
-          </ns1:PreviewOptions>
-        </ns1:requests>
-      </ns1:amend>
-    }
-  }
-
   case class PreviewInvoicesTillEndOfTermViaAmend(subscriptionId: String, paymentDate: LocalDate = now) extends Action[AmendResult] {
     override def additionalLogInfo = Map("SubscriptionId" -> subscriptionId, "PaymentDate" -> paymentDate.toString)
 


### PR DESCRIPTION
### Why do we need this?

Zuora no longer supports the SOAP API for new development, only bug fixes, and members-data-api is still one of the heaviest SOAP users. This migrates the `soap:amend` calls (around 37k in the last 7 days, with a high error rate of ~2,257) off SOAP.

The `soap:amend` traffic here is not actually amending anything. It is a hack that fires a dummy preview amend to project a customer's next payment on the manage-account page (the `/user-attributes/me/mma` endpoints). The hack forces every subscription to an evergreen term to get the projection, which Zuora rejects for many subscription shapes (cancelled, expired, mid-amendment), which is where the errors come from. Those errors were silently swallowed, so the user just saw no next payment.

### The changes

- New `getBillingPreview` on the Zuora REST service, calling `operations/billing-preview` with `assumeRenewal`.
- `PaymentService.getNextBill` now uses billing-preview (filtered to the target subscription) instead of the SOAP amend, mapping the invoice items to the existing shape. Kept like for like: the projected amount includes tax, we look ~30 months ahead to still catch the first paid bill of long promotional periods (e.g. the 24 months free student offer).
- On any failure we show no next payment and never fail the whole `/mma` call, exactly as before, but it is now logged so the failure is visible in the MDAPI logs instead of being silent.
- Removed the now-unused SOAP preview code (`previewInvoices`, `getSubscription`, `PreviewInvoicesViaAmend`), so there is no more `soap:amend` traffic from this path.
- Added a unit test on the invoice-item mapping (that the price includes tax).

I validated billing-preview against real CODE data, including an already-billed annual subscription where `assumeRenewal` correctly projects the renewal charge a year out, so the evergreen trick is not needed. Ran the membership-common and membership-attribute-service test suites locally, all green.

### trello card/screenshot/json/related PRs etc

Asana card: Zuora: Migrate remaining SOAP calls to REST API.

Follow-up for a later PR: the larger `soap:query` share (~225k: getAccountIds, getAccount, getContact, getPaymentSummary, getPaymentMethod) still needs migrating to the REST `action/query` / object endpoints.
