### PR TITLE
Read the payment method through the existing REST service

### DIFF
--- a/membership-attribute-service/app/services/PaymentFailureAlerter.scala
+++ b/membership-attribute-service/app/services/PaymentFailureAlerter.scala
@@ -50,7 +50,7 @@ object PaymentFailureAlerter extends SafeLogging {
         case Some(id) =>
           val paymentMethod: Future[Either[String, PaymentMethodResponse]] =
             paymentMethodGetter(id) fallbackTo Future.successful(Left("Failed to get payment method"))
-          paymentMethod.map(_.map(_.lastTransactionDateTime).toOption)
+          paymentMethod.map(_.map(_.lastTransactionDateTime).toOption.flatten)
         case None => Future.successful(None)
       }
 

--- a/membership-attribute-service/app/services/PaymentFailureAlerter.scala
+++ b/membership-attribute-service/app/services/PaymentFailureAlerter.scala
@@ -102,7 +102,7 @@ object PaymentFailureAlerter extends SafeLogging {
       val eventualPaymentMethod: Future[Either[String, PaymentMethodResponse]] = paymentMethodGetter(paymentMethodId)
       eventualPaymentMethod map { maybePaymentMethod: Either[String, PaymentMethodResponse] =>
         maybePaymentMethod.map { pm: PaymentMethodResponse =>
-          creditCard(pm) && pm.numConsecutiveFailures > 0
+          creditCard(pm) && pm.numConsecutiveFailures.exists(_ > 0)
         }
       }
     }

--- a/membership-attribute-service/app/services/zuora/payment/PaymentService.scala
+++ b/membership-attribute-service/app/services/zuora/payment/PaymentService.scala
@@ -84,7 +84,6 @@ class PaymentService(zuoraService: ZuoraService, restService: ZuoraRestService)(
         buildBankTransferPaymentMethod(defaultMandateIdIfApplicable, bankTransfer, response)
       case paypal: ZuoraRestService.PaymentMethodDetails.PayPal =>
         Some(PayPalMethod(paypal.email, response.numConsecutiveFailures, response.paymentMethodStatus))
-      case _: ZuoraRestService.PaymentMethodDetails.Other => None
     }
 
   private def getNextBill(subscriptionNumber: SubscriptionNumber, account: Account, targetDate: LocalDate)(implicit

--- a/membership-attribute-service/app/services/zuora/payment/PaymentService.scala
+++ b/membership-attribute-service/app/services/zuora/payment/PaymentService.scala
@@ -55,18 +55,18 @@ class PaymentService(zuoraService: ZuoraService, restService: ZuoraRestService)(
 
   private def buildBankTransferPaymentMethod(
       defaultMandateIdIfApplicable: Option[String],
-      m: ZuoraRestService.PaymentMethodResponse,
+      response: ZuoraRestService.PaymentMethodResponse,
   ): Option[PaymentMethod] = {
     for {
-      mandateId <- m.mandateId.orElse(defaultMandateIdIfApplicable)
-      accountName <- m.bankTransferAccountName
-      accountNumber <- m.bankTransferAccountNumberMask
+      mandateId <- response.mandateId.orElse(defaultMandateIdIfApplicable)
+      accountName <- response.bankTransferAccountName
+      accountNumber <- response.bankTransferAccountNumberMask
       paymentMethod <-
-        (m.bankTransferType, m.bankCode) match {
+        (response.bankTransferType, response.bankCode) match {
           case (Some("SEPA"), _) =>
-            Some(Sepa(mandateId, accountName, accountNumber, m.numConsecutiveFailures, m.paymentMethodStatus))
+            Some(Sepa(mandateId, accountName, accountNumber, response.numConsecutiveFailures, response.paymentMethodStatus))
           case (_, Some(sortCode)) =>
-            Some(GoCardless(mandateId, accountName, accountNumber, sortCode, m.numConsecutiveFailures, m.paymentMethodStatus))
+            Some(GoCardless(mandateId, accountName, accountNumber, sortCode, response.numConsecutiveFailures, response.paymentMethodStatus))
           case _ => None
         }
     } yield paymentMethod
@@ -74,18 +74,18 @@ class PaymentService(zuoraService: ZuoraService, restService: ZuoraRestService)(
 
   private def buildPaymentMethod(
       defaultMandateIdIfApplicable: Option[String] = None,
-      m: ZuoraRestService.PaymentMethodResponse,
+      response: ZuoraRestService.PaymentMethodResponse,
   ): Option[PaymentMethod] =
-    m.paymentMethodType match {
+    response.paymentMethodType match {
       case "CreditCard" | "CreditCardReferenceTransaction" =>
-        val isReferenceTransaction = m.paymentMethodType == "CreditCardReferenceTransaction"
+        val isReferenceTransaction = response.paymentMethodType == "CreditCardReferenceTransaction"
         val details =
-          (m.creditCardNumber |@| m.creditCardExpirationMonth |@| m.creditCardExpirationYear)(PaymentCardDetails)
-        Some(PaymentCard(isReferenceTransaction, m.creditCardType, details, m.numConsecutiveFailures, m.paymentMethodStatus))
+          (response.creditCardNumber |@| response.creditCardExpirationMonth |@| response.creditCardExpirationYear)(PaymentCardDetails)
+        Some(PaymentCard(isReferenceTransaction, response.creditCardType, details, response.numConsecutiveFailures, response.paymentMethodStatus))
       case "BankTransfer" =>
-        buildBankTransferPaymentMethod(defaultMandateIdIfApplicable, m)
+        buildBankTransferPaymentMethod(defaultMandateIdIfApplicable, response)
       case "PayPal" =>
-        Some(PayPalMethod(m.payPalEmail.get, m.numConsecutiveFailures, m.paymentMethodStatus))
+        Some(PayPalMethod(response.payPalEmail.get, response.numConsecutiveFailures, response.paymentMethodStatus))
       case _ => None
     }
 
@@ -131,11 +131,11 @@ class PaymentService(zuoraService: ZuoraService, restService: ZuoraRestService)(
       paymentMethodId <- maybePaymentMethodId
     } yield restService
       .getPaymentMethod(paymentMethodId)
-      .withLogging(s"get payment method for $maybePaymentMethodId")
       .map {
         case \/-(paymentMethod) => buildPaymentMethod(defaultMandateIdIfApplicable, paymentMethod)
         case -\/(error) => throw new RuntimeException(s"Failed to get payment method $paymentMethodId: $error")
-      })
+      }
+      .withLogging(s"get payment method for $maybePaymentMethodId"))
       .getOrElse(Future.successful(None))
 
 }

--- a/membership-attribute-service/app/services/zuora/payment/PaymentService.scala
+++ b/membership-attribute-service/app/services/zuora/payment/PaymentService.scala
@@ -55,14 +55,15 @@ class PaymentService(zuoraService: ZuoraService, restService: ZuoraRestService)(
 
   private def buildBankTransferPaymentMethod(
       defaultMandateIdIfApplicable: Option[String],
+      bankTransfer: ZuoraRestService.PaymentMethodDetails.BankTransfer,
       response: ZuoraRestService.PaymentMethodResponse,
-  ): Option[PaymentMethod] = {
+  ): Option[PaymentMethod] =
     for {
-      mandateId <- response.mandateId.orElse(defaultMandateIdIfApplicable)
-      accountName <- response.bankTransferAccountName
-      accountNumber <- response.bankTransferAccountNumberMask
+      mandateId <- bankTransfer.mandateId.orElse(defaultMandateIdIfApplicable)
+      accountName <- bankTransfer.accountName
+      accountNumber <- bankTransfer.accountNumberMask
       paymentMethod <-
-        (response.bankTransferType, response.bankCode) match {
+        (bankTransfer.transferType, bankTransfer.bankCode) match {
           case (Some("SEPA"), _) =>
             Some(Sepa(mandateId, accountName, accountNumber, response.numConsecutiveFailures, response.paymentMethodStatus))
           case (_, Some(sortCode)) =>
@@ -70,23 +71,20 @@ class PaymentService(zuoraService: ZuoraService, restService: ZuoraRestService)(
           case _ => None
         }
     } yield paymentMethod
-  }
 
   private def buildPaymentMethod(
       defaultMandateIdIfApplicable: Option[String] = None,
       response: ZuoraRestService.PaymentMethodResponse,
   ): Option[PaymentMethod] =
-    response.paymentMethodType match {
-      case "CreditCard" | "CreditCardReferenceTransaction" =>
-        val isReferenceTransaction = response.paymentMethodType == "CreditCardReferenceTransaction"
-        val details =
-          (response.creditCardNumber |@| response.creditCardExpirationMonth |@| response.creditCardExpirationYear)(PaymentCardDetails)
-        Some(PaymentCard(isReferenceTransaction, response.creditCardType, details, response.numConsecutiveFailures, response.paymentMethodStatus))
-      case "BankTransfer" =>
-        buildBankTransferPaymentMethod(defaultMandateIdIfApplicable, response)
-      case "PayPal" =>
-        Some(PayPalMethod(response.payPalEmail.get, response.numConsecutiveFailures, response.paymentMethodStatus))
-      case _ => None
+    response.details match {
+      case card: ZuoraRestService.PaymentMethodDetails.Card =>
+        val details = (card.number |@| card.expirationMonth |@| card.expirationYear)(PaymentCardDetails)
+        Some(PaymentCard(card.isReferenceTransaction, card.cardType, details, response.numConsecutiveFailures, response.paymentMethodStatus))
+      case bankTransfer: ZuoraRestService.PaymentMethodDetails.BankTransfer =>
+        buildBankTransferPaymentMethod(defaultMandateIdIfApplicable, bankTransfer, response)
+      case paypal: ZuoraRestService.PaymentMethodDetails.PayPal =>
+        Some(PayPalMethod(paypal.email, response.numConsecutiveFailures, response.paymentMethodStatus))
+      case _: ZuoraRestService.PaymentMethodDetails.Other => None
     }
 
   private def getNextBill(subscriptionNumber: SubscriptionNumber, account: Account, targetDate: LocalDate)(implicit

--- a/membership-attribute-service/app/services/zuora/payment/PaymentService.scala
+++ b/membership-attribute-service/app/services/zuora/payment/PaymentService.scala
@@ -12,7 +12,6 @@ import com.gu.services.model.PaymentDetails.Payment
 import com.gu.zuora.ZuoraService
 import com.gu.zuora.models.Queries
 import com.gu.zuora.models.Queries.Account
-import com.gu.zuora.models.Queries.PaymentMethod._
 import org.joda.time.LocalDate
 import services.zuora.rest.ZuoraRestService
 import scalaz.{-\/, \/-}
@@ -54,7 +53,10 @@ class PaymentService(zuoraService: ZuoraService, restService: ZuoraRestService)(
     }
   }
 
-  private def buildBankTransferPaymentMethod(defaultMandateIdIfApplicable: Option[String], m: Queries.PaymentMethod): Option[PaymentMethod] = {
+  private def buildBankTransferPaymentMethod(
+      defaultMandateIdIfApplicable: Option[String],
+      m: ZuoraRestService.PaymentMethodResponse,
+  ): Option[PaymentMethod] = {
     for {
       mandateId <- m.mandateId.orElse(defaultMandateIdIfApplicable)
       accountName <- m.bankTransferAccountName
@@ -62,9 +64,9 @@ class PaymentService(zuoraService: ZuoraService, restService: ZuoraRestService)(
       paymentMethod <-
         (m.bankTransferType, m.bankCode) match {
           case (Some("SEPA"), _) =>
-            Some(Sepa(mandateId, accountName, accountNumber, m.numConsecutiveFailures, m.paymentMethodStatus))
+            Some(Sepa(mandateId, accountName, accountNumber, Some(m.numConsecutiveFailures), m.paymentMethodStatus))
           case (_, Some(sortCode)) =>
-            Some(GoCardless(mandateId, accountName, accountNumber, sortCode, m.numConsecutiveFailures, m.paymentMethodStatus))
+            Some(GoCardless(mandateId, accountName, accountNumber, sortCode, Some(m.numConsecutiveFailures), m.paymentMethodStatus))
           case _ => None
         }
     } yield paymentMethod
@@ -72,19 +74,18 @@ class PaymentService(zuoraService: ZuoraService, restService: ZuoraRestService)(
 
   private def buildPaymentMethod(
       defaultMandateIdIfApplicable: Option[String] = None,
-      soapPaymentMethod: Queries.PaymentMethod,
+      m: ZuoraRestService.PaymentMethodResponse,
   ): Option[PaymentMethod] =
-    soapPaymentMethod.`type` match {
-      case `CreditCard` | `CreditCardReferenceTransaction` =>
-        val isReferenceTransaction = soapPaymentMethod.`type` == `CreditCardReferenceTransaction`
-        val m = soapPaymentMethod
+    m.paymentMethodType match {
+      case "CreditCard" | "CreditCardReferenceTransaction" =>
+        val isReferenceTransaction = m.paymentMethodType == "CreditCardReferenceTransaction"
         val details =
           (m.creditCardNumber |@| m.creditCardExpirationMonth |@| m.creditCardExpirationYear)(PaymentCardDetails)
-        Some(PaymentCard(isReferenceTransaction, m.creditCardType, details, m.numConsecutiveFailures, m.paymentMethodStatus))
-      case `BankTransfer` =>
-        buildBankTransferPaymentMethod(defaultMandateIdIfApplicable, soapPaymentMethod)
-      case `PayPal` =>
-        Some(PayPalMethod(soapPaymentMethod.payPalEmail.get, soapPaymentMethod.numConsecutiveFailures, soapPaymentMethod.paymentMethodStatus))
+        Some(PaymentCard(isReferenceTransaction, m.creditCardType, details, Some(m.numConsecutiveFailures), m.paymentMethodStatus))
+      case "BankTransfer" =>
+        buildBankTransferPaymentMethod(defaultMandateIdIfApplicable, m)
+      case "PayPal" =>
+        Some(PayPalMethod(m.payPalEmail.get, Some(m.numConsecutiveFailures), m.paymentMethodStatus))
       case _ => None
     }
 
@@ -128,9 +129,13 @@ class PaymentService(zuoraService: ZuoraService, restService: ZuoraRestService)(
   ): Future[Option[PaymentMethod]] =
     (for {
       paymentMethodId <- maybePaymentMethodId
-    } yield for {
-      soapPaymentMethod <- zuoraService.getPaymentMethod(paymentMethodId).withLogging(s"get payment method for $maybePaymentMethodId")
-    } yield buildPaymentMethod(defaultMandateIdIfApplicable, soapPaymentMethod))
+    } yield restService
+      .getPaymentMethod(paymentMethodId)
+      .withLogging(s"get payment method for $maybePaymentMethodId")
+      .map {
+        case \/-(paymentMethod) => buildPaymentMethod(defaultMandateIdIfApplicable, paymentMethod)
+        case -\/(error) => throw new RuntimeException(s"Failed to get payment method $paymentMethodId: $error")
+      })
       .getOrElse(Future.successful(None))
 
 }

--- a/membership-attribute-service/app/services/zuora/payment/PaymentService.scala
+++ b/membership-attribute-service/app/services/zuora/payment/PaymentService.scala
@@ -64,9 +64,9 @@ class PaymentService(zuoraService: ZuoraService, restService: ZuoraRestService)(
       paymentMethod <-
         (m.bankTransferType, m.bankCode) match {
           case (Some("SEPA"), _) =>
-            Some(Sepa(mandateId, accountName, accountNumber, Some(m.numConsecutiveFailures), m.paymentMethodStatus))
+            Some(Sepa(mandateId, accountName, accountNumber, m.numConsecutiveFailures, m.paymentMethodStatus))
           case (_, Some(sortCode)) =>
-            Some(GoCardless(mandateId, accountName, accountNumber, sortCode, Some(m.numConsecutiveFailures), m.paymentMethodStatus))
+            Some(GoCardless(mandateId, accountName, accountNumber, sortCode, m.numConsecutiveFailures, m.paymentMethodStatus))
           case _ => None
         }
     } yield paymentMethod
@@ -81,11 +81,11 @@ class PaymentService(zuoraService: ZuoraService, restService: ZuoraRestService)(
         val isReferenceTransaction = m.paymentMethodType == "CreditCardReferenceTransaction"
         val details =
           (m.creditCardNumber |@| m.creditCardExpirationMonth |@| m.creditCardExpirationYear)(PaymentCardDetails)
-        Some(PaymentCard(isReferenceTransaction, m.creditCardType, details, Some(m.numConsecutiveFailures), m.paymentMethodStatus))
+        Some(PaymentCard(isReferenceTransaction, m.creditCardType, details, m.numConsecutiveFailures, m.paymentMethodStatus))
       case "BankTransfer" =>
         buildBankTransferPaymentMethod(defaultMandateIdIfApplicable, m)
       case "PayPal" =>
-        Some(PayPalMethod(m.payPalEmail.get, Some(m.numConsecutiveFailures), m.paymentMethodStatus))
+        Some(PayPalMethod(m.payPalEmail.get, m.numConsecutiveFailures, m.paymentMethodStatus))
       case _ => None
     }
 

--- a/membership-attribute-service/app/services/zuora/rest/ZuoraRestService.scala
+++ b/membership-attribute-service/app/services/zuora/rest/ZuoraRestService.scala
@@ -325,7 +325,7 @@ object ZuoraRestService {
   }
 
   case class PaymentMethodResponse(
-      numConsecutiveFailures: Int,
+      numConsecutiveFailures: Option[Int],
       paymentMethodType: String,
       lastTransactionDateTime: Option[DateTime],
       mandateId: Option[String] = None,
@@ -345,7 +345,7 @@ object ZuoraRestService {
 
   implicit val paymentMethodReads: Reads[PaymentMethodResponse] = Reads { json =>
     for {
-      numConsecutiveFailures <- (json \ "NumConsecutiveFailures").validate[Int]
+      numConsecutiveFailures <- (json \ "NumConsecutiveFailures").validateOpt[Int]
       paymentMethodType <- (json \ "Type").validate[String]
       lastTransactionDateTime <- (json \ "LastTransactionDateTime").validateOpt[String].map(_.map(isoDateStringAsDateTime))
       mandateId <- (json \ "MandateID").validateOpt[String]

--- a/membership-attribute-service/app/services/zuora/rest/ZuoraRestService.scala
+++ b/membership-attribute-service/app/services/zuora/rest/ZuoraRestService.scala
@@ -324,13 +324,62 @@ object ZuoraRestService {
     implicit val reads: Reads[GiftSubscriptionsFromIdentityIdResponse] = Json.reads[GiftSubscriptionsFromIdentityIdResponse]
   }
 
-  case class PaymentMethodResponse(numConsecutiveFailures: Int, paymentMethodType: String, lastTransactionDateTime: DateTime)
+  case class PaymentMethodResponse(
+      numConsecutiveFailures: Int,
+      paymentMethodType: String,
+      lastTransactionDateTime: DateTime,
+      mandateId: Option[String] = None,
+      tokenId: Option[String] = None,
+      secondTokenId: Option[String] = None,
+      payPalEmail: Option[String] = None,
+      bankTransferType: Option[String] = None,
+      bankTransferAccountName: Option[String] = None,
+      bankTransferAccountNumberMask: Option[String] = None,
+      bankCode: Option[String] = None,
+      creditCardNumber: Option[String] = None,
+      creditCardExpirationMonth: Option[Int] = None,
+      creditCardExpirationYear: Option[Int] = None,
+      creditCardType: Option[String] = None,
+      paymentMethodStatus: Option[String] = None,
+  )
 
-  implicit val paymentMethodReads: Reads[PaymentMethodResponse] = (
-    (JsPath \ "NumConsecutiveFailures").read[Int] and
-      (JsPath \ "Type").read[String] and
-      (JsPath \ "LastTransactionDateTime").read[String].map(isoDateStringAsDateTime)
-  )(PaymentMethodResponse.apply _)
+  implicit val paymentMethodReads: Reads[PaymentMethodResponse] = Reads { json =>
+    for {
+      numConsecutiveFailures <- (json \ "NumConsecutiveFailures").validate[Int]
+      paymentMethodType <- (json \ "Type").validate[String]
+      lastTransactionDateTime <- (json \ "LastTransactionDateTime").validate[String].map(isoDateStringAsDateTime)
+      mandateId <- (json \ "MandateID").validateOpt[String]
+      tokenId <- (json \ "TokenId").validateOpt[String]
+      secondTokenId <- (json \ "SecondTokenId").validateOpt[String]
+      payPalEmail <- (json \ "PaypalEmail").validateOpt[String]
+      bankTransferType <- (json \ "BankTransferType").validateOpt[String]
+      bankTransferAccountName <- (json \ "BankTransferAccountName").validateOpt[String]
+      bankTransferAccountNumberMask <- (json \ "BankTransferAccountNumberMask").validateOpt[String]
+      bankCode <- (json \ "BankCode").validateOpt[String]
+      creditCardMaskNumber <- (json \ "CreditCardMaskNumber").validateOpt[String]
+      creditCardExpirationMonth <- (json \ "CreditCardExpirationMonth").validateOpt[Int]
+      creditCardExpirationYear <- (json \ "CreditCardExpirationYear").validateOpt[Int]
+      creditCardType <- (json \ "CreditCardType").validateOpt[String]
+      paymentMethodStatus <- (json \ "PaymentMethodStatus").validateOpt[String]
+    } yield PaymentMethodResponse(
+      numConsecutiveFailures = numConsecutiveFailures,
+      paymentMethodType = paymentMethodType,
+      lastTransactionDateTime = lastTransactionDateTime,
+      mandateId = mandateId,
+      tokenId = tokenId,
+      secondTokenId = secondTokenId,
+      payPalEmail = payPalEmail,
+      bankTransferType = bankTransferType,
+      bankTransferAccountName = bankTransferAccountName,
+      bankTransferAccountNumberMask = bankTransferAccountNumberMask,
+      bankCode = bankCode,
+      creditCardNumber = creditCardMaskNumber.map(_.takeRight(4)),
+      creditCardExpirationMonth = creditCardExpirationMonth,
+      creditCardExpirationYear = creditCardExpirationYear,
+      creditCardType = creditCardType,
+      paymentMethodStatus = paymentMethodStatus,
+    )
+  }
 
   implicit val paymentGatewayReads: Reads[Option[PaymentGateway]] =
     __.read[String].map(PaymentGateway.getByName)

--- a/membership-attribute-service/app/services/zuora/rest/ZuoraRestService.scala
+++ b/membership-attribute-service/app/services/zuora/rest/ZuoraRestService.scala
@@ -25,6 +25,7 @@ import services.zuora.rest.ZuoraRestService.{
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.higherKinds
+import scala.util.Try
 
 object ZuoraRestService {
 
@@ -42,6 +43,15 @@ object ZuoraRestService {
 
   def jsStringOrNull(value: Option[String]) = value.map(JsString(_)).getOrElse(JsNull)
   def isoDateStringAsDateTime(dateString: String): DateTime = ISODateTimeFormat.dateTimeParser().parseDateTime(dateString)
+
+  /** Parse an ISO datetime into the JsResult error channel: a malformed value becomes a JsError rather than a thrown exception that would escape the
+    * Reads and crash parsing of the whole payload.
+    */
+  def isoDateStringAsDateTimeResult(dateString: String): JsResult[DateTime] =
+    Try(isoDateStringAsDateTime(dateString)).fold(
+      error => JsError(s"could not parse '$dateString' as an ISO 8601 datetime: ${error.getMessage}"),
+      JsSuccess(_),
+    )
 
   case class AddressData(
       address1: Option[String],
@@ -347,7 +357,10 @@ object ZuoraRestService {
     for {
       numConsecutiveFailures <- (json \ "NumConsecutiveFailures").validateOpt[Int]
       paymentMethodType <- (json \ "Type").validate[String]
-      lastTransactionDateTime <- (json \ "LastTransactionDateTime").validateOpt[String].map(_.map(isoDateStringAsDateTime))
+      lastTransactionDateTime <- (json \ "LastTransactionDateTime").validateOpt[String].flatMap {
+        case Some(dateString) => isoDateStringAsDateTimeResult(dateString).map(Some(_))
+        case None => JsSuccess(None)
+      }
       mandateId <- (json \ "MandateID").validateOpt[String]
       tokenId <- (json \ "TokenId").validateOpt[String]
       secondTokenId <- (json \ "SecondTokenId").validateOpt[String]

--- a/membership-attribute-service/app/services/zuora/rest/ZuoraRestService.scala
+++ b/membership-attribute-service/app/services/zuora/rest/ZuoraRestService.scala
@@ -49,7 +49,7 @@ object ZuoraRestService {
     */
   def isoDateStringAsDateTimeResult(dateString: String): JsResult[DateTime] =
     Try(isoDateStringAsDateTime(dateString)).fold(
-      error => JsError(s"could not parse '$dateString' as an ISO 8601 datetime: ${error.getMessage}"),
+      error => JsError(s"could not parse '$dateString' as an ISO 8601 datetime: ${error.toString}"),
       JsSuccess(_),
     )
 
@@ -354,8 +354,6 @@ object ZuoraRestService {
         bankCode: Option[String],
     ) extends PaymentMethodDetails
     case class PayPal(email: String) extends PaymentMethodDetails
-    // A payment method type we don't render (e.g. a new gateway's type). Kept so parsing never fails on an unknown type.
-    case class Other(paymentMethodType: String) extends PaymentMethodDetails
   }
 
   case class PaymentMethodResponse(
@@ -392,7 +390,9 @@ object ZuoraRestService {
       case "PayPal" =>
         (json \ "PaypalEmail").validate[String].map(PaymentMethodDetails.PayPal)
       case other =>
-        JsSuccess(PaymentMethodDetails.Other(other))
+        // Fail loudly on a payment method type we don't model, rather than silently returning no details: downstream that
+        // reads as a missing payment method, which is misleading. A JsError names the actual type and gives a useful stack trace.
+        JsError(s"unknown payment method type: $other")
     }
 
   implicit val paymentMethodReads: Reads[PaymentMethodResponse] = Reads { json =>

--- a/membership-attribute-service/app/services/zuora/rest/ZuoraRestService.scala
+++ b/membership-attribute-service/app/services/zuora/rest/ZuoraRestService.scala
@@ -327,7 +327,7 @@ object ZuoraRestService {
   case class PaymentMethodResponse(
       numConsecutiveFailures: Int,
       paymentMethodType: String,
-      lastTransactionDateTime: DateTime,
+      lastTransactionDateTime: Option[DateTime],
       mandateId: Option[String] = None,
       tokenId: Option[String] = None,
       secondTokenId: Option[String] = None,
@@ -347,7 +347,7 @@ object ZuoraRestService {
     for {
       numConsecutiveFailures <- (json \ "NumConsecutiveFailures").validate[Int]
       paymentMethodType <- (json \ "Type").validate[String]
-      lastTransactionDateTime <- (json \ "LastTransactionDateTime").validate[String].map(isoDateStringAsDateTime)
+      lastTransactionDateTime <- (json \ "LastTransactionDateTime").validateOpt[String].map(_.map(isoDateStringAsDateTime))
       mandateId <- (json \ "MandateID").validateOpt[String]
       tokenId <- (json \ "TokenId").validateOpt[String]
       secondTokenId <- (json \ "SecondTokenId").validateOpt[String]

--- a/membership-attribute-service/app/services/zuora/rest/ZuoraRestService.scala
+++ b/membership-attribute-service/app/services/zuora/rest/ZuoraRestService.scala
@@ -334,63 +334,83 @@ object ZuoraRestService {
     implicit val reads: Reads[GiftSubscriptionsFromIdentityIdResponse] = Json.reads[GiftSubscriptionsFromIdentityIdResponse]
   }
 
+  /** The type-specific part of a payment method. Modelling it as a discriminated union (rather than one flat record where every field is optional)
+    * keeps the fields that only exist for a given type together, and lets required fields — e.g. a PayPal email — be non-optional.
+    */
+  sealed trait PaymentMethodDetails
+  object PaymentMethodDetails {
+    case class Card(
+        number: Option[String],
+        expirationMonth: Option[Int],
+        expirationYear: Option[Int],
+        cardType: Option[String],
+        isReferenceTransaction: Boolean,
+    ) extends PaymentMethodDetails
+    case class BankTransfer(
+        mandateId: Option[String],
+        transferType: Option[String],
+        accountName: Option[String],
+        accountNumberMask: Option[String],
+        bankCode: Option[String],
+    ) extends PaymentMethodDetails
+    case class PayPal(email: String) extends PaymentMethodDetails
+    // A payment method type we don't render (e.g. a new gateway's type). Kept so parsing never fails on an unknown type.
+    case class Other(paymentMethodType: String) extends PaymentMethodDetails
+  }
+
   case class PaymentMethodResponse(
-      numConsecutiveFailures: Option[Int],
       paymentMethodType: String,
+      numConsecutiveFailures: Option[Int],
       lastTransactionDateTime: Option[DateTime],
-      mandateId: Option[String] = None,
-      tokenId: Option[String] = None,
-      secondTokenId: Option[String] = None,
-      payPalEmail: Option[String] = None,
-      bankTransferType: Option[String] = None,
-      bankTransferAccountName: Option[String] = None,
-      bankTransferAccountNumberMask: Option[String] = None,
-      bankCode: Option[String] = None,
-      creditCardNumber: Option[String] = None,
-      creditCardExpirationMonth: Option[Int] = None,
-      creditCardExpirationYear: Option[Int] = None,
-      creditCardType: Option[String] = None,
-      paymentMethodStatus: Option[String] = None,
+      paymentMethodStatus: Option[String],
+      details: PaymentMethodDetails,
   )
+
+  private def paymentMethodDetailsReads(paymentMethodType: String, json: JsValue): JsResult[PaymentMethodDetails] =
+    paymentMethodType match {
+      case "CreditCard" | "CreditCardReferenceTransaction" =>
+        for {
+          maskNumber <- (json \ "CreditCardMaskNumber").validateOpt[String]
+          expirationMonth <- (json \ "CreditCardExpirationMonth").validateOpt[Int]
+          expirationYear <- (json \ "CreditCardExpirationYear").validateOpt[Int]
+          cardType <- (json \ "CreditCardType").validateOpt[String]
+        } yield PaymentMethodDetails.Card(
+          number = maskNumber.map(_.takeRight(4)),
+          expirationMonth = expirationMonth,
+          expirationYear = expirationYear,
+          cardType = cardType,
+          isReferenceTransaction = paymentMethodType == "CreditCardReferenceTransaction",
+        )
+      case "BankTransfer" =>
+        for {
+          mandateId <- (json \ "MandateID").validateOpt[String]
+          transferType <- (json \ "BankTransferType").validateOpt[String]
+          accountName <- (json \ "BankTransferAccountName").validateOpt[String]
+          accountNumberMask <- (json \ "BankTransferAccountNumberMask").validateOpt[String]
+          bankCode <- (json \ "BankCode").validateOpt[String]
+        } yield PaymentMethodDetails.BankTransfer(mandateId, transferType, accountName, accountNumberMask, bankCode)
+      case "PayPal" =>
+        (json \ "PaypalEmail").validate[String].map(PaymentMethodDetails.PayPal)
+      case other =>
+        JsSuccess(PaymentMethodDetails.Other(other))
+    }
 
   implicit val paymentMethodReads: Reads[PaymentMethodResponse] = Reads { json =>
     for {
-      numConsecutiveFailures <- (json \ "NumConsecutiveFailures").validateOpt[Int]
       paymentMethodType <- (json \ "Type").validate[String]
+      numConsecutiveFailures <- (json \ "NumConsecutiveFailures").validateOpt[Int]
       lastTransactionDateTime <- (json \ "LastTransactionDateTime").validateOpt[String].flatMap {
         case Some(dateString) => isoDateStringAsDateTimeResult(dateString).map(Some(_))
         case None => JsSuccess(None)
       }
-      mandateId <- (json \ "MandateID").validateOpt[String]
-      tokenId <- (json \ "TokenId").validateOpt[String]
-      secondTokenId <- (json \ "SecondTokenId").validateOpt[String]
-      payPalEmail <- (json \ "PaypalEmail").validateOpt[String]
-      bankTransferType <- (json \ "BankTransferType").validateOpt[String]
-      bankTransferAccountName <- (json \ "BankTransferAccountName").validateOpt[String]
-      bankTransferAccountNumberMask <- (json \ "BankTransferAccountNumberMask").validateOpt[String]
-      bankCode <- (json \ "BankCode").validateOpt[String]
-      creditCardMaskNumber <- (json \ "CreditCardMaskNumber").validateOpt[String]
-      creditCardExpirationMonth <- (json \ "CreditCardExpirationMonth").validateOpt[Int]
-      creditCardExpirationYear <- (json \ "CreditCardExpirationYear").validateOpt[Int]
-      creditCardType <- (json \ "CreditCardType").validateOpt[String]
       paymentMethodStatus <- (json \ "PaymentMethodStatus").validateOpt[String]
+      details <- paymentMethodDetailsReads(paymentMethodType, json)
     } yield PaymentMethodResponse(
-      numConsecutiveFailures = numConsecutiveFailures,
       paymentMethodType = paymentMethodType,
+      numConsecutiveFailures = numConsecutiveFailures,
       lastTransactionDateTime = lastTransactionDateTime,
-      mandateId = mandateId,
-      tokenId = tokenId,
-      secondTokenId = secondTokenId,
-      payPalEmail = payPalEmail,
-      bankTransferType = bankTransferType,
-      bankTransferAccountName = bankTransferAccountName,
-      bankTransferAccountNumberMask = bankTransferAccountNumberMask,
-      bankCode = bankCode,
-      creditCardNumber = creditCardMaskNumber.map(_.takeRight(4)),
-      creditCardExpirationMonth = creditCardExpirationMonth,
-      creditCardExpirationYear = creditCardExpirationYear,
-      creditCardType = creditCardType,
       paymentMethodStatus = paymentMethodStatus,
+      details = details,
     )
   }
 

--- a/membership-attribute-service/test/acceptance/PaymentUpdateControllerAcceptanceTest.scala
+++ b/membership-attribute-service/test/acceptance/PaymentUpdateControllerAcceptanceTest.scala
@@ -182,16 +182,15 @@ class PaymentUpdateControllerAcceptanceTest extends AcceptanceTest {
 
       zuoraServiceMock.createPaymentMethod(createPaymentMethod)(any) returns Future.successful(())
 
-      val paymentMethod = TestQueriesPaymentMethod(
-        id = paymentMethodId,
+      val paymentMethod = TestPaymentMethodResponse(
+        paymentMethodType = "BankTransfer",
         mandateId = Some(randomId("mandateId")),
         bankTransferAccountName = Some("Frank Poole"),
         bankCode = Some("000000"),
         bankTransferAccountNumberMask = Some("4444 4444 4444 4444"),
-        paymentType = Queries.PaymentMethod.BankTransfer,
       )
 
-      zuoraServiceMock.getPaymentMethod(paymentMethodId)(any) returns Future(paymentMethod)
+      zuoraRestServiceMock.getPaymentMethod(paymentMethodId)(any) returns Future(\/.right(paymentMethod))
 
       sendEmailMock.send(emailData)(any) returns Future.successful(())
 
@@ -215,7 +214,7 @@ class PaymentUpdateControllerAcceptanceTest extends AcceptanceTest {
       zuoraServiceMock.getAccount(subscription.accountId)(any) wasCalled twice
       zuoraServiceMock.getContact(account.billToId)(any) was called
       zuoraServiceMock.createPaymentMethod(createPaymentMethod)(any) was called
-      zuoraServiceMock.getPaymentMethod(paymentMethodId)(any) was called
+      zuoraRestServiceMock.getPaymentMethod(paymentMethodId)(any) was called
       sendEmailMock.send(emailData)(any) was called
 
       supporterProductDataServiceMock wasNever called

--- a/membership-attribute-service/test/acceptance/data/TestPaymentMethodResponse.scala
+++ b/membership-attribute-service/test/acceptance/data/TestPaymentMethodResponse.scala
@@ -6,7 +6,7 @@ import services.zuora.rest.ZuoraRestService.PaymentMethodResponse
 object TestPaymentMethodResponse {
   def apply(
       paymentMethodType: String,
-      numConsecutiveFailures: Int = 0,
+      numConsecutiveFailures: Option[Int] = None,
       lastTransactionDateTime: Option[DateTime] = None,
       mandateId: Option[String] = None,
       tokenId: Option[String] = None,

--- a/membership-attribute-service/test/acceptance/data/TestPaymentMethodResponse.scala
+++ b/membership-attribute-service/test/acceptance/data/TestPaymentMethodResponse.scala
@@ -7,7 +7,7 @@ object TestPaymentMethodResponse {
   def apply(
       paymentMethodType: String,
       numConsecutiveFailures: Int = 0,
-      lastTransactionDateTime: DateTime = DateTime.now(),
+      lastTransactionDateTime: Option[DateTime] = None,
       mandateId: Option[String] = None,
       tokenId: Option[String] = None,
       secondTokenId: Option[String] = None,

--- a/membership-attribute-service/test/acceptance/data/TestPaymentMethodResponse.scala
+++ b/membership-attribute-service/test/acceptance/data/TestPaymentMethodResponse.scala
@@ -1,17 +1,15 @@
 package acceptance.data
 
 import org.joda.time.DateTime
-import services.zuora.rest.ZuoraRestService.PaymentMethodResponse
+import services.zuora.rest.ZuoraRestService.{PaymentMethodDetails, PaymentMethodResponse}
 
 object TestPaymentMethodResponse {
   def apply(
       paymentMethodType: String,
       numConsecutiveFailures: Option[Int] = None,
       lastTransactionDateTime: Option[DateTime] = None,
+      paymentMethodStatus: Option[String] = None,
       mandateId: Option[String] = None,
-      tokenId: Option[String] = None,
-      secondTokenId: Option[String] = None,
-      payPalEmail: Option[String] = None,
       bankTransferType: Option[String] = None,
       bankTransferAccountName: Option[String] = None,
       bankTransferAccountNumberMask: Option[String] = None,
@@ -20,23 +18,24 @@ object TestPaymentMethodResponse {
       creditCardExpirationMonth: Option[Int] = None,
       creditCardExpirationYear: Option[Int] = None,
       creditCardType: Option[String] = None,
-      paymentMethodStatus: Option[String] = None,
-  ): PaymentMethodResponse = PaymentMethodResponse(
-    numConsecutiveFailures = numConsecutiveFailures,
-    paymentMethodType = paymentMethodType,
-    lastTransactionDateTime = lastTransactionDateTime,
-    mandateId = mandateId,
-    tokenId = tokenId,
-    secondTokenId = secondTokenId,
-    payPalEmail = payPalEmail,
-    bankTransferType = bankTransferType,
-    bankTransferAccountName = bankTransferAccountName,
-    bankTransferAccountNumberMask = bankTransferAccountNumberMask,
-    bankCode = bankCode,
-    creditCardNumber = creditCardNumber,
-    creditCardExpirationMonth = creditCardExpirationMonth,
-    creditCardExpirationYear = creditCardExpirationYear,
-    creditCardType = creditCardType,
-    paymentMethodStatus = paymentMethodStatus,
-  )
+      payPalEmail: Option[String] = None,
+  ): PaymentMethodResponse = {
+    val details: PaymentMethodDetails = paymentMethodType match {
+      case "CreditCard" | "CreditCardReferenceTransaction" =>
+        PaymentMethodDetails.Card(
+          creditCardNumber,
+          creditCardExpirationMonth,
+          creditCardExpirationYear,
+          creditCardType,
+          isReferenceTransaction = paymentMethodType == "CreditCardReferenceTransaction",
+        )
+      case "BankTransfer" =>
+        PaymentMethodDetails.BankTransfer(mandateId, bankTransferType, bankTransferAccountName, bankTransferAccountNumberMask, bankCode)
+      case "PayPal" =>
+        PaymentMethodDetails.PayPal(payPalEmail.getOrElse("test@paypal.com"))
+      case other =>
+        PaymentMethodDetails.Other(other)
+    }
+    PaymentMethodResponse(paymentMethodType, numConsecutiveFailures, lastTransactionDateTime, paymentMethodStatus, details)
+  }
 }

--- a/membership-attribute-service/test/acceptance/data/TestPaymentMethodResponse.scala
+++ b/membership-attribute-service/test/acceptance/data/TestPaymentMethodResponse.scala
@@ -34,7 +34,7 @@ object TestPaymentMethodResponse {
       case "PayPal" =>
         PaymentMethodDetails.PayPal(payPalEmail.getOrElse("test@paypal.com"))
       case other =>
-        PaymentMethodDetails.Other(other)
+        throw new IllegalArgumentException(s"TestPaymentMethodResponse: unsupported payment method type '$other'")
     }
     PaymentMethodResponse(paymentMethodType, numConsecutiveFailures, lastTransactionDateTime, paymentMethodStatus, details)
   }

--- a/membership-attribute-service/test/acceptance/data/TestPaymentMethodResponse.scala
+++ b/membership-attribute-service/test/acceptance/data/TestPaymentMethodResponse.scala
@@ -1,11 +1,13 @@
 package acceptance.data
 
-import acceptance.data.Randoms.randomId
-import com.gu.zuora.models.Queries.PaymentMethod
+import org.joda.time.DateTime
+import services.zuora.rest.ZuoraRestService.PaymentMethodResponse
 
-object TestQueriesPaymentMethod {
+object TestPaymentMethodResponse {
   def apply(
-      id: String = randomId("paymentMethod"),
+      paymentMethodType: String,
+      numConsecutiveFailures: Int = 0,
+      lastTransactionDateTime: DateTime = DateTime.now(),
       mandateId: Option[String] = None,
       tokenId: Option[String] = None,
       secondTokenId: Option[String] = None,
@@ -14,15 +16,15 @@ object TestQueriesPaymentMethod {
       bankTransferAccountName: Option[String] = None,
       bankTransferAccountNumberMask: Option[String] = None,
       bankCode: Option[String] = None,
-      paymentType: String,
       creditCardNumber: Option[String] = None,
       creditCardExpirationMonth: Option[Int] = None,
       creditCardExpirationYear: Option[Int] = None,
       creditCardType: Option[String] = None,
-      numConsecutiveFailures: Option[Int] = None,
       paymentMethodStatus: Option[String] = None,
-  ) = PaymentMethod(
-    id: String,
+  ): PaymentMethodResponse = PaymentMethodResponse(
+    numConsecutiveFailures = numConsecutiveFailures,
+    paymentMethodType = paymentMethodType,
+    lastTransactionDateTime = lastTransactionDateTime,
     mandateId = mandateId,
     tokenId = tokenId,
     secondTokenId = secondTokenId,
@@ -31,13 +33,10 @@ object TestQueriesPaymentMethod {
     bankTransferAccountName = bankTransferAccountName,
     bankTransferAccountNumberMask = bankTransferAccountNumberMask,
     bankCode = bankCode,
-    `type` = paymentType,
     creditCardNumber = creditCardNumber,
     creditCardExpirationMonth = creditCardExpirationMonth,
     creditCardExpirationYear = creditCardExpirationYear,
     creditCardType = creditCardType,
-    numConsecutiveFailures = numConsecutiveFailures,
     paymentMethodStatus = paymentMethodStatus,
   )
-
 }

--- a/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
+++ b/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
@@ -1,7 +1,8 @@
 package services
 
+import acceptance.data.TestPaymentMethodResponse
 import com.gu.memsub.Subscription.AccountId
-import services.zuora.rest.ZuoraRestService.{Invoice, InvoiceId, PaymentMethodId, PaymentMethodResponse}
+import services.zuora.rest.ZuoraRestService.{Invoice, InvoiceId, PaymentMethodId}
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.{DateTime, LocalDate}
 import org.specs2.concurrent.ExecutionEnv
@@ -18,12 +19,12 @@ class PaymentFailureAlerterTest(implicit ee: ExecutionEnv) extends Specification
   override def referenceDate = new LocalDate()
 
   def paymentMethodResponseNoFailures(id: PaymentMethodId) =
-    Future.successful(Right(PaymentMethodResponse(Some(0), "CreditCardReferenceTransaction", Some(referenceDate.toDateTimeAtCurrentTime))))
+    Future.successful(Right(TestPaymentMethodResponse("CreditCardReferenceTransaction", Some(0), Some(referenceDate.toDateTimeAtCurrentTime))))
   def paymentMethodResponseRecentFailure(id: PaymentMethodId) =
-    Future.successful(Right(PaymentMethodResponse(Some(1), "CreditCardReferenceTransaction", Some(DateTime.now().minusDays(1)))))
+    Future.successful(Right(TestPaymentMethodResponse("CreditCardReferenceTransaction", Some(1), Some(DateTime.now().minusDays(1)))))
   def paymentMethodLeftResponse(id: PaymentMethodId) = Future.successful(Left("Something's gone wrong!"))
   def paymentMethodResponseStaleFailure(id: PaymentMethodId) =
-    Future.successful(Right(PaymentMethodResponse(Some(1), "CreditCardReferenceTransaction", Some(DateTime.now().minusMonths(2)))))
+    Future.successful(Right(TestPaymentMethodResponse("CreditCardReferenceTransaction", Some(1), Some(DateTime.now().minusMonths(2)))))
 
   "PaymentFailureAlerterTest" should {
     "membershipAlertText" should {
@@ -121,7 +122,7 @@ class PaymentFailureAlerterTest(implicit ee: ExecutionEnv) extends Specification
 
       "return false for a member who pays via paypal" in {
         def paymentMethodResponsePaypal(paymentMethodId: PaymentMethodId) =
-          Future.successful(Right(PaymentMethodResponse(Some(1), "PayPal", Some(DateTime.now().minusDays(1)))))
+          Future.successful(Right(TestPaymentMethodResponse("PayPal", Some(1), Some(DateTime.now().minusDays(1)))))
 
         val result = PaymentFailureAlerter.alertAvailableFor(accountObjectWithBalance, membership, paymentMethodResponsePaypal, catalog)
 

--- a/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
+++ b/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
@@ -18,12 +18,12 @@ class PaymentFailureAlerterTest(implicit ee: ExecutionEnv) extends Specification
   override def referenceDate = new LocalDate()
 
   def paymentMethodResponseNoFailures(id: PaymentMethodId) =
-    Future.successful(Right(PaymentMethodResponse(0, "CreditCardReferenceTransaction", referenceDate.toDateTimeAtCurrentTime)))
+    Future.successful(Right(PaymentMethodResponse(0, "CreditCardReferenceTransaction", Some(referenceDate.toDateTimeAtCurrentTime))))
   def paymentMethodResponseRecentFailure(id: PaymentMethodId) =
-    Future.successful(Right(PaymentMethodResponse(1, "CreditCardReferenceTransaction", DateTime.now().minusDays(1))))
+    Future.successful(Right(PaymentMethodResponse(1, "CreditCardReferenceTransaction", Some(DateTime.now().minusDays(1)))))
   def paymentMethodLeftResponse(id: PaymentMethodId) = Future.successful(Left("Something's gone wrong!"))
   def paymentMethodResponseStaleFailure(id: PaymentMethodId) =
-    Future.successful(Right(PaymentMethodResponse(1, "CreditCardReferenceTransaction", DateTime.now().minusMonths(2))))
+    Future.successful(Right(PaymentMethodResponse(1, "CreditCardReferenceTransaction", Some(DateTime.now().minusMonths(2)))))
 
   "PaymentFailureAlerterTest" should {
     "membershipAlertText" should {
@@ -121,7 +121,7 @@ class PaymentFailureAlerterTest(implicit ee: ExecutionEnv) extends Specification
 
       "return false for a member who pays via paypal" in {
         def paymentMethodResponsePaypal(paymentMethodId: PaymentMethodId) =
-          Future.successful(Right(PaymentMethodResponse(1, "PayPal", DateTime.now().minusDays(1))))
+          Future.successful(Right(PaymentMethodResponse(1, "PayPal", Some(DateTime.now().minusDays(1)))))
 
         val result = PaymentFailureAlerter.alertAvailableFor(accountObjectWithBalance, membership, paymentMethodResponsePaypal, catalog)
 

--- a/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
+++ b/membership-attribute-service/test/services/PaymentFailureAlerterTest.scala
@@ -18,12 +18,12 @@ class PaymentFailureAlerterTest(implicit ee: ExecutionEnv) extends Specification
   override def referenceDate = new LocalDate()
 
   def paymentMethodResponseNoFailures(id: PaymentMethodId) =
-    Future.successful(Right(PaymentMethodResponse(0, "CreditCardReferenceTransaction", Some(referenceDate.toDateTimeAtCurrentTime))))
+    Future.successful(Right(PaymentMethodResponse(Some(0), "CreditCardReferenceTransaction", Some(referenceDate.toDateTimeAtCurrentTime))))
   def paymentMethodResponseRecentFailure(id: PaymentMethodId) =
-    Future.successful(Right(PaymentMethodResponse(1, "CreditCardReferenceTransaction", Some(DateTime.now().minusDays(1)))))
+    Future.successful(Right(PaymentMethodResponse(Some(1), "CreditCardReferenceTransaction", Some(DateTime.now().minusDays(1)))))
   def paymentMethodLeftResponse(id: PaymentMethodId) = Future.successful(Left("Something's gone wrong!"))
   def paymentMethodResponseStaleFailure(id: PaymentMethodId) =
-    Future.successful(Right(PaymentMethodResponse(1, "CreditCardReferenceTransaction", Some(DateTime.now().minusMonths(2)))))
+    Future.successful(Right(PaymentMethodResponse(Some(1), "CreditCardReferenceTransaction", Some(DateTime.now().minusMonths(2)))))
 
   "PaymentFailureAlerterTest" should {
     "membershipAlertText" should {
@@ -121,7 +121,7 @@ class PaymentFailureAlerterTest(implicit ee: ExecutionEnv) extends Specification
 
       "return false for a member who pays via paypal" in {
         def paymentMethodResponsePaypal(paymentMethodId: PaymentMethodId) =
-          Future.successful(Right(PaymentMethodResponse(1, "PayPal", Some(DateTime.now().minusDays(1)))))
+          Future.successful(Right(PaymentMethodResponse(Some(1), "PayPal", Some(DateTime.now().minusDays(1)))))
 
         val result = PaymentFailureAlerter.alertAvailableFor(accountObjectWithBalance, membership, paymentMethodResponsePaypal, catalog)
 

--- a/membership-attribute-service/test/services/zuora/rest/PaymentMethodResponseReadsTest.scala
+++ b/membership-attribute-service/test/services/zuora/rest/PaymentMethodResponseReadsTest.scala
@@ -7,15 +7,15 @@ import services.zuora.rest.ZuoraRestService.PaymentMethodResponse
 class PaymentMethodResponseReadsTest extends Specification {
 
   "PaymentMethodResponse reads" should {
-    "parse a credit card, reading the expiry as numbers and keeping only the last 4 mask digits" in {
+    "parse a credit card that has never been charged (no LastTransactionDateTime), reading the expiry as numbers and keeping only the last 4 mask digits" in {
       val json = Json.parse("""{
         "Type": "CreditCardReferenceTransaction", "PaymentMethodStatus": "Active",
-        "NumConsecutiveFailures": 0, "LastTransactionDateTime": "2026-06-18T00:00:00.000+01:00",
-        "CreditCardMaskNumber": "************4242",
+        "NumConsecutiveFailures": 0, "CreditCardMaskNumber": "************4242",
         "CreditCardExpirationMonth": 10, "CreditCardExpirationYear": 2026, "CreditCardType": "Visa"
       }""")
       val pm = json.as[PaymentMethodResponse]
       pm.paymentMethodType must_== "CreditCardReferenceTransaction"
+      pm.lastTransactionDateTime must beNone
       pm.creditCardExpirationMonth must beSome(10)
       pm.creditCardExpirationYear must beSome(2026)
       pm.creditCardNumber must beSome("4242")

--- a/membership-attribute-service/test/services/zuora/rest/PaymentMethodResponseReadsTest.scala
+++ b/membership-attribute-service/test/services/zuora/rest/PaymentMethodResponseReadsTest.scala
@@ -36,5 +36,15 @@ class PaymentMethodResponseReadsTest extends Specification {
       pm.bankTransferAccountName must beSome("Frank Poole")
       pm.bankCode must beSome("200000")
     }
+
+    "return a JsError, rather than throwing, when LastTransactionDateTime is malformed" in {
+      val json = Json.parse("""{
+        "Type": "CreditCardReferenceTransaction", "PaymentMethodStatus": "Active",
+        "LastTransactionDateTime": "not-a-real-date",
+        "CreditCardMaskNumber": "************4242",
+        "CreditCardExpirationMonth": 10, "CreditCardExpirationYear": 2026, "CreditCardType": "Visa"
+      }""")
+      json.validate[PaymentMethodResponse].isError must beTrue
+    }
   }
 }

--- a/membership-attribute-service/test/services/zuora/rest/PaymentMethodResponseReadsTest.scala
+++ b/membership-attribute-service/test/services/zuora/rest/PaymentMethodResponseReadsTest.scala
@@ -7,19 +7,19 @@ import services.zuora.rest.ZuoraRestService.PaymentMethodResponse
 class PaymentMethodResponseReadsTest extends Specification {
 
   "PaymentMethodResponse reads" should {
-    "parse a credit card that has never been charged (no LastTransactionDateTime), reading the expiry as numbers and keeping only the last 4 mask digits" in {
+    "parse a credit card that has never been charged (no LastTransactionDateTime or NumConsecutiveFailures), reading the expiry as numbers and keeping only the last 4 mask digits" in {
       val json = Json.parse("""{
         "Type": "CreditCardReferenceTransaction", "PaymentMethodStatus": "Active",
-        "NumConsecutiveFailures": 0, "CreditCardMaskNumber": "************4242",
+        "CreditCardMaskNumber": "************4242",
         "CreditCardExpirationMonth": 10, "CreditCardExpirationYear": 2026, "CreditCardType": "Visa"
       }""")
       val pm = json.as[PaymentMethodResponse]
       pm.paymentMethodType must_== "CreditCardReferenceTransaction"
       pm.lastTransactionDateTime must beNone
+      pm.numConsecutiveFailures must beNone
       pm.creditCardExpirationMonth must beSome(10)
       pm.creditCardExpirationYear must beSome(2026)
       pm.creditCardNumber must beSome("4242")
-      pm.numConsecutiveFailures must_== 0
       pm.bankCode must beNone
     }
 

--- a/membership-attribute-service/test/services/zuora/rest/PaymentMethodResponseReadsTest.scala
+++ b/membership-attribute-service/test/services/zuora/rest/PaymentMethodResponseReadsTest.scala
@@ -2,7 +2,7 @@ package services.zuora.rest
 
 import org.specs2.mutable.Specification
 import play.api.libs.json.Json
-import services.zuora.rest.ZuoraRestService.PaymentMethodResponse
+import services.zuora.rest.ZuoraRestService.{PaymentMethodDetails, PaymentMethodResponse}
 
 class PaymentMethodResponseReadsTest extends Specification {
 
@@ -17,10 +17,12 @@ class PaymentMethodResponseReadsTest extends Specification {
       pm.paymentMethodType must_== "CreditCardReferenceTransaction"
       pm.lastTransactionDateTime must beNone
       pm.numConsecutiveFailures must beNone
-      pm.creditCardExpirationMonth must beSome(10)
-      pm.creditCardExpirationYear must beSome(2026)
-      pm.creditCardNumber must beSome("4242")
-      pm.bankCode must beNone
+      pm.details must beLike { case card: PaymentMethodDetails.Card =>
+        (card.expirationMonth must beSome(10)) and
+          (card.expirationYear must beSome(2026)) and
+          (card.number must beSome("4242")) and
+          (card.isReferenceTransaction must beTrue)
+      }
     }
 
     "parse a direct debit bank transfer" in {
@@ -32,9 +34,26 @@ class PaymentMethodResponseReadsTest extends Specification {
       }""")
       val pm = json.as[PaymentMethodResponse]
       pm.paymentMethodType must_== "BankTransfer"
-      pm.mandateId must beSome("mandate-1")
-      pm.bankTransferAccountName must beSome("Frank Poole")
-      pm.bankCode must beSome("200000")
+      pm.details must beLike { case bankTransfer: PaymentMethodDetails.BankTransfer =>
+        (bankTransfer.mandateId must beSome("mandate-1")) and
+          (bankTransfer.accountName must beSome("Frank Poole")) and
+          (bankTransfer.bankCode must beSome("200000"))
+      }
+    }
+
+    "parse a PayPal payment method, keeping the email as a required field rather than an Option" in {
+      val json = Json.parse("""{ "Type": "PayPal", "PaypalEmail": "frank.poole@example.com" }""")
+      json.as[PaymentMethodResponse].details must_== PaymentMethodDetails.PayPal("frank.poole@example.com")
+    }
+
+    "return a JsError for a PayPal payment method with no email, rather than accepting it" in {
+      val json = Json.parse("""{ "Type": "PayPal" }""")
+      json.validate[PaymentMethodResponse].isError must beTrue
+    }
+
+    "keep an unknown payment method type as Other rather than failing to parse the whole payload" in {
+      val json = Json.parse("""{ "Type": "AmazonPay" }""")
+      json.as[PaymentMethodResponse].details must_== PaymentMethodDetails.Other("AmazonPay")
     }
 
     "return a JsError, rather than throwing, when LastTransactionDateTime is malformed" in {

--- a/membership-attribute-service/test/services/zuora/rest/PaymentMethodResponseReadsTest.scala
+++ b/membership-attribute-service/test/services/zuora/rest/PaymentMethodResponseReadsTest.scala
@@ -1,0 +1,40 @@
+package services.zuora.rest
+
+import org.specs2.mutable.Specification
+import play.api.libs.json.Json
+import services.zuora.rest.ZuoraRestService.PaymentMethodResponse
+
+class PaymentMethodResponseReadsTest extends Specification {
+
+  "PaymentMethodResponse reads" should {
+    "parse a credit card, reading the expiry as numbers and keeping only the last 4 mask digits" in {
+      val json = Json.parse("""{
+        "Type": "CreditCardReferenceTransaction", "PaymentMethodStatus": "Active",
+        "NumConsecutiveFailures": 0, "LastTransactionDateTime": "2026-06-18T00:00:00.000+01:00",
+        "CreditCardMaskNumber": "************4242",
+        "CreditCardExpirationMonth": 10, "CreditCardExpirationYear": 2026, "CreditCardType": "Visa"
+      }""")
+      val pm = json.as[PaymentMethodResponse]
+      pm.paymentMethodType must_== "CreditCardReferenceTransaction"
+      pm.creditCardExpirationMonth must beSome(10)
+      pm.creditCardExpirationYear must beSome(2026)
+      pm.creditCardNumber must beSome("4242")
+      pm.numConsecutiveFailures must_== 0
+      pm.bankCode must beNone
+    }
+
+    "parse a direct debit bank transfer" in {
+      val json = Json.parse("""{
+        "Type": "BankTransfer", "NumConsecutiveFailures": 0,
+        "LastTransactionDateTime": "2026-06-18T00:00:00.000+01:00",
+        "MandateID": "mandate-1", "BankTransferAccountName": "Frank Poole",
+        "BankTransferAccountNumberMask": "****4444", "BankCode": "200000"
+      }""")
+      val pm = json.as[PaymentMethodResponse]
+      pm.paymentMethodType must_== "BankTransfer"
+      pm.mandateId must beSome("mandate-1")
+      pm.bankTransferAccountName must beSome("Frank Poole")
+      pm.bankCode must beSome("200000")
+    }
+  }
+}

--- a/membership-attribute-service/test/services/zuora/rest/PaymentMethodResponseReadsTest.scala
+++ b/membership-attribute-service/test/services/zuora/rest/PaymentMethodResponseReadsTest.scala
@@ -51,9 +51,9 @@ class PaymentMethodResponseReadsTest extends Specification {
       json.validate[PaymentMethodResponse].isError must beTrue
     }
 
-    "keep an unknown payment method type as Other rather than failing to parse the whole payload" in {
+    "return a JsError for an unknown payment method type, so it surfaces loudly rather than looking like a missing method" in {
       val json = Json.parse("""{ "Type": "AmazonPay" }""")
-      json.as[PaymentMethodResponse].details must_== PaymentMethodDetails.Other("AmazonPay")
+      json.validate[PaymentMethodResponse].isError must beTrue
     }
 
     "return a JsError, rather than throwing, when LastTransactionDateTime is malformed" in {

--- a/membership-common/src/main/scala/com/gu/zuora/ZuoraService.scala
+++ b/membership-common/src/main/scala/com/gu/zuora/ZuoraService.scala
@@ -143,7 +143,4 @@ class ZuoraService(restClient: rest.SimpleClient[Future])(implicit ec: Execution
     }
   }
 
-  def getPaymentMethod(id: String)(implicit logPrefix: LogPrefix): Future[Queries.PaymentMethod] =
-    getObject[Queries.PaymentMethod](s"object/payment-method/$id")
-
 }

--- a/membership-common/src/main/scala/com/gu/zuora/models/Query.scala
+++ b/membership-common/src/main/scala/com/gu/zuora/models/Query.scala
@@ -14,33 +14,6 @@ trait Identifiable { self: Query =>
 
 object Queries {
 
-  object PaymentMethod {
-    val CreditCard = "CreditCard"
-    val CreditCardReferenceTransaction = "CreditCardReferenceTransaction"
-    val BankTransfer = "BankTransfer"
-    val PayPal = "PayPal"
-  }
-
-  case class PaymentMethod(
-      id: String,
-      mandateId: Option[String],
-      tokenId: Option[String],
-      secondTokenId: Option[String],
-      payPalEmail: Option[String],
-      bankTransferType: Option[String],
-      bankTransferAccountName: Option[String],
-      bankTransferAccountNumberMask: Option[String],
-      bankCode: Option[String],
-      `type`: String,
-      creditCardNumber: Option[String],
-      creditCardExpirationMonth: Option[Int],
-      creditCardExpirationYear: Option[Int],
-      creditCardType: Option[String],
-      numConsecutiveFailures: Option[Int],
-      paymentMethodStatus: Option[String],
-  ) extends Query
-      with Identifiable
-
   case class ProductRatePlan(id: String, name: String, productId: String, effectiveStartDate: LocalDate, effectiveEndDate: LocalDate)
       extends Query
       with Identifiable

--- a/membership-common/src/main/scala/com/gu/zuora/rest/ZuoraQueryReads.scala
+++ b/membership-common/src/main/scala/com/gu/zuora/rest/ZuoraQueryReads.scala
@@ -67,45 +67,6 @@ object ZuoraQueryReads {
     )
   }
 
-  /** @see https://developer.zuora.com/api-references/older-api/operation/Object_GETPaymentMethod */
-  implicit val paymentMethodReads: Reads[Queries.PaymentMethod] = Reads { json =>
-    for {
-      id <- (json \ "Id").validate[String]
-      paymentType <- (json \ "Type").validate[String]
-      numConsecutiveFailures <- (json \ "NumConsecutiveFailures").validateOpt[Int]
-      paymentMethodStatus <- (json \ "PaymentMethodStatus").validateOpt[String]
-      mandateId <- (json \ "MandateID").validateOpt[String]
-      tokenId <- (json \ "TokenId").validateOpt[String]
-      secondTokenId <- (json \ "SecondTokenId").validateOpt[String]
-      payPalEmail <- (json \ "PaypalEmail").validateOpt[String]
-      bankTransferType <- (json \ "BankTransferType").validateOpt[String]
-      bankTransferAccountName <- (json \ "BankTransferAccountName").validateOpt[String]
-      bankTransferAccountNumberMask <- (json \ "BankTransferAccountNumberMask").validateOpt[String]
-      bankCode <- (json \ "BankCode").validateOpt[String]
-      creditCardMaskNumber <- (json \ "CreditCardMaskNumber").validateOpt[String]
-      creditCardExpirationMonth <- (json \ "CreditCardExpirationMonth").validateOpt[Int]
-      creditCardExpirationYear <- (json \ "CreditCardExpirationYear").validateOpt[Int]
-      creditCardType <- (json \ "CreditCardType").validateOpt[String]
-    } yield Queries.PaymentMethod(
-      id = id,
-      mandateId = mandateId,
-      tokenId = tokenId,
-      secondTokenId = secondTokenId,
-      payPalEmail = payPalEmail,
-      bankTransferType = bankTransferType,
-      bankTransferAccountName = bankTransferAccountName,
-      bankTransferAccountNumberMask = bankTransferAccountNumberMask,
-      bankCode = bankCode,
-      `type` = paymentType,
-      creditCardNumber = creditCardMaskNumber.map(_.takeRight(4)),
-      creditCardExpirationMonth = creditCardExpirationMonth,
-      creditCardExpirationYear = creditCardExpirationYear,
-      creditCardType = creditCardType,
-      numConsecutiveFailures = numConsecutiveFailures,
-      paymentMethodStatus = paymentMethodStatus,
-    )
-  }
-
   /** @see https://developer.zuora.com/api-references/api/operation/Action_POSTquery */
   implicit val invoiceItemReads: Reads[Queries.InvoiceItem] = Reads { json =>
     for {

--- a/membership-common/src/test/scala/com/gu/zuora/rest/ZuoraQueryReadsTest.scala
+++ b/membership-common/src/test/scala/com/gu/zuora/rest/ZuoraQueryReadsTest.scala
@@ -27,23 +27,6 @@ class ZuoraQueryReadsTest extends Specification {
     }
   }
 
-  "paymentMethodReads" should {
-    "parse credit card expiry returned as JSON numbers into strings, and keep only the last 4 mask digits" in {
-      val json = Json.parse("""{
-        "Id": "pm-1", "Type": "CreditCardReferenceTransaction", "PaymentMethodStatus": "Active",
-        "NumConsecutiveFailures": 0, "CreditCardMaskNumber": "************4242",
-        "CreditCardExpirationMonth": 10, "CreditCardExpirationYear": 2026, "CreditCardType": "Visa"
-      }""")
-      val pm = json.as[Queries.PaymentMethod]
-      pm.`type` must_== "CreditCardReferenceTransaction"
-      pm.creditCardExpirationMonth must beSome(10)
-      pm.creditCardExpirationYear must beSome(2026)
-      pm.creditCardNumber must beSome("4242")
-      pm.numConsecutiveFailures must beSome(0)
-      pm.bankCode must beNone
-    }
-  }
-
   "invoiceItemReads" should {
     "sum charge and tax into the price" in {
       val json = Json.parse("""{


### PR DESCRIPTION
First step of the follow-up John suggested on #1264: move the ex-SOAP reads onto the existing REST functions to remove the duplication between `ZuoraService` and `ZuoraRestService`.

`ZuoraService.getPaymentMethod` and `ZuoraRestService.getPaymentMethod` already hit the same `object/payment-method/{id}` endpoint, just parsed into two different types (the SOAP-shaped `Queries.PaymentMethod` vs the thinner `PaymentMethodResponse`). This merges them: `PaymentMethodResponse` gains the card / direct-debit / PayPal fields it was missing, `PaymentService` reads through `ZuoraRestService`, and the ex-SOAP `getPaymentMethod`, `Queries.PaymentMethod` and its reader are deleted.

No behaviour change on the read: same JSON, same fields, same graceful handling, and the error path stays like-for-like (a failed fetch still fails rather than silently returning nothing). The card expiry flows through as Ints, following on from #1265. Coverage for the card/direct-debit parsing moves to a `PaymentMethodResponse` reads test.

More of the ex-SOAP reads (`getAccount`, `getContact`, `getPaymentSummary`) will move over in follow-up PRs.
