### PR TITLE
replace SOAP query reads with Zuora REST equivalents

### DIFF
--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -109,7 +109,7 @@ class TouchpointComponents(
         metrics = zuoraMetrics,
       )
 
-    lazy val simpleZuoraSoapService = new ZuoraSoapService(zuoraSoapClient) with HealthCheckableService {
+    lazy val simpleZuoraSoapService = new ZuoraSoapService(zuoraSoapClient, zuoraRestClient) with HealthCheckableService {
       override def checkHealth: Boolean = zuoraSoapClient.isReady
     }
 

--- a/membership-common/src/main/scala/com/gu/zuora/ZuoraSoapService.scala
+++ b/membership-common/src/main/scala/com/gu/zuora/ZuoraSoapService.scala
@@ -57,8 +57,7 @@ class ZuoraSoapService(soapClient: soap.Client, restClient: rest.SimpleClient[Fu
       .map(_.valueOr(error => throw QueryError(s"Zuora REST query '$zoql' failed: $error")).records)
 
   def getAccountIds(contactId: ContactId)(implicit logPrefix: LogPrefix): Future[List[AccountId]] =
-    query[AccountIdRecord](s"select Id from account where crmId = '${contactId.salesforceAccountId}'")
-      .map(_.map(record => AccountId(record.id)))
+    query[AccountId](s"select Id from account where crmId = '${contactId.salesforceAccountId}'")
 
   def getAccount(accountId: AccountId)(implicit logPrefix: LogPrefix): Future[SoapQueries.Account] =
     getObject[SoapQueries.Account](s"object/account/${accountId.get}")
@@ -130,11 +129,21 @@ class ZuoraSoapService(soapClient: soap.Client, restClient: rest.SimpleClient[Fu
     } yield result
   }
 
-  def getPaymentSummary(subscriptionNumber: S.SubscriptionNumber, accountCurrency: Currency)(implicit logPrefix: LogPrefix): Future[PaymentSummary] =
-    query[SoapQueries.InvoiceItem](
-      s"select Id, ChargeAmount, TaxAmount, ServiceStartDate, ServiceEndDate, ChargeNumber, ProductName, SubscriptionId " +
-        s"from invoiceitem where SubscriptionNumber = '${subscriptionNumber.getNumber}'",
-    ).map(invoiceItems => PaymentSummary(latestInvoiceItems(invoiceItems), accountCurrency))
+  def getPaymentSummary(subscriptionNumber: S.SubscriptionNumber, accountCurrency: Currency)(implicit
+      logPrefix: LogPrefix,
+  ): Future[PaymentSummary] = {
+    val zoql = List(
+      "select Id, ChargeAmount, TaxAmount, ServiceStartDate, ServiceEndDate, ChargeNumber, ProductName, SubscriptionId",
+      "from invoiceitem",
+      s"where SubscriptionNumber = '${subscriptionNumber.getNumber}'",
+    ).mkString(" ")
+    for {
+      invoiceItems <- query[SoapQueries.InvoiceItem](zoql)
+    } yield {
+      val filteredInvoices = latestInvoiceItems(invoiceItems)
+      PaymentSummary(filteredInvoices, accountCurrency)
+    }
+  }
 
   def getPaymentMethod(id: String)(implicit logPrefix: LogPrefix): Future[SoapQueries.PaymentMethod] =
     getObject[SoapQueries.PaymentMethod](s"object/payment-method/$id")

--- a/membership-common/src/main/scala/com/gu/zuora/ZuoraSoapService.scala
+++ b/membership-common/src/main/scala/com/gu/zuora/ZuoraSoapService.scala
@@ -45,16 +45,16 @@ class ZuoraSoapService(soapClient: soap.Client, restClient: rest.SimpleClient[Fu
 
   import ZuoraSoapService._
 
-  // These reads used to go through the SOAP query API; they now hit the equivalent Zuora REST endpoints (object/{type}/{id} and action/query),
-  // mapping the responses back to the same case classes so callers are unchanged. A missing record or REST error fails the Future, matching the
-  // old queryOne behaviour.
+  /* These reads used to go through the SOAP query API; they now hit the equivalent Zuora REST endpoints (object/{type}/{id} and action/query),
+     mapping the responses back to the same case classes so callers are unchanged. getObject fails the Future if the object is missing or the call
+     errors, like the old queryOne; query returns the records (empty if none) and only fails on a REST error, like the old plural query. */
   private def getObject[A: Reads](url: String)(implicit logPrefix: LogPrefix): Future[A] =
-    restClient.get[A](url).map(_.valueOr(error => throw new RuntimeException(s"Zuora REST get '$url' failed: $error")))
+    restClient.get[A](url).map(_.valueOr(error => throw QueryError(s"Zuora REST get '$url' failed: $error")))
 
   private def query[A: Reads](zoql: String)(implicit logPrefix: LogPrefix): Future[List[A]] =
     restClient
       .post[RestQuery, QueryResponse[A]]("action/query", RestQuery(zoql))
-      .map(_.valueOr(error => throw new RuntimeException(s"Zuora REST query '$zoql' failed: $error")).records)
+      .map(_.valueOr(error => throw QueryError(s"Zuora REST query '$zoql' failed: $error")).records)
 
   def getAccountIds(contactId: ContactId)(implicit logPrefix: LogPrefix): Future[List[AccountId]] =
     query[AccountIdRecord](s"select Id from account where crmId = '${contactId.salesforceAccountId}'")

--- a/membership-common/src/main/scala/com/gu/zuora/ZuoraSoapService.scala
+++ b/membership-common/src/main/scala/com/gu/zuora/ZuoraSoapService.scala
@@ -17,6 +17,8 @@ import com.gu.zuora.soap.models.Results.{CreateResult, UpdateResult}
 import com.gu.zuora.soap.models.errors._
 import com.gu.zuora.soap.models.{PaymentSummary, Queries => SoapQueries}
 import com.gu.zuora.soap.writers.Command.createPaymentMethodWrites
+import com.gu.zuora.rest.ZuoraQueryReads._
+import play.api.libs.json.Reads
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -37,20 +39,32 @@ trait SoapClient[M[_]] {
   def getAccountIds(contactId: ContactId)(implicit logPrefix: LogPrefix): M[List[AccountId]]
 }
 
-class ZuoraSoapService(soapClient: soap.Client)(implicit ec: ExecutionContext) extends SoapClient[Future] with SafeLogging {
+class ZuoraSoapService(soapClient: soap.Client, restClient: rest.SimpleClient[Future])(implicit ec: ExecutionContext)
+    extends SoapClient[Future]
+    with SafeLogging {
 
   import ZuoraSoapService._
 
+  // These reads used to go through the SOAP query API; they now hit the equivalent Zuora REST endpoints (object/{type}/{id} and action/query),
+  // mapping the responses back to the same case classes so callers are unchanged. A missing record or REST error fails the Future, matching the
+  // old queryOne behaviour.
+  private def getObject[A: Reads](url: String)(implicit logPrefix: LogPrefix): Future[A] =
+    restClient.get[A](url).map(_.valueOr(error => throw new RuntimeException(s"Zuora REST get '$url' failed: $error")))
+
+  private def query[A: Reads](zoql: String)(implicit logPrefix: LogPrefix): Future[List[A]] =
+    restClient
+      .post[RestQuery, QueryResponse[A]]("action/query", RestQuery(zoql))
+      .map(_.valueOr(error => throw new RuntimeException(s"Zuora REST query '$zoql' failed: $error")).records)
+
   def getAccountIds(contactId: ContactId)(implicit logPrefix: LogPrefix): Future[List[AccountId]] =
-    soapClient
-      .query[SoapQueries.Account](SimpleFilter("crmId", contactId.salesforceAccountId))
-      .map(_.map(a => AccountId(a.id)).toList)
+    query[AccountIdRecord](s"select Id from account where crmId = '${contactId.salesforceAccountId}'")
+      .map(_.map(record => AccountId(record.id)))
 
   def getAccount(accountId: AccountId)(implicit logPrefix: LogPrefix): Future[SoapQueries.Account] =
-    soapClient.queryOne[SoapQueries.Account](SimpleFilter("id", accountId.get))
+    getObject[SoapQueries.Account](s"object/account/${accountId.get}")
 
   def getContact(contactId: String)(implicit logPrefix: LogPrefix): Future[SoapQueries.Contact] =
-    soapClient.queryOne[SoapQueries.Contact](SimpleFilter("Id", contactId))
+    getObject[SoapQueries.Contact](s"object/contact/$contactId")
 
   private def setDefaultPaymentMethod(
       accountId: AccountId,
@@ -117,14 +131,12 @@ class ZuoraSoapService(soapClient: soap.Client)(implicit ec: ExecutionContext) e
   }
 
   def getPaymentSummary(subscriptionNumber: S.SubscriptionNumber, accountCurrency: Currency)(implicit logPrefix: LogPrefix): Future[PaymentSummary] =
-    for {
-      invoiceItems <- soapClient.query[SoapQueries.InvoiceItem](SimpleFilter("SubscriptionNumber", subscriptionNumber.getNumber))
-    } yield {
-      val filteredInvoices = latestInvoiceItems(invoiceItems)
-      PaymentSummary(filteredInvoices, accountCurrency)
-    }
+    query[SoapQueries.InvoiceItem](
+      s"select Id, ChargeAmount, TaxAmount, ServiceStartDate, ServiceEndDate, ChargeNumber, ProductName, SubscriptionId " +
+        s"from invoiceitem where SubscriptionNumber = '${subscriptionNumber.getNumber}'",
+    ).map(invoiceItems => PaymentSummary(latestInvoiceItems(invoiceItems), accountCurrency))
 
   def getPaymentMethod(id: String)(implicit logPrefix: LogPrefix): Future[SoapQueries.PaymentMethod] =
-    soapClient.queryOne[SoapQueries.PaymentMethod](SimpleFilter("Id", id))
+    getObject[SoapQueries.PaymentMethod](s"object/payment-method/$id")
 
 }

--- a/membership-common/src/main/scala/com/gu/zuora/rest/ZuoraQueryReads.scala
+++ b/membership-common/src/main/scala/com/gu/zuora/rest/ZuoraQueryReads.scala
@@ -1,6 +1,7 @@
 package com.gu.zuora.rest
 
 import com.gu.i18n.Currency
+import com.gu.memsub.Subscription.AccountId
 import com.gu.zuora.ZuoraLookup
 import com.gu.zuora.api.PaymentGateway
 import com.gu.zuora.soap.models.Queries
@@ -9,7 +10,7 @@ import play.api.libs.json._
 
 /** JSON readers that let ZuoraSoapService's read methods hit Zuora REST (object/{type}/{id} and action/query) instead of SOAP query, mapping the
   * responses back to the existing SOAP query case classes so callers are unaffected. Field names and parsing mirror the old SOAP readers in
-  * com.gu.zuora.soap.Readers. See https://developer.zuora.com/api-references/api/operation/Object_GETAccount
+  * com.gu.zuora.soap.Readers. Each reader links the Zuora operation it parses.
   */
 object ZuoraQueryReads {
 
@@ -20,19 +21,10 @@ object ZuoraQueryReads {
   implicit def queryResponseReads[A](implicit r: Reads[A]): Reads[QueryResponse[A]] =
     (__ \ "records").read[List[A]].map(QueryResponse(_))
 
-  case class AccountIdRecord(id: String)
-  implicit val accountIdRecordReads: Reads[AccountIdRecord] = (__ \ "Id").read[String].map(AccountIdRecord)
+  /** @see https://developer.zuora.com/api-references/api/operation/Action_POSTquery */
+  implicit val accountIdReads: Reads[AccountId] = (__ \ "Id").read[String].map(AccountId)
 
-  /* Zuora returns some fields (e.g. credit card expiry) as JSON numbers; the SOAP readers treated everything as strings, so normalise to String. */
-  private def optString(json: JsValue, field: String): JsResult[Option[String]] =
-    (json \ field)
-      .validateOpt[JsValue]
-      .map(_.flatMap {
-        case JsString(s) => Some(s)
-        case JsNumber(n) => Some(n.toBigInt.toString)
-        case _ => None
-      })
-
+  /** @see https://developer.zuora.com/api-references/older-api/operation/Object_GETAccount */
   implicit val accountReads: Reads[Queries.Account] = Reads { json =>
     for {
       id <- (json \ "Id").validate[String]
@@ -57,6 +49,7 @@ object ZuoraQueryReads {
     )
   }
 
+  /** @see https://developer.zuora.com/api-references/older-api/operation/Object_GETContact */
   implicit val contactReads: Reads[Queries.Contact] = Reads { json =>
     for {
       id <- (json \ "Id").validate[String]
@@ -75,6 +68,7 @@ object ZuoraQueryReads {
     )
   }
 
+  /** @see https://developer.zuora.com/api-references/older-api/operation/Object_GETPaymentMethod */
   implicit val paymentMethodReads: Reads[Queries.PaymentMethod] = Reads { json =>
     for {
       id <- (json \ "Id").validate[String]
@@ -89,9 +83,9 @@ object ZuoraQueryReads {
       bankTransferAccountName <- (json \ "BankTransferAccountName").validateOpt[String]
       bankTransferAccountNumberMask <- (json \ "BankTransferAccountNumberMask").validateOpt[String]
       bankCode <- (json \ "BankCode").validateOpt[String]
-      creditCardMaskNumber <- optString(json, "CreditCardMaskNumber")
-      creditCardExpirationMonth <- optString(json, "CreditCardExpirationMonth")
-      creditCardExpirationYear <- optString(json, "CreditCardExpirationYear")
+      creditCardMaskNumber <- (json \ "CreditCardMaskNumber").validateOpt[String]
+      creditCardExpirationMonth <- (json \ "CreditCardExpirationMonth").validateOpt[Int]
+      creditCardExpirationYear <- (json \ "CreditCardExpirationYear").validateOpt[Int]
       creditCardType <- (json \ "CreditCardType").validateOpt[String]
     } yield Queries.PaymentMethod(
       id = id,
@@ -105,14 +99,15 @@ object ZuoraQueryReads {
       bankCode = bankCode,
       `type` = paymentType,
       creditCardNumber = creditCardMaskNumber.map(_.takeRight(4)),
-      creditCardExpirationMonth = creditCardExpirationMonth,
-      creditCardExpirationYear = creditCardExpirationYear,
+      creditCardExpirationMonth = creditCardExpirationMonth.map(_.toString),
+      creditCardExpirationYear = creditCardExpirationYear.map(_.toString),
       creditCardType = creditCardType,
       numConsecutiveFailures = numConsecutiveFailures,
       paymentMethodStatus = paymentMethodStatus,
     )
   }
 
+  /** @see https://developer.zuora.com/api-references/api/operation/Action_POSTquery */
   implicit val invoiceItemReads: Reads[Queries.InvoiceItem] = Reads { json =>
     for {
       id <- (json \ "Id").validate[String]

--- a/membership-common/src/main/scala/com/gu/zuora/rest/ZuoraQueryReads.scala
+++ b/membership-common/src/main/scala/com/gu/zuora/rest/ZuoraQueryReads.scala
@@ -23,7 +23,7 @@ object ZuoraQueryReads {
   case class AccountIdRecord(id: String)
   implicit val accountIdRecordReads: Reads[AccountIdRecord] = (__ \ "Id").read[String].map(AccountIdRecord)
 
-  // Zuora returns some fields (e.g. credit card expiry) as JSON numbers; the SOAP readers treated everything as strings, so normalise to String.
+  /* Zuora returns some fields (e.g. credit card expiry) as JSON numbers; the SOAP readers treated everything as strings, so normalise to String. */
   private def optString(json: JsValue, field: String): JsResult[Option[String]] =
     (json \ field)
       .validateOpt[JsValue]

--- a/membership-common/src/main/scala/com/gu/zuora/rest/ZuoraQueryReads.scala
+++ b/membership-common/src/main/scala/com/gu/zuora/rest/ZuoraQueryReads.scala
@@ -1,0 +1,136 @@
+package com.gu.zuora.rest
+
+import com.gu.i18n.Currency
+import com.gu.zuora.ZuoraLookup
+import com.gu.zuora.api.PaymentGateway
+import com.gu.zuora.soap.models.Queries
+import org.joda.time.LocalDate
+import play.api.libs.json._
+
+/** JSON readers that let ZuoraSoapService's read methods hit Zuora REST (object/{type}/{id} and action/query) instead of SOAP query, mapping the
+  * responses back to the existing SOAP query case classes so callers are unaffected. Field names and parsing mirror the old SOAP readers in
+  * com.gu.zuora.soap.Readers. See https://developer.zuora.com/api-references/api/operation/Object_GETAccount
+  */
+object ZuoraQueryReads {
+
+  case class RestQuery(queryString: String)
+  implicit val restQueryWrites: Writes[RestQuery] = Json.writes[RestQuery]
+
+  case class QueryResponse[A](records: List[A])
+  implicit def queryResponseReads[A](implicit r: Reads[A]): Reads[QueryResponse[A]] =
+    (__ \ "records").read[List[A]].map(QueryResponse(_))
+
+  case class AccountIdRecord(id: String)
+  implicit val accountIdRecordReads: Reads[AccountIdRecord] = (__ \ "Id").read[String].map(AccountIdRecord)
+
+  // Zuora returns some fields (e.g. credit card expiry) as JSON numbers; the SOAP readers treated everything as strings, so normalise to String.
+  private def optString(json: JsValue, field: String): JsResult[Option[String]] =
+    (json \ field)
+      .validateOpt[JsValue]
+      .map(_.flatMap {
+        case JsString(s) => Some(s)
+        case JsNumber(n) => Some(n.toBigInt.toString)
+        case _ => None
+      })
+
+  implicit val accountReads: Reads[Queries.Account] = Reads { json =>
+    for {
+      id <- (json \ "Id").validate[String]
+      billToId <- (json \ "BillToId").validate[String]
+      soldToId <- (json \ "SoldToId").validate[String]
+      billCycleDay <- (json \ "BillCycleDay").validate[Int]
+      creditBalance <- (json \ "CreditBalance").validate[Float]
+      currency <- (json \ "Currency").validateOpt[String]
+      defaultPaymentMethodId <- (json \ "DefaultPaymentMethodId").validateOpt[String]
+      sfContactId <- (json \ "sfContactId__c").validateOpt[String]
+      paymentGateway <- (json \ "PaymentGateway").validateOpt[String]
+    } yield Queries.Account(
+      id = id,
+      billToId = billToId,
+      soldToId = soldToId,
+      billCycleDay = billCycleDay,
+      creditBalance = creditBalance,
+      currency = currency.flatMap(Currency.fromString),
+      defaultPaymentMethodId = defaultPaymentMethodId,
+      sfContactId = sfContactId,
+      paymentGateway = paymentGateway.flatMap(PaymentGateway.getByName),
+    )
+  }
+
+  implicit val contactReads: Reads[Queries.Contact] = Reads { json =>
+    for {
+      id <- (json \ "Id").validate[String]
+      firstName <- (json \ "FirstName").validate[String]
+      lastName <- (json \ "LastName").validate[String]
+      postalCode <- (json \ "PostalCode").validateOpt[String]
+      country <- (json \ "Country").validateOpt[String]
+      email <- (json \ "WorkEmail").validateOpt[String]
+    } yield Queries.Contact(
+      id = id,
+      firstName = firstName,
+      lastName = lastName,
+      postalCode = postalCode,
+      country = country.flatMap(ZuoraLookup.country),
+      email = email,
+    )
+  }
+
+  implicit val paymentMethodReads: Reads[Queries.PaymentMethod] = Reads { json =>
+    for {
+      id <- (json \ "Id").validate[String]
+      paymentType <- (json \ "Type").validate[String]
+      numConsecutiveFailures <- (json \ "NumConsecutiveFailures").validateOpt[Int]
+      paymentMethodStatus <- (json \ "PaymentMethodStatus").validateOpt[String]
+      mandateId <- (json \ "MandateID").validateOpt[String]
+      tokenId <- (json \ "TokenId").validateOpt[String]
+      secondTokenId <- (json \ "SecondTokenId").validateOpt[String]
+      payPalEmail <- (json \ "PaypalEmail").validateOpt[String]
+      bankTransferType <- (json \ "BankTransferType").validateOpt[String]
+      bankTransferAccountName <- (json \ "BankTransferAccountName").validateOpt[String]
+      bankTransferAccountNumberMask <- (json \ "BankTransferAccountNumberMask").validateOpt[String]
+      bankCode <- (json \ "BankCode").validateOpt[String]
+      creditCardMaskNumber <- optString(json, "CreditCardMaskNumber")
+      creditCardExpirationMonth <- optString(json, "CreditCardExpirationMonth")
+      creditCardExpirationYear <- optString(json, "CreditCardExpirationYear")
+      creditCardType <- (json \ "CreditCardType").validateOpt[String]
+    } yield Queries.PaymentMethod(
+      id = id,
+      mandateId = mandateId,
+      tokenId = tokenId,
+      secondTokenId = secondTokenId,
+      payPalEmail = payPalEmail,
+      bankTransferType = bankTransferType,
+      bankTransferAccountName = bankTransferAccountName,
+      bankTransferAccountNumberMask = bankTransferAccountNumberMask,
+      bankCode = bankCode,
+      `type` = paymentType,
+      creditCardNumber = creditCardMaskNumber.map(_.takeRight(4)),
+      creditCardExpirationMonth = creditCardExpirationMonth,
+      creditCardExpirationYear = creditCardExpirationYear,
+      creditCardType = creditCardType,
+      numConsecutiveFailures = numConsecutiveFailures,
+      paymentMethodStatus = paymentMethodStatus,
+    )
+  }
+
+  implicit val invoiceItemReads: Reads[Queries.InvoiceItem] = Reads { json =>
+    for {
+      id <- (json \ "Id").validate[String]
+      chargeAmount <- (json \ "ChargeAmount").validate[Float]
+      taxAmount <- (json \ "TaxAmount").validate[Float]
+      serviceStartDate <- (json \ "ServiceStartDate").validate[String]
+      serviceEndDate <- (json \ "ServiceEndDate").validate[String]
+      chargeNumber <- (json \ "ChargeNumber").validate[String]
+      productName <- (json \ "ProductName").validate[String]
+      subscriptionId <- (json \ "SubscriptionId").validate[String]
+    } yield Queries.InvoiceItem(
+      id = id,
+      price = chargeAmount + taxAmount,
+      serviceStartDate = new LocalDate(serviceStartDate),
+      serviceEndDate = new LocalDate(serviceEndDate),
+      chargeNumber = chargeNumber,
+      productName = productName,
+      subscriptionId = subscriptionId,
+    )
+  }
+}

--- a/membership-common/src/test/scala/com/gu/zuora/rest/ZuoraQueryReadsTest.scala
+++ b/membership-common/src/test/scala/com/gu/zuora/rest/ZuoraQueryReadsTest.scala
@@ -1,6 +1,7 @@
 package com.gu.zuora.rest
 
 import com.gu.i18n.Currency.GBP
+import com.gu.memsub.Subscription.AccountId
 import com.gu.zuora.rest.ZuoraQueryReads._
 import com.gu.zuora.soap.models.Queries
 import org.joda.time.LocalDate
@@ -57,9 +58,9 @@ class ZuoraQueryReadsTest extends Specification {
   }
 
   "queryResponseReads" should {
-    "extract account ids from an action/query response" in {
+    "read account ids straight into AccountId" in {
       val json = Json.parse("""{"records": [{"Id": "acc-1"}, {"Id": "acc-2"}], "size": 2, "done": true}""")
-      json.as[QueryResponse[AccountIdRecord]].records.map(_.id) must_== List("acc-1", "acc-2")
+      json.as[QueryResponse[AccountId]].records.map(_.get) must_== List("acc-1", "acc-2")
     }
   }
 }

--- a/membership-common/src/test/scala/com/gu/zuora/rest/ZuoraQueryReadsTest.scala
+++ b/membership-common/src/test/scala/com/gu/zuora/rest/ZuoraQueryReadsTest.scala
@@ -1,0 +1,65 @@
+package com.gu.zuora.rest
+
+import com.gu.i18n.Currency.GBP
+import com.gu.zuora.rest.ZuoraQueryReads._
+import com.gu.zuora.soap.models.Queries
+import org.joda.time.LocalDate
+import org.specs2.mutable.Specification
+import play.api.libs.json.Json
+
+class ZuoraQueryReadsTest extends Specification {
+
+  "accountReads" should {
+    "parse an object/account response, resolving currency and payment gateway" in {
+      val json = Json.parse("""{
+        "Id": "acc-1", "BillToId": "bill-1", "SoldToId": "sold-1", "BillCycleDay": 18,
+        "CreditBalance": 0, "Currency": "GBP", "DefaultPaymentMethodId": "pm-1",
+        "sfContactId__c": "003xxx", "PaymentGateway": "Stripe PaymentIntents GNM Membership"
+      }""")
+      val account = json.as[Queries.Account]
+      account.billCycleDay must_== 18
+      account.creditBalance must_== 0f
+      account.currency must_== Some(GBP)
+      account.defaultPaymentMethodId must beSome("pm-1")
+      account.sfContactId must beSome("003xxx")
+      account.paymentGateway must beSome
+    }
+  }
+
+  "paymentMethodReads" should {
+    "parse credit card expiry returned as JSON numbers into strings, and keep only the last 4 mask digits" in {
+      val json = Json.parse("""{
+        "Id": "pm-1", "Type": "CreditCardReferenceTransaction", "PaymentMethodStatus": "Active",
+        "NumConsecutiveFailures": 0, "CreditCardMaskNumber": "************4242",
+        "CreditCardExpirationMonth": 10, "CreditCardExpirationYear": 2026, "CreditCardType": "Visa"
+      }""")
+      val pm = json.as[Queries.PaymentMethod]
+      pm.`type` must_== "CreditCardReferenceTransaction"
+      pm.creditCardExpirationMonth must beSome("10")
+      pm.creditCardExpirationYear must beSome("2026")
+      pm.creditCardNumber must beSome("4242")
+      pm.numConsecutiveFailures must beSome(0)
+      pm.bankCode must beNone
+    }
+  }
+
+  "invoiceItemReads" should {
+    "sum charge and tax into the price" in {
+      val json = Json.parse("""{
+        "Id": "ii-1", "ChargeAmount": 10.3, "TaxAmount": 2, "ServiceStartDate": "2026-06-18",
+        "ServiceEndDate": "2026-07-17", "ChargeNumber": "C-1", "ProductName": "Newspaper", "SubscriptionId": "sub-1"
+      }""")
+      val item = json.as[Queries.InvoiceItem]
+      item.price must_== 12.3f
+      item.serviceStartDate must_== new LocalDate("2026-06-18")
+      item.subscriptionId must_== "sub-1"
+    }
+  }
+
+  "queryResponseReads" should {
+    "extract account ids from an action/query response" in {
+      val json = Json.parse("""{"records": [{"Id": "acc-1"}, {"Id": "acc-2"}], "size": 2, "done": true}""")
+      json.as[QueryResponse[AccountIdRecord]].records.map(_.id) must_== List("acc-1", "acc-2")
+    }
+  }
+}


### PR DESCRIPTION
### Why do we need this?

Part of the Zuora SOAP to REST migration for members-data-api. This is the `soap:query` side (the billing-preview/amend side was #1259 and #1260). The five remaining read methods in `ZuoraSoapService` (`getAccount`, `getAccountIds`, `getContact`, `getPaymentSummary`, `getPaymentMethod`) went through the Zuora SOAP query API. They now hit the equivalent REST endpoints (`object/{type}/{id}` and `action/query`).

### The changes

- New JSON readers (`ZuoraQueryReads`) that map the REST responses back to the existing SOAP query case classes, so the method signatures and return types are unchanged and no caller is affected.
- The five read methods now use the REST `SimpleClient`. Zuora returns some fields (e.g. credit card expiry) as JSON numbers where the SOAP path had strings, so the reader normalises them.
- These are core reads, so they still fail on a Zuora error like the old SOAP `queryOne`/`query` did, rather than degrading. This is not the best-effort side-preview from #1259.

Validated against real CODE data: all five methods return the same values as before.

### trello card/screenshot/json/related PRs etc

Asana: Zuora Migrate remaining SOAP calls to REST API. Follows #1259 and #1260.
