### PR TITLE
match billing preview items by subscription number, not zuora id

### DIFF
--- a/membership-attribute-service/app/services/zuora/payment/PaymentService.scala
+++ b/membership-attribute-service/app/services/zuora/payment/PaymentService.scala
@@ -114,7 +114,7 @@ class PaymentService(zuoraService: ZuoraSoapService, restService: ZuoraRestServi
       .getBillingPreview(accountId, targetDate)
       .map {
         case \/-(items) =>
-          items.filter(_.subscriptionNumber == subscriptionNumber.getNumber).map(PaymentService.toPreviewInvoiceItem)
+          items.filter(_.subscriptionNumber == subscriptionNumber).map(PaymentService.toPreviewInvoiceItem)
         case -\/(error) =>
           logger.warn(s"could not get billing preview for account ${accountId.get}, showing no next payment: $error")
           Nil

--- a/membership-attribute-service/app/services/zuora/payment/PaymentService.scala
+++ b/membership-attribute-service/app/services/zuora/payment/PaymentService.scala
@@ -42,7 +42,7 @@ class PaymentService(zuoraService: ZuoraSoapService, restService: ZuoraRestServi
       account <- zuoraService.getAccount(sub.accountId)
       // Preview ~30 months ahead to handle long promotional periods (e.g. Australian student offer: 24 months free),
       // so we still find the first paid bill for those. Like-for-like with the previous SOAP 30-billing-periods request.
-      eventualBills = getNextBill(sub.id, account, LocalDate.now.plusMonths(30)).withLogging(s"next bill for $sub")
+      eventualBills = getNextBill(sub.subscriptionNumber, account, LocalDate.now.plusMonths(30)).withLogging(s"next bill for $sub")
       eventualMaybePaymentMethod = getPaymentMethod(account.defaultPaymentMethodId, defaultMandateIdIfApplicable) // kick off async
       bills <- eventualBills
       maybePaymentMethod <- eventualMaybePaymentMethod
@@ -89,9 +89,11 @@ class PaymentService(zuoraService: ZuoraSoapService, restService: ZuoraRestServi
       case _ => None
     }
 
-  private def getNextBill(subId: Id, account: Account, targetDate: LocalDate)(implicit logPrefix: LogPrefix): Future[List[Bill]] =
+  private def getNextBill(subscriptionNumber: SubscriptionNumber, account: Account, targetDate: LocalDate)(implicit
+      logPrefix: LogPrefix,
+  ): Future[List[Bill]] =
     for {
-      previewInvoiceItems <- getPreviewInvoiceItems(subId, AccountId(account.id), targetDate)
+      previewInvoiceItems <- getPreviewInvoiceItems(subscriptionNumber, AccountId(account.id), targetDate)
     } yield for {
       billingSched <- BillingSchedule.fromPreviewInvoiceItems(previewInvoiceItems).toList
       bill <- billingSched
@@ -101,17 +103,18 @@ class PaymentService(zuoraService: ZuoraSoapService, restService: ZuoraRestServi
         .toList
     } yield bill
 
-  /** billing-preview is account-scoped, so we request the whole account and keep only the target subscription's items. A preview failure only means
-    * we show no next payment; it must never fail the whole /mma call, so we log it and carry on.
+  /** billing-preview is account-scoped, so we request the whole account and keep only the target subscription's items. We match on the subscription
+    * number, not the Zuora id: with assumeRenewal the projected items carry a simulated renewal subscription id, so filtering by id would drop them
+    * all. A preview failure only means we show no next payment; it must never fail the whole /mma call, so we log it and carry on.
     */
-  private def getPreviewInvoiceItems(subId: Id, accountId: AccountId, targetDate: LocalDate)(implicit
+  private def getPreviewInvoiceItems(subscriptionNumber: SubscriptionNumber, accountId: AccountId, targetDate: LocalDate)(implicit
       logPrefix: LogPrefix,
   ): Future[Seq[Queries.PreviewInvoiceItem]] =
     restService
       .getBillingPreview(accountId, targetDate)
       .map {
         case \/-(items) =>
-          items.filter(_.subscriptionId == subId.get).map(PaymentService.toPreviewInvoiceItem)
+          items.filter(_.subscriptionNumber == subscriptionNumber.getNumber).map(PaymentService.toPreviewInvoiceItem)
         case -\/(error) =>
           logger.warn(s"could not get billing preview for account ${accountId.get}, showing no next payment: $error")
           Nil

--- a/membership-attribute-service/app/services/zuora/rest/ZuoraRestService.scala
+++ b/membership-attribute-service/app/services/zuora/rest/ZuoraRestService.scala
@@ -208,7 +208,7 @@ object ZuoraRestService {
   implicit val billingPreviewRequestWrites = Json.writes[BillingPreviewRequest]
 
   case class BillingPreviewInvoiceItem(
-      subscriptionId: String,
+      subscriptionNumber: String,
       chargeAmount: Double,
       taxAmount: Double,
       serviceStartDate: String,

--- a/membership-attribute-service/app/services/zuora/rest/ZuoraRestService.scala
+++ b/membership-attribute-service/app/services/zuora/rest/ZuoraRestService.scala
@@ -207,8 +207,9 @@ object ZuoraRestService {
   case class BillingPreviewRequest(accountId: String, targetDate: LocalDate, assumeRenewal: String = "Autorenew")
   implicit val billingPreviewRequestWrites = Json.writes[BillingPreviewRequest]
 
+  implicit val subscriptionNumberReads: Reads[SubscriptionNumber] = Json.valueReads[SubscriptionNumber]
   case class BillingPreviewInvoiceItem(
-      subscriptionNumber: String,
+      subscriptionNumber: SubscriptionNumber,
       chargeAmount: Double,
       taxAmount: Double,
       serviceStartDate: String,

--- a/membership-attribute-service/test/acceptance/AccountControllerAcceptanceTest.scala
+++ b/membership-attribute-service/test/acceptance/AccountControllerAcceptanceTest.scala
@@ -184,10 +184,17 @@ class AccountControllerAcceptanceTest extends AcceptanceTest {
 
       zuoraSoapServiceMock.getPaymentSummary(nonGiftSubscription.subscriptionNumber, Currency.GBP)(any) returns Future(TestPaymentSummary())
       zuoraSoapServiceMock.getAccount(nonGiftSubscriptionAccountId)(any) returns Future(
-        TestQueriesAccount(id = nonGiftSubscriptionAccountId.get),
+        TestQueriesAccount(id = nonGiftSubscriptionAccountId.get, creditBalance = 0),
       )
+      // billing-preview is account-scoped: it returns items for this subscription plus a different one on the account.
+      // We must keep only this subscription's items (matched by number), so the next payment reflects 10, not 10 + 999.
       zuoraRestServiceMock.getBillingPreview(eqTo(nonGiftSubscriptionAccountId), any)(any) returns Future(
-        \/.right(List(TestBillingPreviewInvoiceItem(subscriptionNumber = nonGiftSubscription.subscriptionNumber.getNumber))),
+        \/.right(
+          List(
+            TestBillingPreviewInvoiceItem(subscriptionNumber = nonGiftSubscription.subscriptionNumber.getNumber, chargeAmount = 10),
+            TestBillingPreviewInvoiceItem(subscriptionNumber = "A-S00000999", chargeAmount = 999),
+          ),
+        ),
       )
 
       val patronSubscription = TestDynamoSupporterRatePlanItem(
@@ -264,6 +271,9 @@ class AccountControllerAcceptanceTest extends AcceptanceTest {
       (supporterPlusProduct \ "subscription" \ "contactId").as[String] shouldEqual contact.salesforceContactId
       (supporterPlusProduct \ "subscription" \ "subscriptionId").as[String] shouldEqual nonGiftSubscription.subscriptionNumber.getNumber
       (supporterPlusProduct \ "subscription" \ "accountId").as[String] shouldEqual nonGiftSubscription.accountId.get
+      // the next payment is this subscription's billing-preview charge (10.00, i.e. 1000 in minor units), not the
+      // other subscription's charge of 999 which must be filtered out
+      (supporterPlusProduct \ "subscription" \ "nextPaymentPrice").as[Double] shouldEqual 1000.0
       (supporterPlusProduct \ "subscription" \ "plan" \ "name").as[String] shouldEqual nonGiftSubscription.plan(catalog).productName
 
       (digiGiftProduct \ "tier").as[String] shouldEqual giftSubscriptionFromSubscriptionService.ratePlans.head.productName

--- a/membership-attribute-service/test/acceptance/AccountControllerAcceptanceTest.scala
+++ b/membership-attribute-service/test/acceptance/AccountControllerAcceptanceTest.scala
@@ -187,7 +187,7 @@ class AccountControllerAcceptanceTest extends AcceptanceTest {
         TestQueriesAccount(id = nonGiftSubscriptionAccountId.get),
       )
       zuoraRestServiceMock.getBillingPreview(eqTo(nonGiftSubscriptionAccountId), any)(any) returns Future(
-        \/.right(List(TestBillingPreviewInvoiceItem(subscriptionId = nonGiftSubscription.id.get))),
+        \/.right(List(TestBillingPreviewInvoiceItem(subscriptionNumber = nonGiftSubscription.subscriptionNumber.getNumber))),
       )
 
       val patronSubscription = TestDynamoSupporterRatePlanItem(

--- a/membership-attribute-service/test/acceptance/data/TestBillingPreviewInvoiceItem.scala
+++ b/membership-attribute-service/test/acceptance/data/TestBillingPreviewInvoiceItem.scala
@@ -4,14 +4,14 @@ import services.zuora.rest.ZuoraRestService.BillingPreviewInvoiceItem
 
 object TestBillingPreviewInvoiceItem {
   def apply(
-      subscriptionId: String = "subscriptionId",
+      subscriptionNumber: String = "A-S00000000",
       chargeAmount: Double = 10,
       taxAmount: Double = 0,
       serviceStartDate: String = "2024-01-01",
       serviceEndDate: String = "2024-02-01",
       chargeName: String = "chargeName",
   ): BillingPreviewInvoiceItem = BillingPreviewInvoiceItem(
-    subscriptionId,
+    subscriptionNumber,
     chargeAmount,
     taxAmount,
     serviceStartDate,

--- a/membership-attribute-service/test/acceptance/data/TestBillingPreviewInvoiceItem.scala
+++ b/membership-attribute-service/test/acceptance/data/TestBillingPreviewInvoiceItem.scala
@@ -1,5 +1,6 @@
 package acceptance.data
 
+import com.gu.memsub.Subscription.SubscriptionNumber
 import services.zuora.rest.ZuoraRestService.BillingPreviewInvoiceItem
 
 object TestBillingPreviewInvoiceItem {
@@ -11,7 +12,7 @@ object TestBillingPreviewInvoiceItem {
       serviceEndDate: String = "2024-02-01",
       chargeName: String = "chargeName",
   ): BillingPreviewInvoiceItem = BillingPreviewInvoiceItem(
-    subscriptionNumber,
+    SubscriptionNumber(subscriptionNumber),
     chargeAmount,
     taxAmount,
     serviceStartDate,


### PR DESCRIPTION
### Why do we need this?

Follow-up to #1259 (SOAP amend to REST billing-preview). Testing that change in CODE showed the next payment coming back as £0.00 for every subscription. The cause: `getNextBill` filtered the account-scoped billing-preview items by the Zuora subscription id, but with `assumeRenewal` the projected items carry a simulated renewal subscription id, so the filter dropped every item and we ended up with no bills (nextPaymentPrice 0). Because a preview failure degrades gracefully (no 500), it was invisible until we looked at the actual value in CODE.

### The changes

- Filter the billing-preview items by subscription number, which is stable across renewals, instead of the Zuora id (the DTO now carries `subscriptionNumber`).

Verified against real CODE data: the next payment for a real subscription goes from £0.00 back to the correct £64.99, and the full test suites are green.

### trello card/screenshot/json/related PRs etc

Follow-up to #1259. Asana: Zuora Migrate remaining SOAP calls to REST API.
