### PR TITLE
replace SOAP payment method writes with Zuora REST equivalents

### DIFF
--- a/membership-attribute-service/app/components/TouchpointBackends.scala
+++ b/membership-attribute-service/app/components/TouchpointBackends.scala
@@ -10,7 +10,7 @@ import org.apache.pekko.actor.ActorSystem
 import services.salesforce.ContactRepository
 import services.stripe.{BasicStripeService, ChooseStripe}
 import services.zuora.rest.ZuoraRestService
-import services.{HealthCheckableService, SupporterProductDataService}
+import services.SupporterProductDataService
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -23,7 +23,7 @@ class TouchpointBackends(
     subscriptionServiceOverride: Option[SubscriptionService[Future]] = None,
     zuoraRestServiceOverride: Option[ZuoraRestService] = None,
     catalogServiceOverride: Option[Future[Catalog]] = None,
-    zuoraServiceOverride: Option[ZuoraSoapService with HealthCheckableService] = None,
+    zuoraServiceOverride: Option[ZuoraSoapService] = None,
     patronsStripeServiceOverride: Option[BasicStripeService] = None,
     chooseStripeOverride: Option[ChooseStripe] = None,
 )(implicit

--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -8,11 +8,10 @@ import com.gu.identity.play.IdentityPlayAuthService
 import com.gu.memsub.subsv2.Catalog
 import com.gu.memsub.subsv2.services.{CatalogService, FetchCatalog, SubscriptionService}
 import com.gu.monitoring.SafeLogger.LogPrefix
-import com.gu.monitoring.{SafeLogging, ZuoraMetrics}
+import com.gu.monitoring.SafeLogging
 import com.gu.okhttp.RequestRunners
 import com.gu.touchpoint.TouchpointBackendConfig
 import com.gu.zuora.rest.SimpleClient
-import com.gu.zuora.soap.Client
 import com.gu.zuora.{ZuoraSoapService, rest}
 import com.typesafe.config.Config
 import configuration.Stage
@@ -37,7 +36,6 @@ import software.amazon.awssdk.auth.credentials.{
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.dynamodb.{DynamoDbAsyncClient, DynamoDbAsyncClientBuilder}
 
-import java.util.concurrent.TimeUnit.SECONDS
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -50,7 +48,7 @@ class TouchpointComponents(
     subscriptionServiceOverride: Option[SubscriptionService[Future]] = None,
     zuoraRestServiceOverride: Option[ZuoraRestService] = None,
     catalogServiceOverride: Option[Future[Catalog]] = None,
-    zuoraServiceOverride: Option[ZuoraSoapService with HealthCheckableService] = None,
+    zuoraServiceOverride: Option[ZuoraSoapService] = None,
     patronsStripeServiceOverride: Option[BasicStripeService] = None,
     chooseStripeOverride: Option[ChooseStripe] = None,
 )(implicit
@@ -99,20 +97,8 @@ class TouchpointComponents(
   lazy val supporterProductDataService: SupporterProductDataService =
     supporterProductDataServiceOverride.getOrElse(dynamoSupporterProductDataService)
 
-  private val zuoraMetrics = new ZuoraMetrics(stage.value, configuration.ApplicationName.applicationName)
-
   lazy val zuoraSoapService = {
-    lazy val zuoraSoapClient =
-      new Client(
-        apiConfig = backendConfig.zuoraSoap,
-        httpClient = RequestRunners.configurableFutureRunner(timeout = Duration(30, SECONDS)),
-        metrics = zuoraMetrics,
-      )
-
-    lazy val simpleZuoraSoapService = new ZuoraSoapService(zuoraRestClient) with HealthCheckableService {
-      override def checkHealth: Boolean = zuoraSoapClient.isReady
-    }
-
+    lazy val simpleZuoraSoapService = new ZuoraSoapService(zuoraRestClient)
     zuoraServiceOverride.getOrElse(simpleZuoraSoapService)
   }
 

--- a/membership-attribute-service/app/components/TouchpointComponents.scala
+++ b/membership-attribute-service/app/components/TouchpointComponents.scala
@@ -109,7 +109,7 @@ class TouchpointComponents(
         metrics = zuoraMetrics,
       )
 
-    lazy val simpleZuoraSoapService = new ZuoraSoapService(zuoraSoapClient, zuoraRestClient) with HealthCheckableService {
+    lazy val simpleZuoraSoapService = new ZuoraSoapService(zuoraRestClient) with HealthCheckableService {
       override def checkHealth: Boolean = zuoraSoapClient.isReady
     }
 

--- a/membership-attribute-service/app/controllers/HealthCheckController.scala
+++ b/membership-attribute-service/app/controllers/HealthCheckController.scala
@@ -21,10 +21,8 @@ class HealthCheckController(touchPointBackends: TouchpointBackends, override val
     with SafeLogging {
 
   val touchpointComponents = touchPointBackends.normal
-  // behaviourService, Stripe and all Zuora services are not critical
   private lazy val services: Set[HealthCheckableService] = Set(
     touchpointComponents.salesforceService,
-    touchpointComponents.zuoraSoapService,
   )
 
   private lazy val tests = services.map(service => new BoolTest(service.serviceName, () => service.checkHealth))

--- a/membership-attribute-service/app/wiring/AppLoader.scala
+++ b/membership-attribute-service/app/wiring/AppLoader.scala
@@ -65,7 +65,7 @@ class MyComponents(context: Context)
   lazy val subscriptionServiceOverride: Option[SubscriptionService[Future]] = None
   lazy val zuoraRestServiceOverride: Option[ZuoraRestService] = None
   lazy val catalogServiceOverride: Option[Future[Catalog]] = None
-  lazy val zuoraSoapServiceOverride: Option[ZuoraSoapService with HealthCheckableService] = None
+  lazy val zuoraSoapServiceOverride: Option[ZuoraSoapService] = None
   lazy val patronsStripeServiceOverride: Option[BasicStripeService] = None
   lazy val chooseStripeOverride: Option[ChooseStripe] = None
 

--- a/membership-attribute-service/test/acceptance/AccountControllerAcceptanceTest.scala
+++ b/membership-attribute-service/test/acceptance/AccountControllerAcceptanceTest.scala
@@ -27,7 +27,7 @@ import services.salesforce.ContactRepository
 import services.stripe.BasicStripeService
 import services.zuora.rest.ZuoraRestService
 import services.zuora.rest.ZuoraRestService.GiftSubscriptionsFromIdentityIdRecord
-import services.{ContributionsStoreDatabaseService, HealthCheckableService, SupporterProductDataService}
+import services.{ContributionsStoreDatabaseService, SupporterProductDataService}
 import utils.SimpleEitherT
 import wiring.MyComponents
 
@@ -39,7 +39,7 @@ class AccountControllerAcceptanceTest extends AcceptanceTest {
   var subscriptionServiceMock: SubscriptionService[Future] = _
   var zuoraRestServiceMock: ZuoraRestService = _
   var catalogServiceMock: Catalog = _
-  var zuoraSoapServiceMock: ZuoraSoapService with HealthCheckableService = _
+  var zuoraSoapServiceMock: ZuoraSoapService = _
   var supporterProductDataServiceMock: SupporterProductDataService = _
   var databaseServiceMock: ContributionsStoreDatabaseService = _
   var patronsStripeServiceMock: BasicStripeService = _
@@ -50,7 +50,7 @@ class AccountControllerAcceptanceTest extends AcceptanceTest {
     subscriptionServiceMock = mock[SubscriptionService[Future]]
     zuoraRestServiceMock = mock[ZuoraRestService]
     catalogServiceMock = catalog
-    zuoraSoapServiceMock = mock[ZuoraSoapService with HealthCheckableService]
+    zuoraSoapServiceMock = mock[ZuoraSoapService]
     supporterProductDataServiceMock = mock[SupporterProductDataService]
     databaseServiceMock = mock[ContributionsStoreDatabaseService]
     patronsStripeServiceMock = mock[BasicStripeService]

--- a/membership-attribute-service/test/acceptance/PaymentUpdateControllerAcceptanceTest.scala
+++ b/membership-attribute-service/test/acceptance/PaymentUpdateControllerAcceptanceTest.scala
@@ -25,7 +25,7 @@ import services.mail.{EmailData, SendEmail}
 import services.salesforce.ContactRepository
 import services.stripe.{BasicStripeService, ChooseStripe, StripePublicKey, StripeService}
 import services.zuora.rest.ZuoraRestService
-import services.{ContributionsStoreDatabaseService, HealthCheckableService, SupporterProductDataService}
+import services.{ContributionsStoreDatabaseService, SupporterProductDataService}
 import wiring.MyComponents
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -36,7 +36,7 @@ class PaymentUpdateControllerAcceptanceTest extends AcceptanceTest {
   var subscriptionServiceMock: SubscriptionService[Future] = _
   var zuoraRestServiceMock: ZuoraRestService = _
   var catalogServiceMock: Catalog = _
-  var zuoraSoapServiceMock: ZuoraSoapService with HealthCheckableService = _
+  var zuoraSoapServiceMock: ZuoraSoapService = _
   var supporterProductDataServiceMock: SupporterProductDataService = _
   var databaseServiceMock: ContributionsStoreDatabaseService = _
   var patronsStripeServiceMock: BasicStripeService = _
@@ -50,7 +50,7 @@ class PaymentUpdateControllerAcceptanceTest extends AcceptanceTest {
     subscriptionServiceMock = mock[SubscriptionService[Future]]
     zuoraRestServiceMock = mock[ZuoraRestService]
     catalogServiceMock = TestCatalog.catalog
-    zuoraSoapServiceMock = mock[ZuoraSoapService with HealthCheckableService]
+    zuoraSoapServiceMock = mock[ZuoraSoapService]
     supporterProductDataServiceMock = mock[SupporterProductDataService]
     databaseServiceMock = mock[ContributionsStoreDatabaseService]
     patronsStripeServiceMock = mock[BasicStripeService]

--- a/membership-common/src/main/scala/com/gu/zuora/ZuoraSoapService.scala
+++ b/membership-common/src/main/scala/com/gu/zuora/ZuoraSoapService.scala
@@ -41,9 +41,8 @@ class ZuoraSoapService(restClient: rest.SimpleClient[Future])(implicit ec: Execu
 
   import ZuoraSoapService._
 
-  /* These reads used to go through the SOAP query API; they now hit the equivalent Zuora REST endpoints (object/{type}/{id} and action/query),
-     mapping the responses back to the same case classes so callers are unchanged. getObject fails the Future if the object is missing or the call
-     errors, like the old queryOne; query returns the records (empty if none) and only fails on a REST error, like the old plural query. */
+  /* getObject fetches a single object via object/{type}/{id} and fails the Future if it is missing or the call errors; query runs a ZOQL query via
+     action/query and returns the records (empty if none), failing only on a REST error. */
   private def getObject[A: Reads](url: String)(implicit logPrefix: LogPrefix): Future[A] =
     restClient.get[A](url).map(_.valueOr(error => throw QueryError(s"Zuora REST get '$url' failed: $error")))
 
@@ -61,9 +60,8 @@ class ZuoraSoapService(restClient: rest.SimpleClient[Future])(implicit ec: Execu
   def getContact(contactId: String)(implicit logPrefix: LogPrefix): Future[SoapQueries.Contact] =
     getObject[SoapQueries.Contact](s"object/contact/$contactId")
 
-  /* These payment-method writes used to go through the SOAP create/update API; they now hit the equivalent Zuora REST endpoints: the account payment
-     fields via PUT accounts/{id}, and the payment method itself via POST object/payment-method (which takes the same zObject fields the SOAP create
-     used). A REST error or an unsuccessful response fails the Future, matching the old behaviour where a non-success SOAP response raised. */
+  /* The account payment fields are updated via PUT accounts/{id}, and the payment method is created via POST object/payment-method. A REST error or an
+     unsuccessful response fails the Future. */
   private def updateAccountPayment(
       accountId: AccountId,
       defaultPaymentMethodId: Option[String],

--- a/membership-common/src/main/scala/com/gu/zuora/ZuoraSoapService.scala
+++ b/membership-common/src/main/scala/com/gu/zuora/ZuoraSoapService.scala
@@ -9,14 +9,14 @@ import com.gu.salesforce.ContactId
 import com.gu.stripe.Stripe
 import com.gu.zuora.api.{PaymentGateway}
 import com.gu.zuora.soap._
-import com.gu.zuora.soap.models.Commands.CreatePaymentMethod
+import com.gu.zuora.soap.models.Commands.{CreatePaymentMethod, CreditCardReferenceTransaction}
 import com.gu.zuora.soap.models.Results.UpdateResult
 import com.gu.zuora.soap.models.errors._
 import com.gu.zuora.soap.models.{PaymentSummary, Queries => SoapQueries}
 import com.gu.zuora.rest.ZuoraQueryReads._
 import com.gu.zuora.rest.ZuoraPaymentWrites._
 import com.gu.zuora.rest.{ZuoraResponse, zuoraResponseReads}
-import play.api.libs.json.{JsObject, Reads}
+import play.api.libs.json.Reads
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -79,11 +79,14 @@ class ZuoraSoapService(restClient: rest.SimpleClient[Future])(implicit ec: Execu
         else throw QueryError(s"Zuora account update for ${accountId.get} was unsuccessful: ${response.error.getOrElse("")}")
       }
 
-  private def createObjectPaymentMethod(zObject: JsObject)(implicit logPrefix: LogPrefix): Future[String] =
+  private def createObjectPaymentMethod(request: CreatePaymentMethodObject)(implicit logPrefix: LogPrefix): Future[String] =
     restClient
-      .post[JsObject, ObjectCreateResponse]("object/payment-method", zObject)
+      .post[CreatePaymentMethodObject, ObjectCreateResponse]("object/payment-method", request)
       .map(_.valueOr(error => throw QueryError(s"Zuora REST create payment method failed: $error")))
-      .map(response => if (response.success) response.id else throw QueryError("Zuora create payment method was unsuccessful"))
+      .map { response =>
+        if (response.success) response.id.getOrElse(throw QueryError("Zuora create payment method succeeded but returned no Id"))
+        else throw QueryError("Zuora create payment method was unsuccessful")
+      }
 
   private def setDefaultPaymentMethod(accountId: AccountId, paymentMethodId: String, paymentGateway: PaymentGateway)(implicit
       logPrefix: LogPrefix,
@@ -100,7 +103,7 @@ class ZuoraSoapService(restClient: rest.SimpleClient[Future])(implicit ec: Execu
      so we cannot swap gateway and method atomically: clear the old default onto the new gateway, create the method, then set it default. */
   def createPaymentMethod(command: CreatePaymentMethod)(implicit logPrefix: LogPrefix): Future[UpdateResult] = for {
     _ <- setGatewayAndClearDefaultMethod(command.accountId, command.paymentGateway)
-    paymentMethodId <- createObjectPaymentMethod(paymentMethod(command.accountId.get, command.paymentMethod))
+    paymentMethodId <- createObjectPaymentMethod(CreatePaymentMethodObject(command.accountId, command.paymentMethod))
     result <- setDefaultPaymentMethod(command.accountId, paymentMethodId, command.paymentGateway)
   } yield result
 
@@ -110,20 +113,18 @@ class ZuoraSoapService(restClient: rest.SimpleClient[Future])(implicit ec: Execu
       paymentGateway: PaymentGateway,
   )(implicit logPrefix: LogPrefix): Future[UpdateResult] = {
     val card = stripeCustomer.card
+    val paymentMethod = CreditCardReferenceTransaction(
+      cardId = card.id,
+      customerId = stripeCustomer.id,
+      last4 = card.last4,
+      cardCountry = CountryGroup.countryByCode(card.country),
+      expirationMonth = card.exp_month,
+      expirationYear = card.exp_year,
+      cardType = card.`type`,
+    )
     for {
       _ <- setGatewayAndClearDefaultMethod(accountId, paymentGateway)
-      paymentMethodId <- createObjectPaymentMethod(
-        creditCardReference(
-          accountId = accountId.get,
-          cardId = card.id,
-          customerId = stripeCustomer.id,
-          last4 = card.last4,
-          cardCountryAlpha2 = CountryGroup.countryByCode(card.country).map(_.alpha2),
-          expirationMonth = card.exp_month,
-          expirationYear = card.exp_year,
-          cardType = card.`type`,
-        ),
-      )
+      paymentMethodId <- createObjectPaymentMethod(CreatePaymentMethodObject(accountId, paymentMethod))
       result <- setDefaultPaymentMethod(accountId, paymentMethodId, paymentGateway)
     } yield result
   }

--- a/membership-common/src/main/scala/com/gu/zuora/ZuoraSoapService.scala
+++ b/membership-common/src/main/scala/com/gu/zuora/ZuoraSoapService.scala
@@ -8,17 +8,15 @@ import com.gu.monitoring.SafeLogging
 import com.gu.salesforce.ContactId
 import com.gu.stripe.Stripe
 import com.gu.zuora.api.{PaymentGateway}
-import com.gu.zuora.soap.Readers._
 import com.gu.zuora.soap._
-import com.gu.zuora.soap.actions.{Action, XmlWriterAction}
-import com.gu.zuora.soap.actions.Actions._
 import com.gu.zuora.soap.models.Commands.CreatePaymentMethod
-import com.gu.zuora.soap.models.Results.{CreateResult, UpdateResult}
+import com.gu.zuora.soap.models.Results.UpdateResult
 import com.gu.zuora.soap.models.errors._
 import com.gu.zuora.soap.models.{PaymentSummary, Queries => SoapQueries}
-import com.gu.zuora.soap.writers.Command.createPaymentMethodWrites
 import com.gu.zuora.rest.ZuoraQueryReads._
-import play.api.libs.json.Reads
+import com.gu.zuora.rest.ZuoraPaymentWrites._
+import com.gu.zuora.rest.{ZuoraResponse, zuoraResponseReads}
+import play.api.libs.json.{JsObject, Reads}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -39,9 +37,7 @@ trait SoapClient[M[_]] {
   def getAccountIds(contactId: ContactId)(implicit logPrefix: LogPrefix): M[List[AccountId]]
 }
 
-class ZuoraSoapService(soapClient: soap.Client, restClient: rest.SimpleClient[Future])(implicit ec: ExecutionContext)
-    extends SoapClient[Future]
-    with SafeLogging {
+class ZuoraSoapService(restClient: rest.SimpleClient[Future])(implicit ec: ExecutionContext) extends SoapClient[Future] with SafeLogging {
 
   import ZuoraSoapService._
 
@@ -65,41 +61,49 @@ class ZuoraSoapService(soapClient: soap.Client, restClient: rest.SimpleClient[Fu
   def getContact(contactId: String)(implicit logPrefix: LogPrefix): Future[SoapQueries.Contact] =
     getObject[SoapQueries.Contact](s"object/contact/$contactId")
 
-  private def setDefaultPaymentMethod(
+  /* These payment-method writes used to go through the SOAP create/update API; they now hit the equivalent Zuora REST endpoints: the account payment
+     fields via PUT accounts/{id}, and the payment method itself via POST object/payment-method (which takes the same zObject fields the SOAP create
+     used). A REST error or an unsuccessful response fails the Future, matching the old behaviour where a non-success SOAP response raised. */
+  private def updateAccountPayment(
       accountId: AccountId,
-      paymentMethodId: String,
+      defaultPaymentMethodId: Option[String],
       paymentGateway: PaymentGateway,
-  )(implicit logPrefix: LogPrefix) = {
-    soapClient.authenticatedRequest(
-      action = UpdateAccountPayment(
-        accountId = accountId.get,
-        defaultPaymentMethodId = SetTo(paymentMethodId),
-        paymentGatewayName = paymentGateway.gatewayName,
-        autoPay = Some(true),
-      ),
-    )
-  }
+      autoPay: Boolean,
+  )(implicit logPrefix: LogPrefix): Future[UpdateResult] =
+    restClient
+      .put[AccountPaymentUpdate, ZuoraResponse](
+        s"accounts/${accountId.get}",
+        AccountPaymentUpdate(defaultPaymentMethodId, paymentGateway.gatewayName, autoPay),
+      )
+      .map(_.valueOr(error => throw QueryError(s"Zuora REST account update for ${accountId.get} failed: $error")))
+      .map { response =>
+        if (response.success) UpdateResult(accountId.get)
+        else throw QueryError(s"Zuora account update for ${accountId.get} was unsuccessful: ${response.error.getOrElse("")}")
+      }
 
-  // When setting the payment gateway in the account we have to clear the default payment method to avoid conflicts
-  private def setGatewayAndClearDefaultMethod(accountId: AccountId, paymentGateway: PaymentGateway)(implicit logPrefix: LogPrefix) = {
-    soapClient.authenticatedRequest(
-      action = UpdateAccountPayment(
-        accountId = accountId.get,
-        defaultPaymentMethodId = Clear,
-        paymentGatewayName = paymentGateway.gatewayName,
-        autoPay = Some(false),
-      ),
-    )
-  }
+  private def createObjectPaymentMethod(zObject: JsObject)(implicit logPrefix: LogPrefix): Future[String] =
+    restClient
+      .post[JsObject, ObjectCreateResponse]("object/payment-method", zObject)
+      .map(_.valueOr(error => throw QueryError(s"Zuora REST create payment method failed: $error")))
+      .map(response => if (response.success) response.id else throw QueryError("Zuora create payment method was unsuccessful"))
 
-  // Creates a payment method in zuora and sets it as default in the specified account.To satisfy zuora validations this has to be done in three steps
+  private def setDefaultPaymentMethod(accountId: AccountId, paymentMethodId: String, paymentGateway: PaymentGateway)(implicit
+      logPrefix: LogPrefix,
+  ): Future[UpdateResult] =
+    updateAccountPayment(accountId, defaultPaymentMethodId = Some(paymentMethodId), paymentGateway, autoPay = true)
+
+  // Clear the default payment method before switching the gateway: Zuora requires the account gateway to match its default method's gateway.
+  private def setGatewayAndClearDefaultMethod(accountId: AccountId, paymentGateway: PaymentGateway)(implicit
+      logPrefix: LogPrefix,
+  ): Future[UpdateResult] =
+    updateAccountPayment(accountId, defaultPaymentMethodId = None, paymentGateway, autoPay = false)
+
+  /* Creates a payment method and sets it as default. Still three steps because Zuora validates that the account's gateway matches its default method's,
+     so we cannot swap gateway and method atomically: clear the old default onto the new gateway, create the method, then set it default. */
   def createPaymentMethod(command: CreatePaymentMethod)(implicit logPrefix: LogPrefix): Future[UpdateResult] = for {
-    _ <- setGatewayAndClearDefaultMethod(
-      command.accountId,
-      command.paymentGateway,
-    ) // We need to set gateway correctly because it must match with the payment method we'll create below
-    createMethodResult <- soapClient.authenticatedRequest[CreateResult](new XmlWriterAction(command)(createPaymentMethodWrites))
-    result <- setDefaultPaymentMethod(command.accountId, createMethodResult.id, command.paymentGateway)
+    _ <- setGatewayAndClearDefaultMethod(command.accountId, command.paymentGateway)
+    paymentMethodId <- createObjectPaymentMethod(paymentMethod(command.accountId.get, command.paymentMethod))
+    result <- setDefaultPaymentMethod(command.accountId, paymentMethodId, command.paymentGateway)
   } yield result
 
   def createCreditCardPaymentMethod(
@@ -109,23 +113,20 @@ class ZuoraSoapService(soapClient: soap.Client, restClient: rest.SimpleClient[Fu
   )(implicit logPrefix: LogPrefix): Future[UpdateResult] = {
     val card = stripeCustomer.card
     for {
-      r <- setGatewayAndClearDefaultMethod(
-        accountId,
-        paymentGateway,
-      ) // We need to set gateway correctly because it must match with the payment method
-      paymentMethod <- soapClient.authenticatedRequest(
-        CreateCreditCardReferencePaymentMethod(
+      _ <- setGatewayAndClearDefaultMethod(accountId, paymentGateway)
+      paymentMethodId <- createObjectPaymentMethod(
+        creditCardReference(
           accountId = accountId.get,
           cardId = card.id,
           customerId = stripeCustomer.id,
           last4 = card.last4,
-          cardCountry = CountryGroup.countryByCode(card.country),
+          cardCountryAlpha2 = CountryGroup.countryByCode(card.country).map(_.alpha2),
           expirationMonth = card.exp_month,
           expirationYear = card.exp_year,
           cardType = card.`type`,
         ),
       )
-      result <- setDefaultPaymentMethod(accountId, paymentMethod.id, paymentGateway)
+      result <- setDefaultPaymentMethod(accountId, paymentMethodId, paymentGateway)
     } yield result
   }
 

--- a/membership-common/src/main/scala/com/gu/zuora/ZuoraSoapService.scala
+++ b/membership-common/src/main/scala/com/gu/zuora/ZuoraSoapService.scala
@@ -81,11 +81,11 @@ class ZuoraSoapService(restClient: rest.SimpleClient[Future])(implicit ec: Execu
 
   private def createObjectPaymentMethod(request: CreatePaymentMethodObject)(implicit logPrefix: LogPrefix): Future[String] =
     restClient
-      .post[CreatePaymentMethodObject, ObjectCreateResponse]("object/payment-method", request)
+      .post[CreatePaymentMethodObject, ObjectCreateResult]("object/payment-method", request)
       .map(_.valueOr(error => throw QueryError(s"Zuora REST create payment method failed: $error")))
-      .map { response =>
-        if (response.success) response.id.getOrElse(throw QueryError("Zuora create payment method succeeded but returned no Id"))
-        else throw QueryError("Zuora create payment method was unsuccessful")
+      .map {
+        case ObjectCreateResult.Created(id) => id
+        case ObjectCreateResult.Failed(reason) => throw QueryError(s"Zuora create payment method was unsuccessful: $reason")
       }
 
   private def setDefaultPaymentMethod(accountId: AccountId, paymentMethodId: String, paymentGateway: PaymentGateway)(implicit

--- a/membership-common/src/main/scala/com/gu/zuora/rest/ZuoraPaymentWrites.scala
+++ b/membership-common/src/main/scala/com/gu/zuora/rest/ZuoraPaymentWrites.scala
@@ -25,7 +25,7 @@ object ZuoraPaymentWrites {
   }
 
   /** POST /v1/object/payment-method returns {"Id": "...", "Success": true}. See
-    * https://developer.zuora.com/api-references/api/operation/Object_POSTPaymentMethod
+    * https://developer.zuora.com/api-references/older-api/operation/Object_POSTPaymentMethod
     */
   case class ObjectCreateResponse(id: String, success: Boolean)
   implicit val objectCreateResponseReads: Reads[ObjectCreateResponse] =

--- a/membership-common/src/main/scala/com/gu/zuora/rest/ZuoraPaymentWrites.scala
+++ b/membership-common/src/main/scala/com/gu/zuora/rest/ZuoraPaymentWrites.scala
@@ -1,0 +1,99 @@
+package com.gu.zuora.rest
+
+import com.gu.zuora.soap.models.Commands
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+
+/** JSON for the Zuora payment-method WRITE operations that ZuoraSoapService used to do over SOAP: account payment updates via PUT /v1/accounts/{id},
+  * and payment-method creation via POST /v1/object/payment-method. The object API takes the same PascalCase zObject fields the SOAP create used, so
+  * the field mapping mirrors com.gu.zuora.soap.writers.Command and the CreateCreditCardReferencePaymentMethod action.
+  */
+object ZuoraPaymentWrites {
+
+  implicit val jsObjectWrites: Writes[JsObject] = Writes(identity)
+
+  /** PUT /v1/accounts/{id}. A None defaultPaymentMethodId is written as an explicit JSON null, which Zuora treats as "clear the default" — the REST
+    * equivalent of the SOAP fieldsToNull. See https://developer.zuora.com/api-references/api/operation/PUT_Account
+    */
+  case class AccountPaymentUpdate(defaultPaymentMethodId: Option[String], paymentGateway: String, autoPay: Boolean)
+  implicit val accountPaymentUpdateWrites: Writes[AccountPaymentUpdate] = Writes { update =>
+    Json.obj(
+      "defaultPaymentMethodId" -> update.defaultPaymentMethodId.fold[JsValue](JsNull)(JsString(_)),
+      "paymentGateway" -> update.paymentGateway,
+      "autoPay" -> update.autoPay,
+    )
+  }
+
+  /** POST /v1/object/payment-method returns {"Id": "...", "Success": true}. See
+    * https://developer.zuora.com/api-references/api/operation/Object_POSTPaymentMethod
+    */
+  case class ObjectCreateResponse(id: String, success: Boolean)
+  implicit val objectCreateResponseReads: Reads[ObjectCreateResponse] =
+    ((__ \ "Id").read[String] and (__ \ "Success").read[Boolean])(ObjectCreateResponse.apply _)
+
+  // Zuora only accepts a fixed set of CreditCardType values; anything else is omitted (matches the old SOAP action).
+  private def normaliseCardType(cardType: String): Option[String] = cardType.toLowerCase.replaceAll(" ", "") match {
+    case "mastercard" => Some("MasterCard")
+    case "visa" => Some("Visa")
+    case "amex" | "americanexpress" => Some("AmericanExpress")
+    case "discover" => Some("Discover")
+    case _ => None
+  }
+
+  def creditCardReference(
+      accountId: String,
+      cardId: String,
+      customerId: String,
+      last4: String,
+      cardCountryAlpha2: Option[String],
+      expirationMonth: Int,
+      expirationYear: Int,
+      cardType: String,
+  ): JsObject = {
+    val base = Json.obj(
+      "AccountId" -> accountId,
+      "Type" -> "CreditCardReferenceTransaction",
+      "TokenId" -> cardId,
+      "SecondTokenId" -> customerId,
+      "CreditCardNumber" -> last4,
+      "CreditCardExpirationMonth" -> expirationMonth,
+      "CreditCardExpirationYear" -> expirationYear,
+    )
+    val withCountry = cardCountryAlpha2.fold(base)(country => base + ("CreditCardCountry" -> JsString(country)))
+    normaliseCardType(cardType).fold(withCountry)(mapped => withCountry + ("CreditCardType" -> JsString(mapped)))
+  }
+
+  def paymentMethod(accountId: String, paymentMethod: Commands.PaymentMethod): JsObject = paymentMethod match {
+    case card: Commands.CreditCardReferenceTransaction =>
+      creditCardReference(
+        accountId,
+        card.cardId,
+        card.customerId,
+        card.last4,
+        card.cardCountry.map(_.alpha2),
+        card.expirationMonth,
+        card.expirationYear,
+        card.cardType,
+      )
+    case bankTransfer: Commands.BankTransfer =>
+      Json.obj(
+        "AccountId" -> accountId,
+        "Type" -> "BankTransfer",
+        "BankTransferType" -> "DirectDebitUK",
+        "Country" -> bankTransfer.countryCode,
+        "BankTransferAccountName" -> bankTransfer.accountHolderName,
+        "BankTransferAccountNumber" -> bankTransfer.accountNumber,
+        "BankCode" -> bankTransfer.sortCode,
+        "FirstName" -> bankTransfer.firstName,
+        "LastName" -> bankTransfer.lastName,
+      )
+    case payPal: Commands.PayPalReferenceTransaction =>
+      Json.obj(
+        "AccountId" -> accountId,
+        "Type" -> "PayPal",
+        "PaypalType" -> "ExpressCheckout",
+        "PaypalBaid" -> payPal.baId,
+        "PaypalEmail" -> payPal.email,
+      )
+  }
+}

--- a/membership-common/src/main/scala/com/gu/zuora/rest/ZuoraPaymentWrites.scala
+++ b/membership-common/src/main/scala/com/gu/zuora/rest/ZuoraPaymentWrites.scala
@@ -1,7 +1,8 @@
 package com.gu.zuora.rest
 
+import com.gu.memsub.Subscription.AccountId
 import com.gu.zuora.soap.models.Commands
-import play.api.libs.functional.syntax._
+import play.api.libs.json.JsonNaming.PascalCase
 import play.api.libs.json._
 
 /** JSON for the Zuora payment-method write operations: account payment updates via PUT /v1/accounts/{id}, and payment-method creation via POST
@@ -9,12 +10,14 @@ import play.api.libs.json._
   */
 object ZuoraPaymentWrites {
 
-  implicit val jsObjectWrites: Writes[JsObject] = Writes(identity)
+  // The Zuora object API names its fields in PascalCase (Id, Success, ...), so derived readers/writers use that naming.
+  implicit val jsonConfig: JsonConfiguration = JsonConfiguration(PascalCase)
 
   /** PUT /v1/accounts/{id}. A None defaultPaymentMethodId is written as an explicit JSON null, which Zuora treats as clearing the default. See
-    * https://developer.zuora.com/api-references/api/operation/PUT_Account
+    * https://developer.zuora.com/v1-api-reference/api/accounts/put_account
     */
   case class AccountPaymentUpdate(defaultPaymentMethodId: Option[String], paymentGateway: String, autoPay: Boolean)
+  // Hand-written rather than derived: a None must serialise to an explicit JSON null (to clear the default), whereas Json.writes would omit it.
   implicit val accountPaymentUpdateWrites: Writes[AccountPaymentUpdate] = Writes { update =>
     Json.obj(
       "defaultPaymentMethodId" -> update.defaultPaymentMethodId.fold[JsValue](JsNull)(JsString(_)),
@@ -23,60 +26,32 @@ object ZuoraPaymentWrites {
     )
   }
 
-  /** POST /v1/object/payment-method returns {"Id": "...", "Success": true}. See
+  /** POST /v1/object/payment-method returns {"Id": "...", "Success": true}. Id is absent on a failure response, hence optional. See
     * https://developer.zuora.com/api-references/older-api/operation/Object_POSTPaymentMethod
     */
-  case class ObjectCreateResponse(id: String, success: Boolean)
-  implicit val objectCreateResponseReads: Reads[ObjectCreateResponse] =
-    ((__ \ "Id").read[String] and (__ \ "Success").read[Boolean])(ObjectCreateResponse.apply _)
+  case class ObjectCreateResponse(id: Option[String], success: Boolean)
+  implicit val objectCreateResponseReads: Reads[ObjectCreateResponse] = Json.reads[ObjectCreateResponse]
 
-  // Zuora only accepts a fixed set of CreditCardType values; anything else is omitted (matches the old SOAP action).
-  private def normaliseCardType(cardType: String): Option[String] = cardType.toLowerCase.replaceAll(" ", "") match {
-    case "mastercard" => Some("MasterCard")
-    case "visa" => Some("Visa")
-    case "amex" | "americanexpress" => Some("AmericanExpress")
-    case "discover" => Some("Discover")
-    case _ => None
+  /** The zObject payload for POST /v1/object/payment-method: the target account plus the payment-method business object. */
+  case class CreatePaymentMethodObject(accountId: AccountId, paymentMethod: Commands.PaymentMethod)
+  implicit val createPaymentMethodObjectWrites: Writes[CreatePaymentMethodObject] = Writes { request =>
+    Json.obj("AccountId" -> request.accountId.get) ++ paymentMethodFields(request.paymentMethod)
   }
 
-  def creditCardReference(
-      accountId: String,
-      cardId: String,
-      customerId: String,
-      last4: String,
-      cardCountryAlpha2: Option[String],
-      expirationMonth: Int,
-      expirationYear: Int,
-      cardType: String,
-  ): JsObject = {
-    val base = Json.obj(
-      "AccountId" -> accountId,
-      "Type" -> "CreditCardReferenceTransaction",
-      "TokenId" -> cardId,
-      "SecondTokenId" -> customerId,
-      "CreditCardNumber" -> last4,
-      "CreditCardExpirationMonth" -> expirationMonth,
-      "CreditCardExpirationYear" -> expirationYear,
-    )
-    val withCountry = cardCountryAlpha2.fold(base)(country => base + ("CreditCardCountry" -> JsString(country)))
-    normaliseCardType(cardType).fold(withCountry)(mapped => withCountry + ("CreditCardType" -> JsString(mapped)))
-  }
-
-  def paymentMethod(accountId: String, paymentMethod: Commands.PaymentMethod): JsObject = paymentMethod match {
+  private def paymentMethodFields(paymentMethod: Commands.PaymentMethod): JsObject = paymentMethod match {
     case card: Commands.CreditCardReferenceTransaction =>
-      creditCardReference(
-        accountId,
-        card.cardId,
-        card.customerId,
-        card.last4,
-        card.cardCountry.map(_.alpha2),
-        card.expirationMonth,
-        card.expirationYear,
-        card.cardType,
+      val base = Json.obj(
+        "Type" -> "CreditCardReferenceTransaction",
+        "TokenId" -> card.cardId,
+        "SecondTokenId" -> card.customerId,
+        "CreditCardNumber" -> card.last4,
+        "CreditCardExpirationMonth" -> card.expirationMonth,
+        "CreditCardExpirationYear" -> card.expirationYear,
+        "CreditCardType" -> normaliseCardType(card.cardType),
       )
+      card.cardCountry.fold(base)(country => base + ("CreditCardCountry" -> JsString(country.alpha2)))
     case bankTransfer: Commands.BankTransfer =>
       Json.obj(
-        "AccountId" -> accountId,
         "Type" -> "BankTransfer",
         "BankTransferType" -> "DirectDebitUK",
         "Country" -> bankTransfer.countryCode,
@@ -88,11 +63,19 @@ object ZuoraPaymentWrites {
       )
     case payPal: Commands.PayPalReferenceTransaction =>
       Json.obj(
-        "AccountId" -> accountId,
         "Type" -> "PayPal",
         "PaypalType" -> "ExpressCheckout",
         "PaypalBaid" -> payPal.baId,
         "PaypalEmail" -> payPal.email,
       )
+  }
+
+  // Normalise the common brands to Zuora's CreditCardType casing; anything else is passed through with spaces removed.
+  private def normaliseCardType(cardType: String): String = cardType.toLowerCase.replaceAll(" ", "") match {
+    case "mastercard" => "MasterCard"
+    case "visa" => "Visa"
+    case "amex" | "americanexpress" => "AmericanExpress"
+    case "discover" => "Discover"
+    case _ => cardType.replaceAll(" ", "")
   }
 }

--- a/membership-common/src/main/scala/com/gu/zuora/rest/ZuoraPaymentWrites.scala
+++ b/membership-common/src/main/scala/com/gu/zuora/rest/ZuoraPaymentWrites.scala
@@ -2,16 +2,12 @@ package com.gu.zuora.rest
 
 import com.gu.memsub.Subscription.AccountId
 import com.gu.zuora.soap.models.Commands
-import play.api.libs.json.JsonNaming.PascalCase
 import play.api.libs.json._
 
 /** JSON for the Zuora payment-method write operations: account payment updates via PUT /v1/accounts/{id}, and payment-method creation via POST
   * /v1/object/payment-method (which takes the PascalCase zObject fields of the payment method).
   */
 object ZuoraPaymentWrites {
-
-  // The Zuora object API names its fields in PascalCase (Id, Success, ...), so derived readers/writers use that naming.
-  implicit val jsonConfig: JsonConfiguration = JsonConfiguration(PascalCase)
 
   /** PUT /v1/accounts/{id}. A None defaultPaymentMethodId is written as an explicit JSON null, which Zuora treats as clearing the default. See
     * https://developer.zuora.com/v1-api-reference/api/accounts/put_account
@@ -26,11 +22,21 @@ object ZuoraPaymentWrites {
     )
   }
 
-  /** POST /v1/object/payment-method returns {"Id": "...", "Success": true}. Id is absent on a failure response, hence optional. See
+  /** The outcome of POST /v1/object/payment-method: {"Success": true, "Id": "..."} on success, {"Success": false, ...} on failure. Modelled as a
+    * success/failure result so the Id is required exactly when the create succeeded (no Option to unwrap downstream). See
     * https://developer.zuora.com/api-references/older-api/operation/Object_POSTPaymentMethod
     */
-  case class ObjectCreateResponse(id: Option[String], success: Boolean)
-  implicit val objectCreateResponseReads: Reads[ObjectCreateResponse] = Json.reads[ObjectCreateResponse]
+  sealed trait ObjectCreateResult
+  object ObjectCreateResult {
+    case class Created(id: String) extends ObjectCreateResult
+    case class Failed(reason: String) extends ObjectCreateResult
+
+    implicit val reads: Reads[ObjectCreateResult] = (json: JsValue) =>
+      (json \ "Success").validate[Boolean].flatMap {
+        case true => (json \ "Id").validate[String].map(Created.apply)
+        case false => JsSuccess(Failed((json \ "Errors").asOpt[JsValue].map(_.toString).getOrElse("no error detail")))
+      }
+  }
 
   /** The zObject payload for POST /v1/object/payment-method: the target account plus the payment-method business object. */
   case class CreatePaymentMethodObject(accountId: AccountId, paymentMethod: Commands.PaymentMethod)

--- a/membership-common/src/main/scala/com/gu/zuora/rest/ZuoraPaymentWrites.scala
+++ b/membership-common/src/main/scala/com/gu/zuora/rest/ZuoraPaymentWrites.scala
@@ -4,16 +4,15 @@ import com.gu.zuora.soap.models.Commands
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
-/** JSON for the Zuora payment-method WRITE operations that ZuoraSoapService used to do over SOAP: account payment updates via PUT /v1/accounts/{id},
-  * and payment-method creation via POST /v1/object/payment-method. The object API takes the same PascalCase zObject fields the SOAP create used, so
-  * the field mapping mirrors com.gu.zuora.soap.writers.Command and the CreateCreditCardReferencePaymentMethod action.
+/** JSON for the Zuora payment-method write operations: account payment updates via PUT /v1/accounts/{id}, and payment-method creation via POST
+  * /v1/object/payment-method (which takes the PascalCase zObject fields of the payment method).
   */
 object ZuoraPaymentWrites {
 
   implicit val jsObjectWrites: Writes[JsObject] = Writes(identity)
 
-  /** PUT /v1/accounts/{id}. A None defaultPaymentMethodId is written as an explicit JSON null, which Zuora treats as "clear the default" — the REST
-    * equivalent of the SOAP fieldsToNull. See https://developer.zuora.com/api-references/api/operation/PUT_Account
+  /** PUT /v1/accounts/{id}. A None defaultPaymentMethodId is written as an explicit JSON null, which Zuora treats as clearing the default. See
+    * https://developer.zuora.com/api-references/api/operation/PUT_Account
     */
   case class AccountPaymentUpdate(defaultPaymentMethodId: Option[String], paymentGateway: String, autoPay: Boolean)
   implicit val accountPaymentUpdateWrites: Writes[AccountPaymentUpdate] = Writes { update =>

--- a/membership-common/src/test/scala/com/gu/zuora/rest/ZuoraPaymentWritesTest.scala
+++ b/membership-common/src/test/scala/com/gu/zuora/rest/ZuoraPaymentWritesTest.scala
@@ -1,5 +1,7 @@
 package com.gu.zuora.rest
 
+import com.gu.i18n.Country
+import com.gu.memsub.Subscription.AccountId
 import com.gu.zuora.rest.ZuoraPaymentWrites._
 import com.gu.zuora.soap.models.Commands
 import org.specs2.mutable.Specification
@@ -21,21 +23,28 @@ class ZuoraPaymentWritesTest extends Specification {
     }
   }
 
-  "paymentMethod object for a bank transfer" should {
+  "CreatePaymentMethodObject writes for a bank transfer" should {
     "map to the Zuora Direct Debit zObject fields" in {
-      val json = paymentMethod("acc-1", Commands.BankTransfer("Jane Doe", "55779911", "200000", "Jane", "Doe", "GB"))
+      val json =
+        Json.toJson(CreatePaymentMethodObject(AccountId("acc-1"), Commands.BankTransfer("Jane Doe", "55779911", "200000", "Jane", "Doe", "GB")))
+      (json \ "AccountId").as[String] must_== "acc-1"
       (json \ "Type").as[String] must_== "BankTransfer"
       (json \ "BankTransferType").as[String] must_== "DirectDebitUK"
       (json \ "BankTransferAccountName").as[String] must_== "Jane Doe"
       (json \ "BankTransferAccountNumber").as[String] must_== "55779911"
       (json \ "BankCode").as[String] must_== "200000"
-      (json \ "AccountId").as[String] must_== "acc-1"
     }
   }
 
-  "creditCardReference object" should {
-    "map the card reference fields and normalise the card type" in {
-      val json = creditCardReference("acc-1", "pm_token", "cus_token", "4242", Some("GB"), 12, 2030, "visa")
+  "CreatePaymentMethodObject writes for a credit card reference" should {
+    "map the card reference fields and normalise a common card type" in {
+      val json = Json.toJson(
+        CreatePaymentMethodObject(
+          AccountId("acc-1"),
+          Commands.CreditCardReferenceTransaction("pm_token", "cus_token", "4242", Some(Country.UK), 12, 2030, "visa"),
+        ),
+      )
+      (json \ "AccountId").as[String] must_== "acc-1"
       (json \ "Type").as[String] must_== "CreditCardReferenceTransaction"
       (json \ "TokenId").as[String] must_== "pm_token"
       (json \ "SecondTokenId").as[String] must_== "cus_token"
@@ -43,10 +52,25 @@ class ZuoraPaymentWritesTest extends Specification {
       (json \ "CreditCardCountry").as[String] must_== "GB"
       (json \ "CreditCardType").as[String] must_== "Visa"
     }
-    "omit the card type and country when absent or unrecognised" in {
-      val json = creditCardReference("acc-1", "t", "c", "4242", None, 1, 2030, "some-unknown-scheme")
-      (json \ "CreditCardType").toOption must beNone
+    "pass an unrecognised card type through with spaces removed, and omit the country when absent" in {
+      val json = Json.toJson(
+        CreatePaymentMethodObject(AccountId("acc-1"), Commands.CreditCardReferenceTransaction("t", "c", "4242", None, 1, 2030, "Some Scheme")),
+      )
+      (json \ "CreditCardType").as[String] must_== "SomeScheme"
       (json \ "CreditCardCountry").toOption must beNone
+    }
+  }
+
+  "ObjectCreateResponse reads" should {
+    "read the PascalCase Id and Success fields" in {
+      val response = Json.parse("""{"Id":"pm-1","Success":true}""").as[ObjectCreateResponse]
+      response.id must beSome("pm-1")
+      response.success must beTrue
+    }
+    "treat a missing Id on a failure response as absent rather than failing to parse" in {
+      val response = Json.parse("""{"Success":false}""").as[ObjectCreateResponse]
+      response.id must beNone
+      response.success must beFalse
     }
   }
 }

--- a/membership-common/src/test/scala/com/gu/zuora/rest/ZuoraPaymentWritesTest.scala
+++ b/membership-common/src/test/scala/com/gu/zuora/rest/ZuoraPaymentWritesTest.scala
@@ -61,16 +61,12 @@ class ZuoraPaymentWritesTest extends Specification {
     }
   }
 
-  "ObjectCreateResponse reads" should {
-    "read the PascalCase Id and Success fields" in {
-      val response = Json.parse("""{"Id":"pm-1","Success":true}""").as[ObjectCreateResponse]
-      response.id must beSome("pm-1")
-      response.success must beTrue
+  "ObjectCreateResult reads" should {
+    "read a success response as Created with the required Id" in {
+      Json.parse("""{"Id":"pm-1","Success":true}""").as[ObjectCreateResult] must_== ObjectCreateResult.Created("pm-1")
     }
-    "treat a missing Id on a failure response as absent rather than failing to parse" in {
-      val response = Json.parse("""{"Success":false}""").as[ObjectCreateResponse]
-      response.id must beNone
-      response.success must beFalse
+    "read a failure response as Failed without needing an Id" in {
+      Json.parse("""{"Success":false,"Errors":[{"Message":"bad card"}]}""").as[ObjectCreateResult] must beAnInstanceOf[ObjectCreateResult.Failed]
     }
   }
 }

--- a/membership-common/src/test/scala/com/gu/zuora/rest/ZuoraPaymentWritesTest.scala
+++ b/membership-common/src/test/scala/com/gu/zuora/rest/ZuoraPaymentWritesTest.scala
@@ -1,0 +1,52 @@
+package com.gu.zuora.rest
+
+import com.gu.zuora.rest.ZuoraPaymentWrites._
+import com.gu.zuora.soap.models.Commands
+import org.specs2.mutable.Specification
+import play.api.libs.json.{JsNull, Json}
+
+class ZuoraPaymentWritesTest extends Specification {
+
+  "AccountPaymentUpdate writes" should {
+    "send an explicit null to clear the default payment method" in {
+      val json = Json.toJson(AccountPaymentUpdate(None, "GoCardless", autoPay = false))
+      (json \ "defaultPaymentMethodId").get must_== JsNull
+      (json \ "paymentGateway").as[String] must_== "GoCardless"
+      (json \ "autoPay").as[Boolean] must_== false
+    }
+    "send the id to set the default payment method" in {
+      val json = Json.toJson(AccountPaymentUpdate(Some("pm-1"), "Stripe", autoPay = true))
+      (json \ "defaultPaymentMethodId").as[String] must_== "pm-1"
+      (json \ "autoPay").as[Boolean] must_== true
+    }
+  }
+
+  "paymentMethod object for a bank transfer" should {
+    "map to the Zuora Direct Debit zObject fields" in {
+      val json = paymentMethod("acc-1", Commands.BankTransfer("Jane Doe", "55779911", "200000", "Jane", "Doe", "GB"))
+      (json \ "Type").as[String] must_== "BankTransfer"
+      (json \ "BankTransferType").as[String] must_== "DirectDebitUK"
+      (json \ "BankTransferAccountName").as[String] must_== "Jane Doe"
+      (json \ "BankTransferAccountNumber").as[String] must_== "55779911"
+      (json \ "BankCode").as[String] must_== "200000"
+      (json \ "AccountId").as[String] must_== "acc-1"
+    }
+  }
+
+  "creditCardReference object" should {
+    "map the card reference fields and normalise the card type" in {
+      val json = creditCardReference("acc-1", "pm_token", "cus_token", "4242", Some("GB"), 12, 2030, "visa")
+      (json \ "Type").as[String] must_== "CreditCardReferenceTransaction"
+      (json \ "TokenId").as[String] must_== "pm_token"
+      (json \ "SecondTokenId").as[String] must_== "cus_token"
+      (json \ "CreditCardNumber").as[String] must_== "4242"
+      (json \ "CreditCardCountry").as[String] must_== "GB"
+      (json \ "CreditCardType").as[String] must_== "Visa"
+    }
+    "omit the card type and country when absent or unrecognised" in {
+      val json = creditCardReference("acc-1", "t", "c", "4242", None, 1, 2030, "some-unknown-scheme")
+      (json \ "CreditCardType").toOption must beNone
+      (json \ "CreditCardCountry").toOption must beNone
+    }
+  }
+}


### PR DESCRIPTION
### Why do we need this?

The last part of the Zuora SOAP to REST migration for members-data-api (after #1259 / #1260 billing-preview and #1261 the query reads). The remaining SOAP calls were the payment-method writes in `ZuoraSoapService`: creating a payment method and setting it as the account default, used by the update-card and update-direct-debit flows. They now go through the equivalent Zuora REST endpoints, so `ZuoraSoapService` no longer makes any SOAP calls.

### The changes

- Account payment updates (set/clear default payment method, gateway, autoPay) now use `PUT /v1/accounts/{id}`. A null `defaultPaymentMethodId` clears the default, the REST equivalent of the SOAP `fieldsToNull`.
- Payment method creation now uses `POST /v1/object/payment-method`, which takes the same zObject fields the SOAP create used (Direct Debit bank transfer, and Stripe credit-card reference).
- The three-step ordering (clear + set gateway, create, set default) is kept, because Zuora still validates that the account gateway matches its default method's gateway.
- New writers in `ZuoraPaymentWrites` plus unit tests; the SOAP client is no longer passed to `ZuoraSoapService`.

Tested end to end on the deployed CODE build against the real Zuora sandbox. Both write flows go through manage cleanly: updating to a direct debit (GoCardless gateway) and updating a card (Stripe gateway), each one created in Zuora and set as the account default via the three-step dance, then confirmed server side on `/api/me/mma`. The reads (account, contact, payment summary, payment method) come back correct too, including the card expiry that Zuora REST returns as numbers rather than strings. Reads and writes all good.

### Asana / PRs

Asana: Zuora Migrate remaining SOAP calls to REST API. Follows #1259, #1260, #1261. Follow-up: delete the now-dead `com.gu.zuora.soap` package and move the health check off the SOAP client.

